### PR TITLE
Drop const enums - fixes #3

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -1118,8 +1118,8 @@ several code generators:
 
 | generator               | version         | optimize for      | webpack output size |
 |-------------------------|----------------:|-------------------|--------------------:|
-| protobuf-ts | 1.0.1 | size | 40.627 b |
-| protobuf-ts | 1.0.1 | speed | 69.189 b |
+| protobuf-ts | 1.0.4 | size | 42,353 b |
+| protobuf-ts | 1.0.4 | speed | 72,558 b |
 | ts-proto | 1.26.0 |  | 111.825 b |
 | google-protobuf | 3.12.2 |  | 396.934 b |
 

--- a/packages/grpcweb-transport/src/grpc-web-format.ts
+++ b/packages/grpcweb-transport/src/grpc-web-format.ts
@@ -115,7 +115,7 @@ export function readGrpcWebResponseTrailer(data: Uint8Array): [GrpcStatusCode, s
  * A grpc-frame type. Can be used to determine type of frame emitted by
  * `readGrpcWebResponseBody()`.
  */
-export const enum GrpcWebFrame { DATA = 0x00, TRAILER = 0x80 }
+export enum GrpcWebFrame { DATA = 0x00, TRAILER = 0x80 }
 
 
 /**

--- a/packages/runtime-rpc/src/deferred.ts
+++ b/packages/runtime-rpc/src/deferred.ts
@@ -1,4 +1,4 @@
-export const enum DeferredState {
+export enum DeferredState {
     PENDING,
     REJECTED,
     RESOLVED

--- a/packages/runtime/src/binary-format-contract.ts
+++ b/packages/runtime/src/binary-format-contract.ts
@@ -406,10 +406,8 @@ export interface IBinaryWriter {
  * following value.
  *
  * See https://developers.google.com/protocol-buffers/docs/encoding#structure
- *
- * This is a const enum and cannot be used to lookup names.
  */
-export const enum WireType {
+export enum WireType {
 
     /**
      * Used for int32, int64, uint32, uint64, sint32, sint64, bool, enum

--- a/packages/runtime/src/reflection-info.ts
+++ b/packages/runtime/src/reflection-info.ts
@@ -287,10 +287,8 @@ type fiPartialRules<T> = Omit<T, 'jsonName' | 'localName' | 'oneof' | 'repeat' |
  * Scalar value types. This is a subset of field types declared by protobuf
  * enum google.protobuf.FieldDescriptorProto.Type The types GROUP and MESSAGE
  * are omitted, but the numerical values are identical.
- *
- * This is a const enum and cannot be used to lookup names.
  */
-export const enum ScalarType {
+export enum ScalarType {
     // 0 is reserved for errors.
     // Order is weird for historical reasons.
     DOUBLE = 1,
@@ -340,10 +338,8 @@ export const enum ScalarType {
  * uint64 my_field = 1 [jstype = JS_STRING];
  * uint64 other_field = 2 [jstype = JS_NUMBER];
  * ```
- *
- * This is a const enum and cannot be used to lookup names.
  */
-export const enum LongType {
+export enum LongType {
 
     /**
      * Use JavaScript `bigint`.
@@ -384,10 +380,8 @@ export const enum LongType {
  * value for each element.
  *
  * `bytes` and `string` cannot be packed.
- *
- * This is a const enum and cannot be used to lookup names.
  */
-export const enum RepeatType {
+export enum RepeatType {
 
     /**
      * The field is not repeated.

--- a/packages/test-generated/tsconfig.bigint.json
+++ b/packages/test-generated/tsconfig.bigint.json
@@ -1,6 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+
+    // compiler requires this target for bigint
     "target": "ES2020"
   }
 }

--- a/packages/test-generated/tsconfig.json
+++ b/packages/test-generated/tsconfig.json
@@ -9,6 +9,13 @@
     "module": "CommonJS",
     "target": "ES2015",
     "baseUrl": "./",
+
+
+    // activated for issue #3
+    // react sets this option, breaking const enum
+    "isolatedModules": true,
+
+
     "strict": true,
     "lib": [
       "es2017",


### PR DESCRIPTION
Const enums conflict with typescript compiler option "isolatedModules". See #3.

This PR:

- changes all const enum declarations to plain enum

- updates generated reflection information to numerical literal with a comment to keep code size small

- activates compiler option "isolatedModules" for the "test-generated" package to cover regressions