### PR TITLE
Access Error through globalThis for generated code

### DIFF
--- a/packages/plugin/src/message-type-extensions/internal-binary-read.ts
+++ b/packages/plugin/src/message-type-extensions/internal-binary-read.ts
@@ -282,7 +282,10 @@ export class InternalBinaryRead implements CustomMethodGenerator {
                         ts.createStringLiteral("throw")
                     ),
                     ts.createThrow(ts.createNew(
-                        ts.createIdentifier("Error"),
+                        ts.createPropertyAccess(
+                            ts.createIdentifier("globalThis"),
+                            ts.createIdentifier("Error")
+                        ),
                         undefined,
                         [ts.createTemplateExpression(
                             ts.createTemplateHead(
@@ -799,7 +802,10 @@ export class InternalBinaryRead implements CustomMethodGenerator {
                                     ]
                                 ),
                                 ts.createDefaultClause([ts.createThrow(ts.createNew(
-                                    ts.createIdentifier("Error"),
+                                    ts.createPropertyAccess(
+                                        ts.createIdentifier("globalThis"),
+                                        ts.createIdentifier("Error")
+                                    ),
                                     undefined,
                                     [ts.createStringLiteral("unknown map entry field for " + this.registry.formatQualifiedName(fieldDescriptor))]
                                 ))])


### PR DESCRIPTION
In my testing, I ran into unexpected behavior when interacting with javascript errors when I have a protobuf message called `Error`.

```proto
message Error {
    // Field with the error
    string field_name = 1;

    // Error message
    string message = 2;
}
```

After generating the interface and compiling my project, I get the following error:

```
Type error: This expression is not constructable.
  Type `Error$Type` has no construct signatures.
```

Seems to be coming from https://github.com/timostamm/protobuf-ts/blob/72866167d93aa0471da25dc82475014465a08847/packages/runtime/src/reflection-binary-reader.ts#L48-L52

--

I have not tested this yet, working on getting my local environment set up. Let me know if there is anything else needed and whether this is valid @timostamm. 🍻 