### PR TITLE
BC: Drop cancel() method of RPC calls.

### DIFF
--- a/packages/runtime-rpc/spec/rpc-interceptor.spec.ts
+++ b/packages/runtime-rpc/spec/rpc-interceptor.spec.ts
@@ -105,13 +105,7 @@ class MockTransport implements RpcTransport {
     readonly unaryTrailer = new Deferred<RpcMetadata>();
 
     unary<I extends object, O extends object>(method: MethodInfo<I, O>, input: I, options: RpcOptions): UnaryCall<I, O> {
-        return new UnaryCall<I, O>(method, options.meta ?? {}, input, this.unaryHeaders.promise, this.unaryResponse.promise, this.unaryStatus.promise, this.unaryTrailer.promise, () => {
-            let e = new RpcError("request cancelled by user", "cancelled");
-            this.unaryHeaders.rejectPending(e);
-            this.unaryResponse.rejectPending(e);
-            this.unaryStatus.rejectPending(e);
-            this.unaryTrailer.rejectPending(e);
-        });
+        return new UnaryCall<I, O>(method, options.meta ?? {}, input, this.unaryHeaders.promise, this.unaryResponse.promise, this.unaryStatus.promise, this.unaryTrailer.promise);
     }
 
     clientStreaming<I extends object, O extends object>(method: MethodInfo<I, O>, options: RpcOptions): ClientStreamingCall<I, O> {

--- a/packages/runtime-rpc/spec/server-streaming-call.spec.ts
+++ b/packages/runtime-rpc/spec/server-streaming-call.spec.ts
@@ -1,0 +1,74 @@
+import {MethodInfo, RpcMetadata, RpcOutputStreamController, RpcStatus, ServerStreamingCall} from "../src";
+
+
+describe('ServerStreamingCall', () => {
+
+    const
+        methodInfo = "fake" as unknown as MethodInfo,
+        requestHeaders = {header: "request"},
+        request = {payload: "request"},
+        responseHeaders = {header: "response"},
+        status = {code: "ok", detail: "..."},
+        trailers = {trailers: "response"};
+
+    type I = object;
+    type O = { id: string };
+    let call: ServerStreamingCall<I, O>;
+    let stream: RpcOutputStreamController<O>;
+
+    beforeEach(function () {
+        const ctrl = new RpcOutputStreamController<O>();
+        setTimeout(() => ctrl.notifyMessage({id: "one"}), 10);
+        setTimeout(() => ctrl.notifyMessage({id: "two"}), 20);
+        setTimeout(() => ctrl.notifyMessage({id: "three"}), 30);
+        setTimeout(() => ctrl.notifyComplete(), 40);
+        stream = ctrl;
+        call = new ServerStreamingCall<I, O>(
+            methodInfo,
+            requestHeaders,
+            request,
+            Promise.resolve(responseHeaders),
+            stream,
+            new Promise<RpcStatus>(resolve => stream.onComplete(() => resolve(status))),
+            new Promise<RpcMetadata>(resolve => stream.onComplete(() => resolve(trailers))),
+        );
+    });
+
+    it('should provide correct data', async function () {
+        expect(call.requestHeaders).toBe(requestHeaders);
+        expect(call.request).toBe(request);
+        expect(call.response).toBe(stream);
+        const ids = [];
+        for await (let x of call.response) {
+            ids.push(x.id);
+        }
+        expect(ids).toEqual(["one", "two", "three"]);
+        expect(await call.status).toBe(status);
+        expect(await call.trailers).toBe(trailers);
+    });
+
+
+    it('should run through with wrong order', async function () {
+        expect(call.requestHeaders).toBe(requestHeaders);
+        expect(call.request).toBe(request);
+        expect(call.response).toBe(stream);
+        expect(await call.status).toBe(status);
+        expect(await call.trailers).toBe(trailers);
+        const ids = [];
+        for await (let x of call.response) {
+            ids.push(x.id);
+        }
+        expect(ids.length).toBe(0);
+    });
+
+    it('should provide correct data when finished', async function () {
+        const finished = await call;
+        expect(finished.requestHeaders).toBe(requestHeaders);
+        expect(finished.request).toBe(request);
+        expect(stream.closed).toBeTrue();
+        expect(finished.status).toBe(status);
+        expect(finished.trailers).toBe(trailers);
+    });
+
+
+});

--- a/packages/runtime-rpc/spec/unary-call.spec.ts
+++ b/packages/runtime-rpc/spec/unary-call.spec.ts
@@ -1,0 +1,52 @@
+import {MethodInfo, UnaryCall} from "../src";
+
+
+describe('UnaryCall', () => {
+
+    const
+        methodInfo = "fake" as unknown as MethodInfo,
+        requestHeaders = {header: "request"},
+        request = {payload: "request"},
+        responseHeaders = {header: "response"},
+        response = {payload: "request"},
+        status = {code: "ok", detail: "..."},
+        trailers = {trailers: "response"};
+
+    let call: UnaryCall;
+
+    beforeEach(function () {
+        call = new UnaryCall(
+            methodInfo,
+            requestHeaders,
+            request,
+            Promise.resolve(responseHeaders),
+            Promise.resolve(response),
+            Promise.resolve(status),
+            Promise.resolve(trailers),
+        );
+    });
+
+    it('should provide correct data', async function () {
+        expect(call.requestHeaders).toBe(requestHeaders);
+        expect(call.request).toBe(request);
+        expect(await call.response).toBe(response);
+        expect(await call.status).toBe(status);
+        expect(await call.trailers).toBe(trailers);
+    });
+
+    it('should provide correct data when awaiting in wrong order', async function () {
+        expect(await call.trailers).toBe(trailers);
+        expect(await call.status).toBe(status);
+        expect(await call.response).toBe(response);
+    });
+
+    it('should provide correct data when finished', async function () {
+        const finished = await call;
+        expect(finished.requestHeaders).toBe(requestHeaders);
+        expect(finished.request).toBe(request);
+        expect(finished.response).toBe(response);
+        expect(finished.status).toBe(status);
+        expect(finished.trailers).toBe(trailers);
+    });
+
+});

--- a/packages/runtime-rpc/src/client-streaming-call.ts
+++ b/packages/runtime-rpc/src/client-streaming-call.ts
@@ -1,4 +1,4 @@
-import {RpcCallShared, RpcCancelFn} from "./rpc-call-shared";
+import {RpcCallShared} from "./rpc-call-shared";
 import {RpcInputStream} from "./rpc-input-stream";
 import {RpcStatus} from "./rpc-status";
 import {RpcMetadata} from "./rpc-metadata";
@@ -65,7 +65,6 @@ export class ClientStreamingCall<I extends object = object, O extends object = o
      */
     readonly trailers: Promise<RpcMetadata>;
 
-    private readonly cancelFn: RpcCancelFn;
 
     constructor(
         method: MethodInfo<I, O>,
@@ -75,7 +74,6 @@ export class ClientStreamingCall<I extends object = object, O extends object = o
         response: Promise<O>,
         status: Promise<RpcStatus>,
         trailers: Promise<RpcMetadata>,
-        cancelFn: RpcCancelFn,
     ) {
         this.method = method;
         this.requestHeaders = requestHeaders;
@@ -84,15 +82,6 @@ export class ClientStreamingCall<I extends object = object, O extends object = o
         this.response = response;
         this.status = status;
         this.trailers = trailers;
-        this.cancelFn = cancelFn;
-    }
-
-
-    /**
-     * Cancel this call.
-     */
-    cancel(): void {
-        this.cancelFn();
     }
 
 

--- a/packages/runtime-rpc/src/duplex-streaming-call.ts
+++ b/packages/runtime-rpc/src/duplex-streaming-call.ts
@@ -1,4 +1,4 @@
-import {RpcCallShared, RpcCancelFn} from "./rpc-call-shared";
+import {RpcCallShared} from "./rpc-call-shared";
 import {RpcInputStream} from "./rpc-input-stream";
 import {RpcOutputStream} from "./rpc-output-stream";
 import {RpcStatus} from "./rpc-status";
@@ -66,7 +66,6 @@ export class DuplexStreamingCall<I extends object = object, O extends object = o
      */
     readonly trailers: Promise<RpcMetadata>;
 
-    private readonly cancelFn: RpcCancelFn;
 
     constructor(
         method: MethodInfo<I, O>,
@@ -76,7 +75,6 @@ export class DuplexStreamingCall<I extends object = object, O extends object = o
         response: RpcOutputStream<O>,
         status: Promise<RpcStatus>,
         trailers: Promise<RpcMetadata>,
-        cancelFn: RpcCancelFn,
     ) {
         this.method = method;
         this.requestHeaders = requestHeaders;
@@ -85,15 +83,6 @@ export class DuplexStreamingCall<I extends object = object, O extends object = o
         this.response = response;
         this.status = status;
         this.trailers = trailers;
-        this.cancelFn = cancelFn;
-    }
-
-
-    /**
-     * Cancel this call.
-     */
-    cancel(): void {
-        this.cancelFn();
     }
 
 

--- a/packages/runtime-rpc/src/rpc-call-shared.ts
+++ b/packages/runtime-rpc/src/rpc-call-shared.ts
@@ -3,9 +3,6 @@ import {RpcStatus} from "./rpc-status";
 import {RpcMetadata} from "./rpc-metadata";
 
 
-export type RpcCancelFn = () => void;
-
-
 export interface RpcCallShared<I extends object, O extends object> {
 
     /**
@@ -50,11 +47,6 @@ export interface RpcCallShared<I extends object, O extends object> {
      * reject with a `RpcError`.
      */
     readonly trailers: Promise<RpcMetadata>;
-
-    /**
-     * Cancel this call.
-     */
-    cancel(): void;
 
 }
 

--- a/packages/runtime-rpc/src/rpc-options.ts
+++ b/packages/runtime-rpc/src/rpc-options.ts
@@ -55,6 +55,12 @@ export interface RpcOptions {
     binaryOptions?: Partial<BinaryReadOptions & BinaryWriteOptions>;
 
     /**
+     * A signal to cancel a call. Can be created with an [AbortController](https://developer.mozilla.org/en-US/docs/Web/API/AbortController).
+     * The npm package `abort-controller` provides a polyfill for Node.js.
+     */
+    abort?: AbortSignal;
+
+    /**
      * A `RpcTransport` implementation may allow arbitrary
      * other options.
      */

--- a/packages/runtime-rpc/src/rpc-transport.ts
+++ b/packages/runtime-rpc/src/rpc-transport.ts
@@ -16,20 +16,22 @@ import {RpcOptions} from "./rpc-options";
  * The transport receives reflection information about the service and
  * method being called.
  *
- * Your implementation **should** accept default `RpcOptions` (or an
+ * Some rules:
+ *
+ * a) An implementation **should** accept default `RpcOptions` (or an
  * interface that extends `RpcOptions`) in the constructor.
  *
- * You **must** merge the options given to `mergeOptions()` with your default
- * options. If you do not implement any extra options, or only primitive
- * values, you can use `mergeExtendedRpcOptions()` to get the desired
- * behaviour.
+ * b) An implementation **must** merge the options given to `mergeOptions()`
+ * with its default options. If no extra options are implemented, or only
+ * primitive option values are used, using `mergeExtendedRpcOptions()` will
+ * produce the required behaviour.
  *
- * You **must** pass `RpcOptions.jsonOptions` and `RpcOptions.binaryOptions`
- * to the `fromBinary`, `toBinary`, `fromJson` and `toJson` methods when
- * preparing a request or parsing a response.
+ * c) An implementation **must** pass `RpcOptions.jsonOptions` and
+ * `RpcOptions.binaryOptions` to the `fromBinary`, `toBinary`, `fromJson`
+ * and `toJson` methods when preparing a request or parsing a response.
  *
- * Your implementation can support arbitrary other options, but they must not
- * interfere with options keys of the binary or JSON options.
+ * d) An implementation may support arbitrary other options, but they **must
+ * not** interfere with options keys of the binary or JSON options.
  */
 export interface RpcTransport {
 

--- a/packages/runtime-rpc/src/server-streaming-call.ts
+++ b/packages/runtime-rpc/src/server-streaming-call.ts
@@ -1,4 +1,4 @@
-import {RpcCallShared, RpcCancelFn} from "./rpc-call-shared";
+import {RpcCallShared} from "./rpc-call-shared";
 import {RpcOutputStream} from "./rpc-output-stream";
 import {RpcStatus} from "./rpc-status";
 import {MethodInfo} from "./reflection-info";
@@ -66,9 +66,6 @@ export class ServerStreamingCall<I extends object = object, O extends object = o
     readonly trailers: Promise<RpcMetadata>;
 
 
-    private readonly cancelFn: RpcCancelFn;
-
-
     constructor(
         method: MethodInfo<I, O>,
         requestHeaders: Readonly<RpcMetadata>,
@@ -77,7 +74,6 @@ export class ServerStreamingCall<I extends object = object, O extends object = o
         response: RpcOutputStream<O>,
         status: Promise<RpcStatus>,
         trailers: Promise<RpcMetadata>,
-        cancelFn: RpcCancelFn,
     ) {
         this.method = method;
         this.requestHeaders = requestHeaders;
@@ -86,15 +82,6 @@ export class ServerStreamingCall<I extends object = object, O extends object = o
         this.response = response;
         this.status = status;
         this.trailers = trailers;
-        this.cancelFn = cancelFn;
-    }
-
-
-    /**
-     * Cancel this call.
-     */
-    cancel(): void {
-        this.cancelFn();
     }
 
 

--- a/packages/runtime-rpc/src/unary-call.ts
+++ b/packages/runtime-rpc/src/unary-call.ts
@@ -1,4 +1,4 @@
-import {RpcCallShared, RpcCancelFn} from "./rpc-call-shared";
+import {RpcCallShared} from "./rpc-call-shared";
 import {RpcStatus} from "./rpc-status";
 import {MethodInfo} from "./reflection-info";
 import {RpcMetadata} from "./rpc-metadata";
@@ -67,8 +67,6 @@ export class UnaryCall<I extends object = object, O extends object = object> imp
     readonly trailers: Promise<RpcMetadata>;
 
 
-    private readonly cancelFn: RpcCancelFn;
-
     constructor(
         method: MethodInfo<I, O>,
         requestHeaders: RpcMetadata,
@@ -77,7 +75,6 @@ export class UnaryCall<I extends object = object, O extends object = object> imp
         response: Promise<O>,
         status: Promise<RpcStatus>,
         trailers: Promise<RpcMetadata>,
-        cancelFn: RpcCancelFn,
     ) {
         this.method = method;
         this.requestHeaders = requestHeaders;
@@ -86,15 +83,6 @@ export class UnaryCall<I extends object = object, O extends object = object> imp
         this.response = response;
         this.status = status;
         this.trailers = trailers;
-        this.cancelFn = cancelFn;
-    }
-
-
-    /**
-     * Cancel this call.
-     */
-    cancel(): void {
-        this.cancelFn();
     }
 
 

--- a/packages/test-generated/spec/service-all-methods.spec.ts
+++ b/packages/test-generated/spec/service-all-methods.spec.ts
@@ -17,7 +17,6 @@ import {
     RpcStatus,
     RpcTransport,
     ServerStreamingCall,
-    ServiceInfo,
     UnaryCall
 } from "@protobuf-ts/runtime-rpc";
 
@@ -159,13 +158,7 @@ class MockTransport implements RpcTransport {
     readonly unaryTrailer = new Deferred<RpcMetadata>();
 
     unary<I extends object, O extends object>(method: MethodInfo<I, O>, input: I, options: RpcOptions): UnaryCall<I, O> {
-        return new UnaryCall<I, O>(method, options.meta ?? {}, input, this.unaryHeaders.promise, this.unaryResponse.promise, this.unaryStatus.promise, this.unaryTrailer.promise, () => {
-            let e = new RpcError("request cancelled by user", "cancelled");
-            this.unaryHeaders.rejectPending(e);
-            this.unaryResponse.rejectPending(e);
-            this.unaryStatus.rejectPending(e);
-            this.unaryTrailer.rejectPending(e);
-        });
+        return new UnaryCall<I, O>(method, options.meta ?? {}, input, this.unaryHeaders.promise, this.unaryResponse.promise, this.unaryStatus.promise, this.unaryTrailer.promise);
     }
 
     clientStreaming<I extends object, O extends object>(method: MethodInfo<I, O>, options: RpcOptions): ClientStreamingCall<I, O> {

--- a/packages/twirp-transport/src/twirp-transport.ts
+++ b/packages/twirp-transport/src/twirp-transport.ts
@@ -41,7 +41,6 @@ export class TwirpFetchTransport implements RpcTransport {
             opt = options as TwirpOptions,
             url = this.makeUrl(method, opt),
             requestBody = opt.sendJson ? method.I.toJsonString(input, opt.jsonOptions) : method.I.toBinary(input, opt.binaryOptions),
-            abort = new globalThis.AbortController(),
             defHeader = new Deferred<RpcMetadata>(),
             defMessage = new Deferred<O>(),
             defStatus = new Deferred<RpcStatus>(),
@@ -51,7 +50,7 @@ export class TwirpFetchTransport implements RpcTransport {
             method: 'POST',
             headers: createTwirpRequestHeader(new globalThis.Headers(), !!opt.sendJson, opt.meta),
             body: requestBody,
-            signal: abort.signal,
+            signal: options.abort,
         })
             .then(fetchResponse => {
 
@@ -129,7 +128,6 @@ export class TwirpFetchTransport implements RpcTransport {
             defMessage.promise,
             defStatus.promise,
             defTrailer.promise,
-            () => abort.abort(),
         );
     }
 


### PR DESCRIPTION
The cancel method is a bit of a headache for adapting calls to Observables.
It also complicates RpcTransport implementation.

This breaking change removes the cancel method.
To cancel a call, RpcOptions now takes an AbortSignal.
