### PR TITLE
fix long fields.

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -100,11 +100,19 @@ npx protoc \
 
 
 Available plugin parameters:
+- "long_type_bigint" (default)
+  Sets jstype = JS_NORMAL for message fields with 64 bit integral values. 
+  Only applies to fields that do *not* use the option `jstype`.
 
 - "long_type_string"  
   Sets jstype = JS_STRING for message fields with 64 bit integral values. 
   The default behaviour is to use native `bigint`.  
   Only applies to fields that do *not* use the option `jstype`.
+
+- "long_type_number"  
+  Sets jstype = JS_NUMBER for message fields with 64 bit integral values. 
+  The default behaviour is to use native `bigint`.  
+  Only applies to fields that do *not* use the option `jstype`.  
 
 - "generate_dependencies"  
   By default, only the PROTO_FILES passed as input to protoc are generated, 

--- a/packages/plugin-framework/src/string-format.ts
+++ b/packages/plugin-framework/src/string-format.ts
@@ -282,8 +282,11 @@ export class StringFormat implements IStringFormat {
             options.push(`jstype = JS_STRING`);
         }
         if (descriptor.options?.jstype == FieldOptions_JSType.JS_NUMBER) {
-            options.push(`jstype = JS_STRING`);
+            options.push(`jstype = JS_NUMBER`);
         }
+        if (descriptor.options?.jstype == FieldOptions_JSType.JS_NORMAL) {
+            options.push(`jstype = JS_NORMAL`);
+        }        
         if (descriptor.options?.packed === true) {
             options.push(`packed = true`);
         }

--- a/packages/plugin/spec/interpreter.spec.ts
+++ b/packages/plugin/spec/interpreter.spec.ts
@@ -5,29 +5,31 @@ import * as rt from "@protobuf-ts/runtime";
 
 
 describe('interpreter', function () {
+    it('recognizes field option jstype', function () {
+        [rt.LongType.NUMBER, rt.LongType.STRING, rt.LongType.BIGINT].forEach(normalLongType => {
 
+            const registry = DescriptorRegistry.createFrom(getFixtureFileDescriptor("msg-longs.proto"));
+            const interpreter = new Interpreter(registry, {
+                normalLongType,
+                synthesizeEnumZeroValue: 'UNSPECIFIED$',
+                oneofKindDiscriminator: 'oneofKind',
+            });
+            const messageType = interpreter.getMessageType('spec.LongsMessage');
 
-    it('recognizes field option jstype = JS_NUMBER', function () {
-
-        const registry = DescriptorRegistry.createFrom(getFixtureFileDescriptor("msg-longs.proto"));
-        const interpreter = new Interpreter(registry, {
-            normalLongType: rt.LongType.BIGINT,
-            synthesizeEnumZeroValue: 'UNSPECIFIED$',
-            oneofKindDiscriminator: 'oneofKind',
+            expectFieldType(messageType, 'sfixed64_field_min', normalLongType);
+            expectFieldType(messageType, 'fixed64_field_min_num', rt.LongType.NUMBER);
+            expectFieldType(messageType, 'fixed64_field_min_str', rt.LongType.STRING);
+            expectFieldType(messageType, 'fixed64_field_min', rt.LongType.BIGINT);
         });
-        const messageType = interpreter.getMessageType('spec.LongsMessage');
-
-        const field = messageType.fields.find(f => f.name === 'fixed64_field_min_num');
-        expect(field).toBeDefined();
-        expect(field!.kind).toBe("scalar");
-        if (field && field.kind === "scalar") {
-
-            expect(field.L).toBe(rt.LongType.NUMBER);
-
-        }
-
     });
-
-
 });
 
+// Expect to find a scalar field `name` of type `type`.
+function expectFieldType(messageType: rt.IMessageType<rt.UnknownMessage>, name: string, type: rt.LongType) {
+    const field = messageType.fields.find(f => f.name === name);
+    expect(field).toBeDefined();
+    expect(field!.kind).toBe("scalar");
+    if (field && field.kind === "scalar") {
+        expect(field.L ?? rt.LongType.STRING).toBe(type);
+    }
+}

--- a/packages/plugin/spec/protobufts-plugin-long.spec.ts
+++ b/packages/plugin/spec/protobufts-plugin-long.spec.ts
@@ -1,0 +1,156 @@
+import {getFixtureCodeGeneratorRequest} from "./support/helpers";
+import {ProtobuftsPlugin} from "../src/protobufts-plugin";
+import { OutFile } from "src/out-file";
+
+const stringSnippets = [
+    // Message
+    '@generated from protobuf field: fixed64 fixed64_field_min_str = 11 [jstype = JS_STRING]',
+    'fixed64FieldMinStr: string;',
+    // MessageType
+    '{ no: 11, name: "fixed64_field_min_str", kind: "scalar", T: 6 /*ScalarType.FIXED64*/ },',
+    // BinaryReader
+    'case /* fixed64 fixed64_field_min_str = 11 [jstype = JS_STRING];*/ 11:',
+    'message.fixed64FieldMinStr = reader.fixed64().toString();',
+    // BinaryWriter
+    '/* fixed64 fixed64_field_min_str = 11 [jstype = JS_STRING]; */',
+    'if (message.fixed64FieldMinStr !== "0")',
+];      
+
+const bigintSnippets = [
+    // Message
+    '@generated from protobuf field: fixed64 fixed64_field_min = 1 [jstype = JS_NORMAL];',
+    'fixed64FieldMin: bigint;',
+    // MessageType
+    '{ no: 1, name: "fixed64_field_min", kind: "scalar", T: 6 /*ScalarType.FIXED64*/, L: 0 /*LongType.BIGINT*/ },',
+    // BinaryReader
+    'case /* fixed64 fixed64_field_min = 1 [jstype = JS_NORMAL];*/ 1:',
+    'message.fixed64FieldMin = reader.fixed64().toBigInt();',
+    // BinaryWriter
+    '/* fixed64 fixed64_field_min = 1 [jstype = JS_NORMAL]; */',
+    'if (message.fixed64FieldMin !== 0n)',
+]
+
+const numberSnippets = [
+    // Message
+    '@generated from protobuf field: fixed64 fixed64_field_min_num = 21 [jstype = JS_NUMBER];',
+    'fixed64FieldMinNum: number;',
+    // MessageType
+    '{ no: 21, name: "fixed64_field_min_num", kind: "scalar", T: 6 /*ScalarType.FIXED64*/, L: 2 /*LongType.NUMBER*/ },',
+    // BinaryReader
+    'case /* fixed64 fixed64_field_min_num = 21 [jstype = JS_NUMBER];*/ 21:',
+    'message.fixed64FieldMinNum = reader.fixed64().toNumber();',
+    // BinaryWriter
+    '/* fixed64 fixed64_field_min_num = 21 [jstype = JS_NUMBER]; */',
+    'if (message.fixed64FieldMinNum !== 0)',
+]
+
+describe('Generated code for long type', function () {
+    describe('Default to string', () => {
+        let file: string;
+        
+        beforeAll(() => {
+            file = generateTypescript('long_type_string').getContent();
+        });
+
+        it('should set the default type to string', () => {
+            expectContainAll(file, [
+                // Message
+                '@generated from protobuf field: sfixed64 sfixed64_field_min = 5;',
+                'sfixed64FieldMin: string;',
+                // MessageType
+                'case /* sfixed64 sfixed64_field_min */ 5:',
+                '{ no: 5, name: "sfixed64_field_min", kind: "scalar", T: 16 /*ScalarType.SFIXED64*/ },',
+                // BinaryReader
+                'message.sfixed64FieldMin = reader.sfixed64().toString();',
+                // BinaryWriter
+                '/* sfixed64 sfixed64_field_min = 5; */',
+                'if (message.sfixed64FieldMin !== "0")',
+            ]);
+        });
+
+        it('should support explicit types', () => {
+            expectContainAll(file, stringSnippets);
+            expectContainAll(file, bigintSnippets);
+            expectContainAll(file, numberSnippets);
+        });
+    });
+
+    describe('Default to bigint', () => {
+        let file: string;
+        
+        beforeAll(() => {
+            file = generateTypescript('long_type_bigint').getContent();
+        });
+
+        it('should set the default type to bigint', () => {
+            expectContainAll(file, [
+                // Message
+                '@generated from protobuf field: sfixed64 sfixed64_field_min = 5;',
+                'sfixed64FieldMin: bigint;',
+                // MessageType
+                'case /* sfixed64 sfixed64_field_min */ 5:',
+                '{ no: 5, name: "sfixed64_field_min", kind: "scalar", T: 16 /*ScalarType.SFIXED64*/, L: 0 /*LongType.BIGINT*/ },',
+                // BinaryReader
+                'message.sfixed64FieldMin = reader.sfixed64().toBigInt();',
+                // BinaryWriter
+                '/* sfixed64 sfixed64_field_min = 5; */',
+                'if (message.sfixed64FieldMin !== 0n)',
+            ]);
+        });
+
+        it('should support explicit types', () => {
+            expectContainAll(file, stringSnippets);
+            expectContainAll(file, bigintSnippets);
+            expectContainAll(file, numberSnippets);
+        });
+    });    
+
+    describe('Default to number', () => {
+        let file: string;
+        
+        beforeAll(() => {
+            file = generateTypescript('long_type_number').getContent();
+        });
+
+        it('should set the default type to number', () => {
+            expectContainAll(file, [
+                // Message
+                '@generated from protobuf field: sfixed64 sfixed64_field_min = 5;',
+                'sfixed64FieldMin: number;',
+                // MessageType
+                'case /* sfixed64 sfixed64_field_min */ 5:',
+                '{ no: 5, name: "sfixed64_field_min", kind: "scalar", T: 16 /*ScalarType.SFIXED64*/, L: 2 /*LongType.NUMBER*/ },',
+                // BinaryReader
+                'message.sfixed64FieldMin = reader.sfixed64().toNumber();',
+                // BinaryWriter
+                '/* sfixed64 sfixed64_field_min = 5; */',
+                'if (message.sfixed64FieldMin !== 0)',
+            ]);
+        });
+
+        it('should support explicit types', () => {
+            expectContainAll(file, stringSnippets);
+            expectContainAll(file, bigintSnippets);
+            expectContainAll(file, numberSnippets);
+        });
+    });       
+});
+
+// Generate typescript code for msg-longs.proto. 
+// The `parameter` is forwarded to the request.
+function generateTypescript(parameter: string): OutFile {
+    let plugin = new ProtobuftsPlugin('test');
+    let request = getFixtureCodeGeneratorRequest({
+        parameter,
+        includeFiles: [ 'msg-longs.proto' ]
+    });
+    const outFiles = plugin.generate(request);
+    expect(outFiles.length).toEqual(1);
+    return outFiles[0];
+}
+
+function expectContainAll(content: string, snippets: string[]) {
+    snippets.forEach(snippet => {
+        expect(content).toContain(snippet, `"${snippet}" not found`);
+    });
+}

--- a/packages/plugin/spec/protobufts-plugin.spec.ts
+++ b/packages/plugin/spec/protobufts-plugin.spec.ts
@@ -5,8 +5,6 @@ import {setupCompiler} from "@protobuf-ts/plugin-framework";
 
 
 describe('protobuftsPlugin', function () {
-
-
     let plugin = new ProtobuftsPlugin('test');
     let request = getFixtureCodeGeneratorRequest({
         parameter: 'long_type_string',
@@ -72,7 +70,8 @@ describe('protobuftsPlugin', function () {
                     "ES2018.AsyncIterable" // for runtime-rpc
                 ],
                 module: ts.ModuleKind.CommonJS,
-                target: ts.ScriptTarget.ES2015,
+                // ES2020 is required for bigint support
+                target: ts.ScriptTarget.ES2020,
                 paths: {
                     "@protobuf-ts/runtime": [
                         '../runtime/src/index'

--- a/packages/plugin/src/interpreter.ts
+++ b/packages/plugin/src/interpreter.ts
@@ -524,6 +524,8 @@ export class Interpreter {
                 case FieldOptions_JSType.JS_STRING:
                     // omitting L equals to STRING
                     return undefined;
+                case FieldOptions_JSType.JS_NORMAL:
+                    return rt.LongType.BIGINT;                    
                 case FieldOptions_JSType.JS_NUMBER:
                     return rt.LongType.NUMBER;
             }


### PR DESCRIPTION
Hey Timo,

Proto fileds with `[jstype = JS_NUMBER]` were documented as `* @generated from protobuf field: [...] [jstype = JS_STRING];`

This is fixed in `string-format.ts`.

While I was looking for the correct place to fix this I found some fishy code in `interpreter.ts` where the normal type (i.e. BigInt) is not taken into account. I am not sure if the change is correct as I don't know where/how to test this. I'm happy to work on the tests if you can give me some pointers.

Thanks,
Vic