### PR TITLE
Fix jstype = JS_STRING field option for speed optimized code

### DIFF
--- a/packages/plugin/src/message-type-extensions/internal-binary-read.ts
+++ b/packages/plugin/src/message-type-extensions/internal-binary-read.ts
@@ -949,11 +949,8 @@ export class InternalBinaryRead implements CustomMethodGenerator {
         if (!Interpreter.isLongValueType(type)) {
             return readerMethodCall;
         }
-        if (longType === undefined) {
-            longType = this.options.normalLongType;
-        }
         let convertMethodProp;
-        switch (longType) {
+        switch (longType ?? rt.LongType.STRING) {
             case rt.LongType.STRING:
                 convertMethodProp = ts.createPropertyAccess(readerMethodCall, ts.createIdentifier('toString'));
                 break;


### PR DESCRIPTION
There was a bug in internal-binary-read.ts

When the field option jstype = JS_STRING was set, the generated method `internalBinaryRead` would still read the field as a bigint.

This problem only surfaces if the plugin parameter long_type_string is *not* set and code is optimized for speed (instead of for code size).