### PR TITLE
Refactor mergeExtendedRpcOptions => mergeRpcOptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 
+### Master
+
+Breaking changes:
+
+- The function `mergeExtendedRpcOptions` was renamed to `mergeRpcOptions`.  
+
+
 ### v2.0.0-alpha.3
 
 - Fix windows import path #41

--- a/packages/grpcweb-transport/src/grpc-web-transport.ts
+++ b/packages/grpcweb-transport/src/grpc-web-transport.ts
@@ -11,7 +11,7 @@ import {
     Deferred,
     DeferredState,
     DuplexStreamingCall,
-    mergeExtendedRpcOptions,
+    mergeRpcOptions,
     MethodInfo,
     RpcError,
     RpcMetadata,
@@ -43,7 +43,7 @@ export class GrpcWebFetchTransport implements RpcTransport {
     }
 
     mergeOptions(options?: Partial<RpcOptions>): RpcOptions {
-        return mergeExtendedRpcOptions(this.defaultOptions, options);
+        return mergeRpcOptions(this.defaultOptions, options);
     }
 
 

--- a/packages/runtime-angular/src/lib/twirp-transport.service.ts
+++ b/packages/runtime-angular/src/lib/twirp-transport.service.ts
@@ -3,7 +3,7 @@ import {
   ClientStreamingCall,
   Deferred,
   DuplexStreamingCall,
-  mergeExtendedRpcOptions,
+  mergeRpcOptions,
   MethodInfo,
   RpcError,
   RpcMetadata,
@@ -44,7 +44,7 @@ export class TwirpTransport implements RpcTransport {
   }
 
   mergeOptions(options?: Partial<RpcOptions>): RpcOptions {
-    return mergeExtendedRpcOptions(this.defaultOptions, options);
+    return mergeRpcOptions(this.defaultOptions, options);
   }
 
   unary<I extends object, O extends object>(method: MethodInfo, input: I, options: RpcOptions): UnaryCall<I, O> {

--- a/packages/runtime-rpc/spec/rpc-options.spec.ts
+++ b/packages/runtime-rpc/spec/rpc-options.spec.ts
@@ -1,23 +1,23 @@
-import {mergeExtendedRpcOptions, RpcOptions} from "../src";
+import {mergeRpcOptions, RpcOptions} from "../src";
 import {IMessageType} from "@protobuf-ts/runtime";
 
 
-describe('mergeExtendedRpcOptions()', () => {
+describe('mergeRpcOptions()', () => {
 
     it('does not require seconds argument', function () {
-        let opt = mergeExtendedRpcOptions({deadline: 123}, undefined);
+        let opt = mergeRpcOptions({deadline: 123}, undefined);
         expect(opt).toEqual({deadline: 123});
     });
 
     it('merges interceptors', function () {
-        let opt = mergeExtendedRpcOptions({interceptors: [{}]}, {interceptors: [{}]});
+        let opt = mergeRpcOptions({interceptors: [{}]}, {interceptors: [{}]});
         expect(opt.interceptors.length).toBe(2);
     });
 
     it('adds default interceptors first', function () {
         let first = {};
         let second = {};
-        let opt = mergeExtendedRpcOptions({interceptors: [first]}, {interceptors: [second]});
+        let opt = mergeRpcOptions({interceptors: [first]}, {interceptors: [second]});
         expect(opt.interceptors[0]).toBe(first);
     });
 
@@ -40,7 +40,7 @@ describe('mergeExtendedRpcOptions()', () => {
                 typeRegistry: [2 as unknown as IMessageType<any>],
             }
         };
-        let act = mergeExtendedRpcOptions(def, opt);
+        let act = mergeRpcOptions(def, opt);
         let exp: RpcOptions = {
             jsonOptions: {
                 ignoreUnknownFields: false,
@@ -66,7 +66,7 @@ describe('mergeExtendedRpcOptions()', () => {
                 b: "b",
             }
         };
-        let c = mergeExtendedRpcOptions(a, b);
+        let c = mergeRpcOptions(a, b);
         expect(c.meta).toEqual({
             overwrite: "b",
             a: "a",

--- a/packages/runtime-rpc/src/index.ts
+++ b/packages/runtime-rpc/src/index.ts
@@ -7,7 +7,7 @@ export {ServiceType} from './service-type';
 export {MethodInfo, PartialMethodInfo, ServiceInfo, ClientStyle, readMethodOptions} from './reflection-info';
 export {RpcError} from './rpc-error';
 export {RpcMetadata} from './rpc-metadata';
-export {RpcOptions, mergeExtendedRpcOptions} from './rpc-options';
+export {RpcOptions, mergeRpcOptions} from './rpc-options';
 export {RpcInputStream} from './rpc-input-stream';
 export {RpcOutputStream, RpcOutputStreamController} from './rpc-output-stream';
 export {RpcStatus} from './rpc-status';

--- a/packages/runtime-rpc/src/rpc-options.ts
+++ b/packages/runtime-rpc/src/rpc-options.ts
@@ -89,7 +89,7 @@ export interface RpcOptions {
  * of primitives. If you have other property types, you have to merge them
  * yourself.
  */
-export function mergeExtendedRpcOptions<T extends RpcOptions>(defaults: T, options?: Partial<T>): T {
+export function mergeRpcOptions<T extends RpcOptions>(defaults: T, options?: Partial<T>): T {
     if (!options)
         return defaults;
     let o = {} as any;

--- a/packages/runtime-rpc/src/rpc-transport.ts
+++ b/packages/runtime-rpc/src/rpc-transport.ts
@@ -23,7 +23,7 @@ import {RpcOptions} from "./rpc-options";
  *
  * b) An implementation **must** merge the options given to `mergeOptions()`
  * with its default options. If no extra options are implemented, or only
- * primitive option values are used, using `mergeExtendedRpcOptions()` will
+ * primitive option values are used, using `mergeRpcOptions()` will
  * produce the required behaviour.
  *
  * c) An implementation **must** pass `RpcOptions.jsonOptions` and

--- a/packages/runtime-rpc/src/test-transport.ts
+++ b/packages/runtime-rpc/src/test-transport.ts
@@ -5,7 +5,7 @@ import {RpcTransport} from "./rpc-transport";
 import {MethodInfo} from "./reflection-info";
 import {assert} from "@protobuf-ts/runtime";
 import {RpcOutputStreamController} from "./rpc-output-stream";
-import {mergeExtendedRpcOptions, RpcOptions} from "./rpc-options";
+import {mergeRpcOptions, RpcOptions} from "./rpc-options";
 import {UnaryCall} from "./unary-call";
 import {ServerStreamingCall} from "./server-streaming-call";
 import {ClientStreamingCall} from "./client-streaming-call";
@@ -251,7 +251,7 @@ export class TestTransport implements RpcTransport {
 
 
     mergeOptions(options?: Partial<RpcOptions>): RpcOptions {
-        return mergeExtendedRpcOptions({}, options);
+        return mergeRpcOptions({}, options);
     }
 
 

--- a/packages/test-generated/spec/service-all-methods.spec.ts
+++ b/packages/test-generated/spec/service-all-methods.spec.ts
@@ -8,7 +8,7 @@ import {
     ClientStreamingCall,
     Deferred,
     DuplexStreamingCall,
-    mergeExtendedRpcOptions,
+    mergeRpcOptions,
     MethodInfo,
     NextUnaryFn,
     RpcError,
@@ -142,7 +142,7 @@ class MockTransport implements RpcTransport {
     }
 
     mergeOptions(options?: Partial<RpcOptions>): RpcOptions {
-        return mergeExtendedRpcOptions(this.defaults, options);
+        return mergeRpcOptions(this.defaults, options);
     }
 
     resolveUnary(headers: RpcMetadata, response: any, status: RpcStatus, trailer: RpcMetadata): void {

--- a/packages/twirp-transport/src/twirp-transport.ts
+++ b/packages/twirp-transport/src/twirp-transport.ts
@@ -4,7 +4,7 @@ import {
     ClientStreamingCall,
     Deferred,
     DuplexStreamingCall,
-    mergeExtendedRpcOptions,
+    mergeRpcOptions,
     MethodInfo,
     RpcError,
     RpcMetadata,
@@ -32,7 +32,7 @@ export class TwirpFetchTransport implements RpcTransport {
     }
 
     mergeOptions(options?: Partial<RpcOptions>): RpcOptions {
-        return mergeExtendedRpcOptions(this.defaultOptions, options);
+        return mergeRpcOptions(this.defaultOptions, options);
     }
 
     unary<I extends object, O extends object>(method: MethodInfo<I, O>, input: I, options: RpcOptions): UnaryCall<I, O> {


### PR DESCRIPTION
This is a simple function rename. The goal is just to keep it as simple as possible and the "extended" is not necessary for that.

Technically a breaking change because the function is part of the public API. But if there are minor breaking changes, this is one. The change only affects RpcTransport implementations.