### PR TITLE
Fix clientStreaming and serverStreaming properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### unreleased changes
+
+Bug Fixes:
+
+- fix missing true values for clientStreaming and serverStreaming properties of generated service info
+
 
 ### v2.0.0-alpha.5
 

--- a/packages/plugin/src/code-gen/method-info-generator.ts
+++ b/packages/plugin/src/code-gen/method-info-generator.ts
@@ -75,10 +75,10 @@ export class MethodInfoGenerator {
         if (info.localName === rt.lowerCamelCase(info.name)) {
             delete partial.localName;
         }
-        if (info.serverStreaming) {
+        if (!info.serverStreaming) {
             delete partial.serverStreaming;
         }
-        if (info.clientStreaming) {
+        if (!info.clientStreaming) {
             delete partial.clientStreaming;
         }
         if (info.options && Object.keys(info.options).length) {


### PR DESCRIPTION
Generated service info is incorrect:

```typescript
    { name: "Unary", serverStreaming: false, clientStreaming: false, options: {}, I: ExampleRequest, O: ExampleResponse },
    { name: "ServerStream", clientStreaming: false, options: {}, I: ExampleRequest, O: ExampleResponse },
    { name: "ClientStream", serverStreaming: false, options: {}, I: ExampleRequest, O: ExampleResponse },
    { name: "Bidi", options: {}, I: ExampleRequest, O: ExampleResponse }
```

The generated properties are unnecessary. All true values are missing, for example serverStreaming: true for "ServerStream".
