### PR TITLE
Support grpc-web-text format with envoy.

### DIFF
--- a/packages/grpcweb-transport/src/grpc-web-format.ts
+++ b/packages/grpcweb-transport/src/grpc-web-format.ts
@@ -78,8 +78,6 @@ export function readGrpcWebResponseHeader(headersOrFetchResponse: HttpHeaders | 
                 // see https://developer.mozilla.org/en-US/docs/Web/API/Response/type
                 throw new RpcError(`fetch response type ${fetchResponse.type}`, GrpcStatusCode[GrpcStatusCode.UNKNOWN]);
         }
-        if (!fetchResponse.body)
-            throw new RpcError('missing response body', GrpcStatusCode[GrpcStatusCode.INTERNAL]);
         return readGrpcWebResponseHeader(
             fetchHeadersToHttp(fetchResponse.headers),
             fetchResponse.status,


### PR DESCRIPTION
Envoy replies with application/grpc-web+proto, regardless of the specified request content type.

Envoy only replies with application/grpc-web-text when the accept request header was set explicitly.

This fix sets `accept: application/grpc-web-text` when requesting in text format.

The fix also looks at the response content type to determine which format to parse.