### PR TITLE
Add perf benchmarks for protobufjs

### DIFF
--- a/packages/benchmarks/perf.ts
+++ b/packages/benchmarks/perf.ts
@@ -6,7 +6,7 @@ import {FileDescriptorSet as sizeType} from "./testees/protobuf-ts.size/.plugin-
 import {FileDescriptorSet as speedType} from "./testees/protobuf-ts.speed/.plugin-out/google/protobuf/descriptor";
 import {FileDescriptorSet as sizeBigintType} from "./testees/protobuf-ts.size-bigint/.plugin-out/google/protobuf/descriptor";
 import {FileDescriptorSet as speedBigintType} from "./testees/protobuf-ts.speed-bigint/.plugin-out/google/protobuf/descriptor";
-
+import {google} from "./testees/protobufjs/.plugin-out/descriptor"
 
 function bench(name: string, fn: () => void, durationSeconds = 5) {
     let startTs = performance.now();
@@ -18,11 +18,19 @@ function bench(name: string, fn: () => void, durationSeconds = 5) {
     }
     let durationMs = performance.now() - startTs;
     let opsPerSecond = 1000 / (durationMs / samples);
-    console.log(`${name}: ${Math.round(opsPerSecond * 100) / 100} ops/s`);
+    console.log(`${name}: ${formatNumber(opsPerSecond)} ops/s`);
 }
 
-
 const bytes = readFileSync('../test-fixtures/all.descriptorset');
+const protobufjsType = google.protobuf.FileDescriptorSet;
+const numberFormat = new Intl.NumberFormat('en-US');
+const formatNumber = (n: number) => {
+    const [whole = '0', fraction = '0'] = numberFormat.format(n).split('.');
+    return [
+        whole.padStart(7, ' '),
+        fraction.padEnd(3, ' '),
+    ].join('.');
+}
 
 let googleProtobufMessage = googleProtobufType.deserializeBinary(bytes);
 let tsProtoMessage = tsProtoType.decode(bytes);
@@ -31,11 +39,11 @@ let tsProtoJsonString = JSON.stringify(tsProtoType.toJSON(tsProtoMessage));
 let sizeMessage = sizeType.fromBinary(bytes);
 let sizeJson = sizeType.toJson(sizeMessage);
 let sizeBigintMessage = sizeBigintType.fromBinary(bytes);
-let sizeBigintJson = sizeBigintType.toJson(sizeBigintMessage);
 let speedMessage = speedType.fromBinary(bytes);
 let speedJson = speedType.toJson(speedMessage);
 let speedBigintMessage = speedBigintType.fromBinary(bytes);
-let speedBigintJson = speedBigintType.toJson(speedBigintMessage);
+let protobufjsMessage = protobufjsType.decode(new Uint8Array(bytes));
+let protobufjsJson = protobufjsType.toObject(protobufjsMessage);
 
 console.log('### read binary');
 bench('google-protobuf             ', () => googleProtobufType.deserializeBinary(bytes));
@@ -44,6 +52,7 @@ bench('protobuf-ts (speed)         ', () => speedType.fromBinary(bytes));
 bench('protobuf-ts (speed, bigint) ', () => speedBigintType.fromBinary(bytes));
 bench('protobuf-ts (size)          ', () => sizeType.fromBinary(bytes));
 bench('protobuf-ts (size, bigint)  ', () => sizeBigintType.fromBinary(bytes));
+bench('protobufjs                  ', () => protobufjsType.decode(new Uint8Array(bytes)));
 
 console.log('### write binary');
 bench('google-protobuf             ', () => googleProtobufMessage.serializeBinary());
@@ -52,6 +61,7 @@ bench('protobuf-ts (speed)         ', () => speedType.toBinary(speedMessage));
 bench('protobuf-ts (speed, bigint) ', () => speedBigintType.toBinary(speedBigintMessage));
 bench('protobuf-ts (size)          ', () => sizeType.toBinary(sizeMessage));
 bench('protobuf-ts (size, bigint)  ', () => sizeBigintType.toBinary(sizeBigintMessage));
+bench('protobufjs                  ', () => protobufjsType.encode(protobufjsMessage).finish());
 
 console.log('### from partial');
 bench('ts-proto                    ', () => tsProtoType.fromPartial(tsProtoMessage));
@@ -62,18 +72,22 @@ console.log('### read json');
 bench('ts-proto                    ', () => tsProtoType.fromJSON(tsProtoJson));
 bench('protobuf-ts (speed)         ', () => speedType.fromJson(speedJson));
 bench('protobuf-ts (size)          ', () => sizeType.fromJson(sizeJson));
+bench('protobufjs                  ', () => protobufjsType.fromObject(protobufjsJson));
 
 console.log('### write json');
 bench('ts-proto                    ', () => tsProtoType.toJSON(tsProtoMessage));
-bench('protobuf-ts (speed)         ', () => speedType.toJson(sizeMessage));
-bench('protobuf-ts (size)          ', () => sizeType.toJson(speedMessage));
+bench('protobuf-ts (speed)         ', () => speedType.toJson(speedMessage));
+bench('protobuf-ts (size)          ', () => sizeType.toJson(sizeMessage));
+bench('protobufjs                  ', () => protobufjsType.toObject(protobufjsMessage));
 
 console.log('### read json string');
 bench('ts-proto                    ', () => tsProtoType.fromJSON(JSON.parse(tsProtoJsonString)));
 bench('protobuf-ts (speed)         ', () => speedType.fromJsonString(tsProtoJsonString));
 bench('protobuf-ts (size)          ', () => sizeType.fromJsonString(tsProtoJsonString));
+bench('protobufjs                  ', () => protobufjsType.fromObject(JSON.parse(tsProtoJsonString)));
 
 console.log('### write json string');
 bench('ts-proto                    ', () => JSON.stringify(tsProtoType.toJSON(tsProtoMessage)));
-bench('protobuf-ts (speed)         ', () => speedType.toJsonString(sizeMessage));
-bench('protobuf-ts (size)          ', () => sizeType.toJsonString(speedMessage));
+bench('protobuf-ts (speed)         ', () => speedType.toJsonString(speedMessage));
+bench('protobuf-ts (size)          ', () => sizeType.toJsonString(sizeMessage));
+bench('protobufjs                  ', () => JSON.stringify(protobufjsType.toObject(protobufjsMessage)));

--- a/packages/benchmarks/testees/protobufjs/Makefile
+++ b/packages/benchmarks/testees/protobufjs/Makefile
@@ -9,6 +9,7 @@ generate: $(PROTOS)
 	@mkdir .plugin-out
 	@echo > .plugin-out/parameters.txt "$(OPTIONS)"
 	@npx pbjs -t static-module -w commonjs -o .plugin-out/descriptor.js $(PROTOS)
+	@npx pbts -o .plugin-out/descriptor.d.ts .plugin-out/descriptor.js
 
 webpack: generate
 	@rm -rf .webpack-out


### PR DESCRIPTION
Partially address #123

Results of the perf benchmark on my machine:

```
### read binary
google-protobuf             :     413.662 ops/s
ts-proto                    :   1,324.736 ops/s
protobuf-ts (speed)         :   1,461.452 ops/s
protobuf-ts (speed, bigint) :   1,475.889 ops/s
protobuf-ts (size)          :   1,250.677 ops/s
protobuf-ts (size, bigint)  :   1,255.167 ops/s
protobufjs                  :   1,732.049 ops/s
### write binary
google-protobuf             :     906.883 ops/s
ts-proto                    :   3,805.993 ops/s
protobuf-ts (speed)         :     430.632 ops/s
protobuf-ts (speed, bigint) :     448.063 ops/s
protobuf-ts (size)          :     378.682 ops/s
protobuf-ts (size, bigint)  :     392.511 ops/s
protobufjs                  :   1,539.768 ops/s
### from partial
ts-proto                    :   4,503.332 ops/s
protobuf-ts (speed)         :   1,568.577 ops/s
protobuf-ts (size)          :   1,555.881 ops/s
### read json
ts-proto                    :   3,719.366 ops/s
protobuf-ts (speed)         :     889.613 ops/s
protobuf-ts (size)          :     890.034 ops/s
protobufjs                  :   4,120.232 ops/s
### write json
ts-proto                    :  13,200.842 ops/s
protobuf-ts (speed)         :   1,865.668 ops/s
protobuf-ts (size)          :   1,862.537 ops/s
protobufjs                  :   4,199.372 ops/s
### read json string
ts-proto                    :     957.057 ops/s
protobuf-ts (speed)         :     416.284 ops/s
protobuf-ts (size)          :     421.48  ops/s
protobufjs                  :     910.256 ops/s
### write json string
ts-proto                    :   1,000.572 ops/s
protobuf-ts (speed)         :     943.338 ops/s
protobuf-ts (size)          :     949.784 ops/s
protobufjs                  :   1,446.891 ops/s
```