### PR TITLE
Support rpc timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ### unreleased changes
 
-none
+Breaking changes:
+
+- `RpcOptions` takes a `timeout` property now. `deadline` property 
+  has been removed. See #138 for details.
 
 
 ### v2.0.0-alpha.29

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -1409,10 +1409,9 @@ The options:
   If a key ends with `-bin`, it should contain binary data in base64
   encoding, allowing you to send serialized messages.
 
-- `deadline: Date | number`
-  
-  Deadline for the call. Can be a specific date or a
-  timeout in milliseconds.
+- `timeout: Date | number`  
+  Timeout for the call in milliseconds.  
+  If a Date object is given, it is used as a deadline.
 
 - `interceptors: RpcInterceptor[]`
   

--- a/packages/example-angular-app/src/app/grpcweb-server-streaming/grpcweb-server-streaming.component.html
+++ b/packages/example-angular-app/src/app/grpcweb-server-streaming/grpcweb-server-streaming.component.html
@@ -19,7 +19,7 @@
     </div>
     <div class="large-3 medium-4 cell">
       <label>Deadline (milliseconds)</label>
-      <input name="options_deadline" type="number" min="0" step="100" [(ngModel)]="options.deadline"
+      <input name="options_timeout" type="number" min="0" step="100" [(ngModel)]="options.timeout"
              placeholder="deadline"/>
     </div>
     <div class="large-3 medium-4 cell">

--- a/packages/example-angular-app/src/app/grpcweb-server-streaming/grpcweb-server-streaming.component.ts
+++ b/packages/example-angular-app/src/app/grpcweb-server-streaming/grpcweb-server-streaming.component.ts
@@ -25,7 +25,7 @@ export class GrpcwebServerStreamingComponent {
 
   readonly options: GrpcWebOptions = {
     baseUrl: 'http://localhost:5080',
-    deadline: Date.now() + 2000,
+    timeout: Date.now() + 2000,
     format: 'binary',
 
     // simple example for how to add auth headers to each request

--- a/packages/example-angular-app/src/app/grpcweb-unary/grpcweb-unary.component.html
+++ b/packages/example-angular-app/src/app/grpcweb-unary/grpcweb-unary.component.html
@@ -19,7 +19,7 @@
     </div>
     <div class="large-3 medium-4 cell">
       <label>Deadline (milliseconds)</label>
-      <input name="options_deadline" type="number" min="0" step="100" [(ngModel)]="options.deadline"
+      <input name="options_timeout" type="number" min="0" step="100" [(ngModel)]="options.timeout"
              placeholder="deadline"/>
     </div>
     <div class="large-3 medium-4 cell">

--- a/packages/example-node-grpcweb-transport-client/client.ts
+++ b/packages/example-node-grpcweb-transport-client/client.ts
@@ -65,7 +65,7 @@ async function callServerStream(client: IExampleServiceClient) {
     const headers = await call.headers;
     console.log("got response headers: ", headers)
 
-    for await (let response of call.response) {
+    for await (let response of call.responses) {
         console.log("got response message: ", response)
     }
 

--- a/packages/grpc-transport/src/grpc-transport.ts
+++ b/packages/grpc-transport/src/grpc-transport.ts
@@ -45,9 +45,13 @@ export class GrpcTransport implements RpcTransport {
         if (options.callOptions) {
             return options.callOptions;
         }
-        return {
-            deadline: options.deadline
-        };
+        const co: CallOptions = {};
+        if (typeof options.timeout === "number") {
+            co.deadline = Date.now() + options.timeout;
+        } else if (options.timeout) {
+            co.deadline = options.timeout;
+        }
+        return co;
     }
 
     unary<I extends object, O extends object>(method: MethodInfo<I, O>, input: I, options: GrpcCallOptions): UnaryCall<I, O> {

--- a/packages/grpcweb-transport/src/grpc-web-format.ts
+++ b/packages/grpcweb-transport/src/grpc-web-format.ts
@@ -6,7 +6,7 @@ import {GrpcStatusCode} from "./goog-grpc-status-code";
 /**
  * Create fetch API headers for a grpc-web request.
  */
-export function createGrpcWebRequestHeader(headers: Headers, format: GrpcWebFormat, deadline: Date | number | undefined, meta?: RpcMetadata, userAgent?: string): Headers {
+export function createGrpcWebRequestHeader(headers: Headers, format: GrpcWebFormat, timeout: Date | number | undefined, meta?: RpcMetadata, userAgent?: string): Headers {
     // add meta as headers
     if (meta) {
         for (let [k, v] of Object.entries(meta)) {
@@ -28,15 +28,11 @@ export function createGrpcWebRequestHeader(headers: Headers, format: GrpcWebForm
     headers.set('X-Grpc-Web', "1");
     if (userAgent)
         headers.set("X-User-Agent", userAgent);
-    if (deadline) {
-        let ts = typeof deadline == "number" ? deadline : deadline.getTime();
-        let timeout = ts - Date.now();
-        headers.set('grpc-timeout', timeout + 'm');
+    if (typeof timeout === "number") {
+        headers.set('grpc-timeout', `${Date.now() + timeout}m`);
+    } else if (timeout) {
+        headers.set('grpc-timeout', `${timeout.getTime()}m`);
     }
-    // let timeout = typeof deadline == "number" ? deadline : deadline instanceof Date ? (deadline.getTime() - Date.now()) : 0;
-    // if (timeout > 0) {
-    //     headers.set('grpc-timeout', timeout + 'm');
-    // }
     return headers;
 }
 

--- a/packages/grpcweb-transport/src/grpc-web-transport.ts
+++ b/packages/grpcweb-transport/src/grpc-web-transport.ts
@@ -97,7 +97,7 @@ export class GrpcWebFetchTransport implements RpcTransport {
         globalThis.fetch(url, {
             ...fetchInit,
             method: 'POST',
-            headers: createGrpcWebRequestHeader(new globalThis.Headers(), format, opt.deadline, opt.meta),
+            headers: createGrpcWebRequestHeader(new globalThis.Headers(), format, opt.timeout, opt.meta),
             body: createGrpcWebRequestBody(inputBytes, format),
             signal: options.abort ?? null // node-fetch@3.0.0-beta.9 rejects `undefined`
         })
@@ -197,7 +197,7 @@ export class GrpcWebFetchTransport implements RpcTransport {
         globalThis.fetch(url, {
             ...fetchInit,
             method: 'POST',
-            headers: createGrpcWebRequestHeader(new globalThis.Headers(), format, opt.deadline, opt.meta),
+            headers: createGrpcWebRequestHeader(new globalThis.Headers(), format, opt.timeout, opt.meta),
             body: createGrpcWebRequestBody(inputBytes, format),
             signal: options.abort ?? null // node-fetch@3.0.0-beta.9 rejects `undefined`
         })

--- a/packages/runtime-rpc/spec/rpc-options.spec.ts
+++ b/packages/runtime-rpc/spec/rpc-options.spec.ts
@@ -5,8 +5,8 @@ import type {IMessageType} from "@protobuf-ts/runtime";
 describe('mergeRpcOptions()', () => {
 
     it('does not require seconds argument', function () {
-        let opt = mergeRpcOptions({deadline: 123}, undefined);
-        expect(opt).toEqual({deadline: 123});
+        let opt = mergeRpcOptions({timeout: 123}, undefined);
+        expect(opt).toEqual({timeout: 123});
     });
 
     it('merges interceptors', function () {

--- a/packages/runtime-rpc/src/rpc-options.ts
+++ b/packages/runtime-rpc/src/rpc-options.ts
@@ -23,10 +23,10 @@ export interface RpcOptions {
     meta?: RpcMetadata;
 
     /**
-     * Deadline for the call. Can be given as a Date object or a
-     * timestamp in milliseconds.
+     * Timeout for the call in milliseconds.
+     * If a Date object is given, it is used as a deadline.
      */
-    deadline?: Date | number;
+    timeout?: number | Date;
 
     /**
      * Interceptors can be used to manipulate request and response data.


### PR DESCRIPTION
Renames rpc option `deadline` to `timeout`. When a number is given, it is used as a timeout in milliseconds. When a Date is given, it is used as a deadline.

Fixes #99