### PR TITLE
Use Symbol.for() to define MESSAGE_TYPE

### DIFF
--- a/packages/runtime/src/binary-format-contract.ts
+++ b/packages/runtime/src/binary-format-contract.ts
@@ -78,7 +78,7 @@ export namespace UnknownFieldHandler {
      * The symbol used to store unknown fields for a message.
      * The property must conform to `UnknownFieldContainer`.
      */
-    export const symbol: unique symbol = Symbol("protobuf-ts/unknown");
+    export const symbol: unique symbol = Symbol.for("protobuf-ts/unknown");
 
 
     /**

--- a/packages/runtime/src/message-type-contract.ts
+++ b/packages/runtime/src/message-type-contract.ts
@@ -9,7 +9,7 @@ import type {JsonReadOptions, JsonWriteOptions, JsonWriteStringOptions} from "./
  * Note that this is an experimental feature - it is here to stay, but
  * implementation details may change without notice.
  */
-export const MESSAGE_TYPE: unique symbol = Symbol("protobuf-ts/message-type");
+export const MESSAGE_TYPE: unique symbol = Symbol.for("protobuf-ts/message-type");
 
 /**
  * Similar to `Partial<T>`, but recursive, and keeps `oneof` groups


### PR DESCRIPTION
I had started using `MESSAGE_TYPE` introduced in 2.0.3 and have run into a problem due to `MESSAGE_TYPE` being a unique symbol. 

My setup is a Lerna monorepo with `packages/proto` carrying all proto definitions (the package devDepends on `@protobuf-ts/plugin`), and `packages/backendlib` containing a function that imports `MESSAGE_TYPE` to do redaction (this package depends on `@protobuf-ts/runtime`). I have a test that imports a proto type from `packages/proto`.

The problem is that `@protobuf-ts/runtime` package happens to be installed twice: both under `packages/proto/node_modules`  and `packages/backendlib/node_modules`. As such, `MESSAGE_TYPE` symbols are unequal (since each of them is unique), and `containsMessageType` function called from `packages/backendlib` code always returns `false` because it probes the object with the "Doppelgaenger" `MESSAGE_TYPE`!

This fix uses `Symbol.for(...)` to define `MESSAGE_TYPE` making it non-unique.
