### PR TITLE
Update parseTrailer function to support empty trailers & trailers with colon in content

### DIFF
--- a/packages/grpcweb-transport/src/grpc-web-format.ts
+++ b/packages/grpcweb-transport/src/grpc-web-format.ts
@@ -300,7 +300,10 @@ function parseMetadata(headers: HttpHeaders): RpcMetadata {
 function parseTrailer(trailerData: Uint8Array): HttpHeaders {
     let headers: HttpHeaders = {};
     for (let chunk of String.fromCharCode.apply(String, trailerData as unknown as number[]).trim().split("\r\n")) {
-        let [key, value] = chunk.split(":", 2);
+        if (chunk == "")
+            continue;
+        let [key, ...val] = chunk.split(":");
+        let value = val.join(":")
         key = key.trim();
         value = value.trim();
         let e = headers[key];


### PR DESCRIPTION
When message ends with `128, 0, 0, 0, 0` and trailerData is empty, splitting it by `\r\n` resulting array contains one empty string.
This causes error:
```
RpcError: Cannot read property 'trim' of undefined
```

Also, if trailer has colon in content it stripping because of limit. See https://github.com/timostamm/protobuf-ts/issues/166

This PR fixes this bugs, according to grpc-web protocol.