### PR TITLE
json: Ignore unknown enum values

### DIFF
--- a/packages/runtime/spec/reflection-json-reader.spec.ts
+++ b/packages/runtime/spec/reflection-json-reader.spec.ts
@@ -1,6 +1,5 @@
 import {fixtures} from "../../test-fixtures";
-import {EnumInfo, JsonObject, normalizeFieldInfo, jsonReadOptions, ReflectionJsonReader} from "../src";
-import {RepeatType} from "../src";
+import {EnumInfo, JsonObject, jsonReadOptions, normalizeFieldInfo, ReflectionJsonReader, RepeatType} from "../src";
 
 describe('ReflectionJsonReader', function () {
 
@@ -169,14 +168,57 @@ describe('ReflectionJsonReader', function () {
             ANY = 0
         }
 
+        it('skip map value if the value is invalid', function () {
+            const reader = new ReflectionJsonReader({
+                typeName: 'test',
+                fields: [
+                    normalizeFieldInfo({no: 1, name: "field", kind: "map", K: 9 /*string*/, V: {kind: "enum", T: () => ["SimpleEnum", SimpleEnum]}}),
+                ]
+            });
+            let output: any = {field: {}};
+            reader.read({field: {valid: "ANY", invalid: "XXX"}}, output, {ignoreUnknownFields: true});
+            expect(output).toEqual({field: {valid: SimpleEnum.ANY}});
+        });
+
+        it('skip array value if the value is invalid', function () {
+            const reader = new ReflectionJsonReader({
+                typeName: 'test',
+                fields: [
+                    normalizeFieldInfo({no: 1, name: "field", kind: "enum", T: () => ["SimpleEnum", SimpleEnum], repeat: RepeatType.PACKED}),
+                ]
+            });
+            let output: any = {field: []};
+            reader.read({field: ["ANY", "XXX", "ANY"]}, output, {ignoreUnknownFields: true});
+            expect(output).toEqual({field: [SimpleEnum.ANY, SimpleEnum.ANY]});
+        });
+
+        it('skip enum value if the value is invalid', function () {
+            const reader = new ReflectionJsonReader({
+                typeName: 'test',
+                fields: [
+                    normalizeFieldInfo({no: 1, name: "field", kind: "enum", T: () => ["SimpleEnum", SimpleEnum]}),
+                ]
+            });
+            let output = {};
+            reader.read({field: "XXX"}, output, {ignoreUnknownFields: true});
+            expect(output).toEqual({});
+        });
+
+    });
+
+    describe('enum()', function () {
+        enum SimpleEnum {
+            ANY = 0
+        }
+
         it('throws if unknown value was found', function () {
             const reader = new ReflectionJsonReader({typeName: '.test.Message', fields: []});
-            expect(() => reader.enum([".spec.SimpleEnum", SimpleEnum], 'test', '')).toThrowError(/enum \.spec\.SimpleEnum has no value for "test"/);
+            expect(() => reader.enum([".spec.SimpleEnum", SimpleEnum], 'test', '', false)).toThrowError(/enum \.spec\.SimpleEnum has no value for "test"/);
         })
 
-        it('return undefined if unknown value was found, but ignoreUnknownFields was set', function () {
+        it('return false if unknown value was found, but ignoreUnknownFields was set', function () {
             const reader = new ReflectionJsonReader({typeName: '.test.Message', fields: []});
-            expect(reader.enum([".spec.SimpleEnum", SimpleEnum], 'test', '', true)).toBeUndefined();
+            expect(reader.enum([".spec.SimpleEnum", SimpleEnum], 'test', '', true)).toBeFalse();
         })
 
     });
@@ -212,20 +254,20 @@ describe('ReflectionJsonReader', function () {
             T: () => ["google.protobuf.NullValue", NullValue]
         });
         it('`null` parses as `null`', () => {
-            const val = reader.enum(handler, null, field.name);
+            const val = reader.enum(handler, null, field.name, false);
             expect(val).toBe(NullValue.NULL_VALUE);
         });
         it('other value throws', () => {
-            expect(() => reader.enum(handler, 0, field.name))
+            expect(() => reader.enum(handler, 0, field.name, false))
                 .toThrow();
-            expect(() => reader.enum(handler, 'NULL_VALUE', field.name))
+            expect(() => reader.enum(handler, 'NULL_VALUE', field.name, false))
                 .toThrow();
         });
         it('`0` throws', () => {
-            expect(() => reader.enum(handler, 0, field.name)).toThrowError(/only accepts null/);
+            expect(() => reader.enum(handler, 0, field.name, false)).toThrowError(/only accepts null/);
         });
         it('`NULL_VALUE` throws', () => {
-            expect(() => reader.enum(handler, 'NULL_VALUE', field.name)).toThrowError(/only accepts null/);
+            expect(() => reader.enum(handler, 'NULL_VALUE', field.name, false)).toThrowError(/only accepts null/);
         });
 
     });

--- a/packages/runtime/src/reflection-json-reader.ts
+++ b/packages/runtime/src/reflection-json-reader.ts
@@ -116,6 +116,8 @@ export class ReflectionJsonReader {
 
                         case "enum":
                             val = this.enum(field.V.T(), jsonObjValue, field.name, options.ignoreUnknownFields);
+                            if (val === false)
+                                continue;
                             break;
 
                         case "scalar":
@@ -155,6 +157,8 @@ export class ReflectionJsonReader {
 
                         case "enum":
                             val = this.enum(field.T(), jsonItem, field.name, options.ignoreUnknownFields);
+                            if (val === false)
+                                continue;
                             break;
 
                         case "scalar":
@@ -180,7 +184,10 @@ export class ReflectionJsonReader {
                         break;
 
                     case "enum":
-                        target[localName] = this.enum(field.T(), jsonValue, field.name, options.ignoreUnknownFields);
+                        let val = this.enum(field.T(), jsonValue, field.name, options.ignoreUnknownFields);
+                        if (val === false)
+                            continue;
+                        target[localName] = val;
                         break;
 
                     case "scalar":
@@ -196,7 +203,7 @@ export class ReflectionJsonReader {
     /**
      * google.protobuf.NullValue accepts only JSON `null`.
      */
-    enum(type: EnumInfo, json: unknown, fieldName: string, ignoreUnknownFields = false): UnknownEnum|undefined {
+    enum(type: EnumInfo, json: unknown, fieldName: string, ignoreUnknownFields: boolean): UnknownEnum|false {
         if (type[0] == 'google.protobuf.NullValue')
             assert(json === null, `Unable to parse field ${this.info.typeName}#${fieldName}, enum ${type[0]} only accepts null.`);
         if (json === null)
@@ -213,7 +220,7 @@ export class ReflectionJsonReader {
                     localEnumName = json.substring(type[2].length);
                 let enumNumber = type[1][localEnumName];
                 if (typeof enumNumber === 'undefined' && ignoreUnknownFields) {
-                    return undefined;
+                    return false;
                 }
                 assert(typeof enumNumber == "number", `Unable to parse field ${this.info.typeName}#${fieldName}, enum ${type[0]} has no value for "${json}".`);
                 return enumNumber;


### PR DESCRIPTION
While parsing proto from JSON, any unknown enum values would result in assertion error. This would cause backward compatibility issue.

I looked on how other implementations are doing it and found that [the protobuf team has decided that ignoringUnknownFields not ignoring missing enum values is a bug](https://github.com/protocolbuffers/protobuf/pull/3289#issuecomment-312354474). The Java implementation now returns 0 if `ignoringUnknownFields` is set.