### PR TITLE
Add keep_enum_prefix plugin option

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -140,6 +140,11 @@ Available plugin options:
   with our option (ts.exclude_options). Set this option if you are certain you do not want
   to include any options at all.
 
+- "keep_enum_prefix"
+  By default, if all enum values share a prefix that corresponds with the enum's name,
+  the prefix is dropped from the value names. Set this option if you want to disable this behavior
+  and keep the prefix intact.
+
 - "client_none"  
   Do not generate rpc clients.
   Only applies to services that do *not* use the option `ts.client`.
@@ -510,7 +515,7 @@ enum Foo {
 }
  ```
 
-The prefix "FOO_" is dropped in TypeScript:
+The prefix "FOO_" is dropped in TypeScript (unless `keep_enum_prefix` option is provided to the plugin):
 
  ```typescript
 enum Foo {
@@ -1120,7 +1125,7 @@ string-based 64 bit integer support (see [Bigint support](#bigint-support)).
 
 
 
-#### Unknown field handling 
+#### Unknown field handling
 
 Unknown fields occur when a message has been created with a newer version 
 of a proto file, or when proto2 extensions are used (see [proto2 support](#proto2-support)). 

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -142,8 +142,7 @@ Available plugin options:
 
 - "keep_enum_prefix"
   By default, if all enum values share a prefix that corresponds with the enum's name,
-  the prefix is dropped from the value names. Set this option if you want to disable this behavior
-  and keep the prefix intact.
+  the prefix is dropped from the value names. Set this option to disable this behavior.
 
 - "client_none"  
   Do not generate rpc clients.

--- a/packages/plugin/spec/interpreter.spec.ts
+++ b/packages/plugin/spec/interpreter.spec.ts
@@ -14,6 +14,7 @@ describe('interpreter', function () {
                 synthesizeEnumZeroValue: 'UNSPECIFIED$',
                 oneofKindDiscriminator: 'oneofKind',
                 forceExcludeAllOptions: false,
+                keepEnumPrefix: false,
             });
             const messageType = interpreter.getMessageType('spec.LongsMessage');
 

--- a/packages/plugin/src/interpreter.ts
+++ b/packages/plugin/src/interpreter.ts
@@ -52,6 +52,7 @@ export class Interpreter {
             oneofKindDiscriminator: string,
             synthesizeEnumZeroValue: string | false,
             forceExcludeAllOptions: boolean,
+            keepEnumPrefix: boolean,
         },
     ) {
     }
@@ -543,7 +544,9 @@ export class Interpreter {
 
 
     protected buildEnumInfo(descriptor: EnumDescriptorProto): rt.EnumInfo {
-        let sharedPrefix = this.registry.findEnumSharedPrefix(descriptor, `${descriptor.name}`);
+        let sharedPrefix = this.options.keepEnumPrefix
+            ? undefined
+            : this.registry.findEnumSharedPrefix(descriptor, `${descriptor.name}`);
         let hasZero = descriptor.value.some(v => v.number === 0);
         let builder = new RuntimeEnumBuilder();
         if (!hasZero && typeof this.options.synthesizeEnumZeroValue == 'string') {

--- a/packages/plugin/src/our-options.ts
+++ b/packages/plugin/src/our-options.ts
@@ -188,6 +188,7 @@ export interface InternalOptions {
     readonly runtimeRpcImportPath: string;
     readonly runtimeImportPath: string;
     readonly forceExcludeAllOptions: boolean;
+    readonly keepEnumPrefix: boolean;
 }
 
 export function makeInternalOptions(options?: Partial<InternalOptions>): InternalOptions {
@@ -211,6 +212,7 @@ const defaultOptions: InternalOptions = {
     angularCoreImportPath: '@angular/core',
     runtimeImportPath: '@protobuf-ts/runtime',
     forceExcludeAllOptions: false,
+    keepEnumPrefix: false,
 } as const;
 
 

--- a/packages/plugin/src/protobufts-plugin.ts
+++ b/packages/plugin/src/protobufts-plugin.ts
@@ -64,8 +64,7 @@ export class ProtobuftsPlugin extends PluginBase<OutFile> {
         },
         keep_enum_prefix: {
             description: "By default, if all enum values share a prefix that corresponds with the enum's name, \n" +
-                "the prefix is dropped from the value names. Set this option if you want to disable this behavior \n" +
-                "and keep the prefix intact.",
+                "the prefix is dropped from the value names. Set this option to disable this behavior.",
         },
 
         // client

--- a/packages/plugin/src/protobufts-plugin.ts
+++ b/packages/plugin/src/protobufts-plugin.ts
@@ -62,6 +62,11 @@ export class ProtobuftsPlugin extends PluginBase<OutFile> {
                 "with our option (ts.exclude_options). Set this option if you are certain you do not want \n" +
                 "to include any options at all.",
         },
+        keep_enum_prefix: {
+            description: "By default, if all enum values share a prefix that corresponds with the enum's name, \n" +
+                "the prefix is dropped from the value names. Set this option if you want to disable this behavior \n" +
+                "and keep the prefix intact.",
+        },
 
         // client
         client_none: {
@@ -154,6 +159,7 @@ export class ProtobuftsPlugin extends PluginBase<OutFile> {
                 emitAngularAnnotations: params.enable_angular_annotations,
                 normalLongType: params.long_type_string ? rt.LongType.STRING : params.long_type_number ? rt.LongType.NUMBER : rt.LongType.BIGINT,
                 forceExcludeAllOptions: params.force_exclude_all_options,
+                keepEnumPrefix: params.keep_enum_prefix,
             }),
             registry = DescriptorRegistry.createFrom(request),
             symbols = new SymbolTable(),


### PR DESCRIPTION
This new option, if specified, will instruct the plugin to NOT drop a common shared enum name prefix. By default, the prefix
is removed.

Motivation: my company has a huge legacy TypeScript codebase that uses protobuf.js-generated proto definitions. We want to migrate it to protobuf-ts. Some enums are very pervasive, converted from and to strings with prefix assumed, so it's easier to just keep the damn prefix where it is. 

We also have a ton of Go code where prefix is not removed, so for the sake of consistency I want to introduce this new option which is, of course, off by default.