### PR TITLE
Fix server_generic plugin option

### DIFF
--- a/packages/plugin/src/our-options.ts
+++ b/packages/plugin/src/our-options.ts
@@ -305,7 +305,7 @@ export function makeInternalOptions(
         o.forcedClientStyle = ClientStyle.NO_CLIENT;
     }
     if (params?.server_generic) {
-        o.normalServerStyle = ServerStyle.NO_SERVER;
+        o.normalServerStyle = ServerStyle.GENERIC_SERVER;
     }
     if (params?.server_grpc1) {
         o.normalServerStyle = ServerStyle.GRPC1_SERVER;


### PR DESCRIPTION
In #200, the `server_generic` option was incorrectly parsed to `ServerStyle.NO_SERVER`.

Fixes #202