### PR TITLE
Support go 1.18 in build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  go: circleci/go@1.6.0
+  go: circleci/go@1.7.0
 jobs:
   build:
     docker:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ### unreleased changes
 
-none
+Project maintenance:
+
+- Support go 1.18 in build #263
 
 
 ### v2.4.0

--- a/packages/twirp-transport/Makefile
+++ b/packages/twirp-transport/Makefile
@@ -40,7 +40,7 @@ clientcompat7: build
 		--proto_path=clientcompat/ \
 		clientcompat/clientcompat.proto
 	./node_modules/.bin/tsc --target ES2015 --module commonjs clientcompat/clientcompat.ts clientcompat/client.ts
-	go get github.com/twitchtv/twirp/clientcompat@v7.0.0
+	go install github.com/twitchtv/twirp/clientcompat@v7.0.0
 	${HOME}/go/bin/clientcompat -client clientcompat/client-runner.js
 
 clientcompat8: build
@@ -50,5 +50,5 @@ clientcompat8: build
 		--proto_path=clientcompat/ \
 		clientcompat/clientcompat.proto
 	./node_modules/.bin/tsc --target ES2015 --module commonjs clientcompat/clientcompat.ts clientcompat/client.ts
-	go get github.com/twitchtv/twirp/clientcompat@v8.0.0
+	go install github.com/twitchtv/twirp/clientcompat@v8.0.0
 	${HOME}/go/bin/clientcompat -client clientcompat/client-runner.js


### PR DESCRIPTION
`go get` is no longer supported by go 1.18.
Switch to `go install` and bump CI to go 1.17.