### PR TITLE
Replace deprecated String.prototype.substr()

### DIFF
--- a/packages/plugin-framework/src/source-code-info.ts
+++ b/packages/plugin-framework/src/source-code-info.ts
@@ -162,7 +162,7 @@ export function sourceCodeLocationToComment(locations: readonly SourceCodeInfo_L
 
 function stripTrailingNewline(block: string): string {
     return block.endsWith('\n')
-        ? block.substr(0, block.length - 1)
+        ? block.slice(0, -1)
         : block;
 }
 


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.