### PR TITLE
export createDefinition from @protobuf-ts/grpc-backend

### DIFF
--- a/packages/grpc-backend/src/index.ts
+++ b/packages/grpc-backend/src/index.ts
@@ -3,4 +3,4 @@
 // webpack verbose output hints that this should be useful
 
 
-export {adaptService, createContext} from "./grpc-adapter";
+export {adaptService, createContext, createDefinition} from "./grpc-adapter";


### PR DESCRIPTION
We have a use case where we need to call `createDefinition` directly and not via `adaptService`. Would be great if this was exported