### PR TITLE
Support forcing optional interface properties

### DIFF
--- a/packages/plugin/src/code-gen/message-interface-generator.ts
+++ b/packages/plugin/src/code-gen/message-interface-generator.ts
@@ -24,6 +24,7 @@ export class MessageInterfaceGenerator extends GeneratorBase {
                 private readonly options: {
                     oneofKindDiscriminator: string;
                     normalLongType: rt.LongType;
+                    forceOptionalInterfaceFields: boolean;
                 }) {
         super(symbols, registry, imports, comments, interpreter);
     }
@@ -160,8 +161,8 @@ export class MessageInterfaceGenerator extends GeneratorBase {
             type = ts.createArrayTypeNode(type);
         }
 
-        // if optional, add question mark
-        let questionToken = fieldInfo.opt ? ts.createToken(ts.SyntaxKind.QuestionToken) : undefined;
+        // if optional, or force optional interface fields is true, add question mark
+        let questionToken = (fieldInfo.opt || this.options.forceOptionalInterfaceFields) ? ts.createToken(ts.SyntaxKind.QuestionToken) : undefined;
 
         // create property
         const property = ts.createPropertySignature(

--- a/packages/plugin/src/our-options.ts
+++ b/packages/plugin/src/our-options.ts
@@ -202,6 +202,7 @@ export interface InternalOptions {
     readonly transpileTarget: ts.ScriptTarget | undefined,
     readonly transpileModule: ts.ModuleKind,
     readonly addPbSuffix: boolean;
+    readonly forceOptionalInterfaceFields: boolean;
 }
 
 export function makeInternalOptions(
@@ -227,6 +228,7 @@ export function makeInternalOptions(
         client_none: boolean,
         client_grpc1: boolean,
         add_pb_suffix: boolean,
+        force_optional_interface_fields: boolean,
         output_typescript: boolean,
         output_javascript: boolean,
         output_javascript_es2015: boolean,
@@ -266,6 +268,7 @@ export function makeInternalOptions(
             transpileTarget: undefined,
             transpileModule: ts.ModuleKind.ES2015,
             addPbSuffix: false,
+            forceOptionalInterfaceFields: false,
         },
     ) as Writeable<InternalOptions>;
     if (pluginCredit) {
@@ -327,6 +330,9 @@ export function makeInternalOptions(
     }
     if (params?.add_pb_suffix) {
         o.addPbSuffix = true;
+    }
+    if (params?.force_optional_interface_fields) {
+        o.forceOptionalInterfaceFields = true;
     }
     if (params?.output_javascript) {
         o.transpileTarget = ts.ScriptTarget.ES2020;

--- a/packages/plugin/src/protobufts-plugin.ts
+++ b/packages/plugin/src/protobufts-plugin.ts
@@ -101,6 +101,9 @@ export class ProtobuftsPlugin extends PluginBase {
             description: "Adds the suffix `_pb` to the names of all generated files. This will become the \n" +
                          "default behaviour in the next major release.",
         },
+        force_optional_interface_fields: {
+            description: "All generated interface fields will have `?` syntax so that they're optional"
+        },
 
         // output types
         output_typescript: {


### PR DESCRIPTION
The default behavior for protobuf optional fields is difficult to use with large objects unless you set `optional` on every message field. This feels like a side effect if you don't want every protobuf field to be optional, but you want to support optional typescript fields. This PR adds an option that is be backwards compatible with current behavior. When true, all fields on generated interfaces are optional.