### PR TITLE
Client suffix fix

### DIFF
--- a/packages/plugin/src/our-options.ts
+++ b/packages/plugin/src/our-options.ts
@@ -202,6 +202,7 @@ export interface InternalOptions {
     readonly transpileTarget: ts.ScriptTarget | undefined,
     readonly transpileModule: ts.ModuleKind,
     readonly addPbSuffix: boolean;
+    readonly changeClientSuffix: boolean;
 }
 
 export function makeInternalOptions(
@@ -227,6 +228,7 @@ export function makeInternalOptions(
         client_none: boolean,
         client_grpc1: boolean,
         add_pb_suffix: boolean,
+        change_client_suffix: boolean,
         output_typescript: boolean,
         output_javascript: boolean,
         output_javascript_es2015: boolean,
@@ -266,6 +268,7 @@ export function makeInternalOptions(
             transpileTarget: undefined,
             transpileModule: ts.ModuleKind.ES2015,
             addPbSuffix: false,
+            changeClientSuffix: false,
         },
     ) as Writeable<InternalOptions>;
     if (pluginCredit) {
@@ -327,6 +330,9 @@ export function makeInternalOptions(
     }
     if (params?.add_pb_suffix) {
         o.addPbSuffix = true;
+    }
+    if (params?.change_client_suffix) {
+        o.changeClientSuffix = true;
     }
     if (params?.output_javascript) {
         o.transpileTarget = ts.ScriptTarget.ES2020;

--- a/packages/plugin/src/protobufts-plugin.ts
+++ b/packages/plugin/src/protobufts-plugin.ts
@@ -101,6 +101,10 @@ export class ProtobuftsPlugin extends PluginBase {
             description: "Adds the suffix `_pb` to the names of all generated files. This will become the \n" +
                          "default behaviour in the next major release.",
         },
+        change_client_suffix: {
+            description: "Changes the suffix `.client` to `_client`. This allows \n" +
+                         "compatibility with remix.run.",
+        },
 
         // output types
         output_typescript: {
@@ -259,9 +263,10 @@ export class ProtobuftsPlugin extends PluginBase {
         }
         for (let fileDescriptor of registry.allFiles()) {
             const base = fileDescriptor.name!.replace('.proto', '') + (options.addPbSuffix ? "_pb" : "");
+            const clientSuffix = (options.changeClientSuffix ? "_" : ".") + 'client.ts';
             fileTable.register(base + '.server.ts', fileDescriptor, 'generic-server');
             fileTable.register(base + '.grpc-server.ts', fileDescriptor, 'grpc1-server');
-            fileTable.register(base + '.client.ts', fileDescriptor, 'client');
+            fileTable.register(base + clientSuffix, fileDescriptor, 'client');
             fileTable.register(base + '.promise-client.ts', fileDescriptor, 'promise-client');
             fileTable.register(base + '.rx-client.ts', fileDescriptor, 'rx-client');
             fileTable.register(base + '.grpc-client.ts', fileDescriptor, 'grpc1-client');


### PR DESCRIPTION
Suggested fix for #315.

Essentially Remix.run allows [separating client and server code](https://remix.run/docs/en/v1/guides/constraints). To achieve this they use the `.client.ts` file extension.

So if you try using _generated_.client.ts on the server, remix would have pruned it from the server bundle, so it is undefined.