### PR TITLE
grpcweb-transport: Guard access of response.type to support Cloudflare Workers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 ### unreleased changes
 
-none
+
+Bug fixes:
+
+- Guard access of response.type to support Cloudflare Workers, see #321  
+  Thanks to @mikeylemmon for the fix!
 
 
 ### v2.6.0

--- a/packages/twirp-transport/src/twirp-transport.ts
+++ b/packages/twirp-transport/src/twirp-transport.ts
@@ -58,7 +58,13 @@ export class TwirpFetchTransport implements RpcTransport {
 
                 defHeader.resolve(parseMetadataFromResponseHeaders(fetchResponse.headers));
 
-                switch (fetchResponse.type) {
+                // Cloudflare Workers throw when the type property of a fetch response
+                // is accessed, so wrap access with try/catch. See:
+                // * https://developers.cloudflare.com/workers/runtime-apis/response/#properties
+                // * https://github.com/cloudflare/miniflare/blob/72f046e/packages/core/src/standards/http.ts#L646
+                let responseType
+                try { responseType = fetchResponse.type } catch {}
+                switch (responseType) {
                     case "error":
                     case "opaque":
                     case "opaqueredirect":


### PR DESCRIPTION
This is #321, but applied to the grpcweb-transport as well.

All tests pass locally.