### PR TITLE
Make repeated field merging consistent

### DIFF
--- a/packages/runtime/src/reflection-merge-partial.ts
+++ b/packages/runtime/src/reflection-merge-partial.ts
@@ -47,12 +47,16 @@ export function reflectionMergePartial<T extends object>(info: MessageInfo, targ
             }
         }
 
+        if (field.repeat)
+            (output[name] as any[]).length = (fieldValue as any[]).length; // resize target array to match source array
+
         // now we just work with `fieldValue` and `output` to merge the value
         switch (field.kind) {
             case "scalar":
             case "enum":
                 if (field.repeat)
-                    output[name] = (fieldValue as any[]).concat(); // elements are not reference types
+                    for (let i = 0; i < (fieldValue as any[]).length; i++)
+                        (output[name] as any[])[i] = (fieldValue as any[])[i]; // not a reference type
                 else
                     output[name] = fieldValue; // not a reference type
                 break;


### PR DESCRIPTION
This addresses https://github.com/timostamm/protobuf-ts/discussions/319

### Setup

```ts
const source = { bars: [1],    foos: [{ foo: 1 }] };
const target = { bars: [2, 3], foos: [{ foo: 2 }, { foo: 3 }] };
reflectionMergePartial(SomeMessageType, target, source);
```

### Before PR

| Repeated Field                                                      | Scalar/Enum        | Message            |
|---------------------------------------------------------------------|--------------------|--------------------|
| result target array is referentially equal to original target array | :x:                | :white_check_mark: |
| result target array is deeply equal to source array                 | :white_check_mark: | :x:                |
| result target array is **NOT** referentially equal to source array  | :white_check_mark: | :white_check_mark: |

### After PR

| Repeated Field                                                      | Scalar/Enum        | Message            |
|---------------------------------------------------------------------|--------------------|--------------------|
| result target array is referentially equal to original target array | :white_check_mark: | :white_check_mark: |
| result target array is deeply equal to source array                 | :white_check_mark: | :white_check_mark: |
| result target array is **NOT** referentially equal to source array  | :white_check_mark: | :white_check_mark: |