### PR TITLE
Adding an option to import well-known types from a provided package.

### DIFF
--- a/packages/plugin-framework/src/typescript-imports.ts
+++ b/packages/plugin-framework/src/typescript-imports.ts
@@ -8,11 +8,9 @@ import {TypescriptFile} from "./typescript-file";
 
 export class TypeScriptImports {
 
-    private readonly symbols: SymbolTable;
-
-
-    constructor(symbols: SymbolTable) {
-        this.symbols = symbols;
+    constructor(
+        private readonly symbols: SymbolTable,
+        private readonly fileToPackageOverloads?: Map<string, string>) {
     }
 
 
@@ -75,10 +73,10 @@ export class TypeScriptImports {
 
         // symbol not in file
         // add an import statement
-        const importPath = createRelativeImportPath(
-            source.getSourceFile().fileName,
-            symbolReg.file.getFilename()
-        );
+        const overloadPackage = this.fileToPackageOverloads?.get(symbolReg.file.getFilename());
+        const importPath = overloadPackage ??
+            createRelativeImportPath(source.getSourceFile().fileName, symbolReg.file.getFilename());
+
         const blackListedNames = this.symbols.list(source).map(e => e.name);
         return ensureNamedImportPresent(
             source.getSourceFile(),

--- a/packages/plugin/src/our-options.ts
+++ b/packages/plugin/src/our-options.ts
@@ -194,6 +194,7 @@ export interface InternalOptions {
     readonly runtimeAngularImportPath: string;
     readonly runtimeRpcImportPath: string;
     readonly runtimeImportPath: string;
+    readonly runtimeWellKnownTypesImportPath: string;
     readonly forceExcludeAllOptions: boolean;
     readonly keepEnumPrefix: boolean;
     readonly useProtoFieldName: boolean;
@@ -260,6 +261,7 @@ export function makeInternalOptions(
             runtimeRpcImportPath: '@protobuf-ts/runtime-rpc',
             angularCoreImportPath: '@angular/core',
             runtimeImportPath: '@protobuf-ts/runtime',
+            runtimeWellKnownTypesImportPath: "",
             forceExcludeAllOptions: false,
             keepEnumPrefix: false,
             useProtoFieldName: false,
@@ -357,6 +359,9 @@ export function makeInternalOptions(
     }
     if (params?.output_legacy_commonjs) {
         o.transpileModule = ts.ModuleKind.CommonJS;
+    }
+    if (process.env.PROTOBUF_TS_RUNTIME_WELL_KNOWN_TYPES_IMPORT_PATH) {
+        o.runtimeWellKnownTypesImportPath = process.env.PROTOBUF_TS_RUNTIME_WELL_KNOWN_TYPES_IMPORT_PATH;
     }
     return o;
 }


### PR DESCRIPTION
The user may want to have well-known types in a separate NPM package:
 - These generated files are always the same and may feel like they are polluting the codebase.
 - For Web, if multiple dependencies of a single project use well-known types, they'll be duplicated in the output Web bundle.

Ideally there would be a single NPM package with well-known types, maintained as a part of protobuf-ts, but this PR is an ok workaround for now.

This option is implemented as an environment variable because the options parser only supports boolean values.