### PR TITLE
Disable an incorrect optimization in int64ToString

### DIFF
--- a/packages/runtime/spec/pb-long.spec.ts
+++ b/packages/runtime/spec/pb-long.spec.ts
@@ -1,4 +1,5 @@
 import {PbLong, PbULong} from "../src";
+import {int64toString} from '../src/goog-varint';
 
 
 describe('PbULong', function () {
@@ -70,6 +71,14 @@ describe('PbULong', function () {
         let ulong = PbULong.from(0);
         expect(ulong.hi).toBe(0);
         expect(ulong.lo).toBe(0);
+    });
+
+    it('int64toString should serialize the same was as BigInt.toString()', function () {
+        let ulong = PbULong.from(1661324400000);
+        expect(ulong.hi).toBe(386);
+        expect(ulong.lo).toBe(-827943552);
+        expect(ulong.toString()).toBe('1661324400000')
+        expect(int64toString(ulong.lo, ulong.hi)).toBe('1661324400000')
     });
 
 });
@@ -302,4 +311,3 @@ describe('testing native bigint', function () {
     });
 
 });
-

--- a/packages/runtime/src/goog-varint.ts
+++ b/packages/runtime/src/goog-varint.ts
@@ -175,12 +175,6 @@ export function int64fromString(dec: string): [boolean, number, number] {
  * Copyright 2008 Google Inc.
  */
 export function int64toString(bitsLow: number, bitsHigh: number): string {
-    // Skip the expensive conversion if the number is small enough to use the
-    // built-in conversions.
-    if (bitsHigh <= 0x1FFFFF) {
-        return '' + (TWO_PWR_32_DBL * bitsHigh + bitsLow);
-    }
-
     // What this code is doing is essentially converting the input number from
     // base-2 to base-1e7, which allows us to represent the 64-bit range with
     // only 3 (very large) digits. Those digits are then trivial to convert to


### PR DESCRIPTION
We've run into a bug where a timestamp seems to be experiencing some bit-flipping

I added a test case here that demonstrates the problem. If BigInt is not available (which is the case when running in react-native), the test will fail, printing out: `      - Expected '1657029432704' to be '1661324400000'.`

A colleague printed out the bits for a different timestamp that shows where the flipping is happening:
![image](https://user-images.githubusercontent.com/126578/186282645-db0e9d66-067b-4b3b-a684-a6af41d03c66.png)

I don't fully understand the int64toString function, so I chose to just disable the optimization, which does fix this problem. I saw it was copied from an experimental directory of the google protobuf implementation, so I'm guessing they just didn't fully test and verify this yet, so disabling the optimization was probably the better short term play?