### PR TITLE
Alternative fix for int64toString

### DIFF
--- a/packages/runtime/spec/pb-long.spec.ts
+++ b/packages/runtime/spec/pb-long.spec.ts
@@ -1,4 +1,5 @@
 import {PbLong, PbULong} from "../src";
+import {int64toString} from "../src/goog-varint";
 
 
 describe('PbULong', function () {
@@ -72,6 +73,13 @@ describe('PbULong', function () {
         expect(ulong.lo).toBe(0);
     });
 
+    it('int64toString should serialize the same was as BigInt.toString()', function () {
+        let ulong = PbULong.from(1661324400000);
+        expect(ulong.hi).toBe(386);
+        expect(ulong.lo).toBe(-827943552);
+        expect(ulong.toString()).toBe('1661324400000')
+        expect(int64toString(ulong.lo, ulong.hi)).toBe('1661324400000')
+    });
 });
 
 

--- a/packages/runtime/src/goog-varint.ts
+++ b/packages/runtime/src/goog-varint.ts
@@ -178,7 +178,7 @@ export function int64toString(bitsLow: number, bitsHigh: number): string {
     // Skip the expensive conversion if the number is small enough to use the
     // built-in conversions.
     if (bitsHigh <= 0x1FFFFF) {
-        return '' + (TWO_PWR_32_DBL * bitsHigh + bitsLow);
+        return '' + (TWO_PWR_32_DBL * bitsHigh + (bitsLow >>> 0));
     }
 
     // What this code is doing is essentially converting the input number from


### PR DESCRIPTION
# Summary

Borrowed from https://github.com/protocolbuffers/protobuf/pull/8170, this PR is an alternative approach for https://github.com/timostamm/protobuf-ts/pull/366. (I'm the colleague.) 

The error in this optimization is that it incorrectly assumes that `bitsLow` is never negative, but that can occur when the highest bit is set due to 2s complement representation.

# Test Plan

```
$ make
...
@protobuf-ts/runtime: 'test-node' ...
@protobuf-ts/runtime: Jasmine started
@protobuf-ts/runtime: Executed 622 of 622 specs SUCCESS in 0.45 sec.
```