### PR TITLE
Run `buf mod update`

### DIFF
--- a/packages/example-buf/proto/buf.lock
+++ b/packages/example-buf/proto/buf.lock
@@ -4,7 +4,4 @@ deps:
   - remote: buf.build
     owner: googleapis
     repository: googleapis
-    branch: main
-    commit: e16155da3b4a49e48bd18cdcb029004d
-    digest: b1--CthFBW4QSXRq35NiPd7Uu9WN2xWeV9_GVRe5mbTVuI=
-    create_time: 2021-09-30T15:08:49.529359Z
+    commit: 62f35d8aed1149c291d606d958a7ce32


### PR DESCRIPTION
Just a quick drive-by `buf mod update` - we [made some changes](https://docs.buf.build/faq#googleapis-failure) to our hosted googleapis/googleapis module; this should fix any issues you might see!
