### PR TITLE
Add global type registry

### DIFF
--- a/packages/plugin/src/code-gen/message-type-generator.ts
+++ b/packages/plugin/src/code-gen/message-type-generator.ts
@@ -83,6 +83,7 @@ export class MessageTypeGenerator extends GeneratorBase {
             MyMessage = this.imports.type(source, descriptor),
             Message$Type = ts.createIdentifier(this.imports.type(source, descriptor) + '$Type'),
             MessageType = ts.createIdentifier(this.imports.name(source, "MessageType", this.options.runtimeImportPath)),
+            RegisterTypeFunc = ts.createIdentifier(this.imports.name(source, "registerType", this.options.runtimeImportPath)),
             interpreterType = this.interpreter.getMessageType(descriptor),
             classDecMembers: ts.ClassElement[] = [],
             classDecSuperArgs: ts.Expression[] = [ // arguments to the MessageType CTOR
@@ -146,9 +147,14 @@ export class MessageTypeGenerator extends GeneratorBase {
         );
 
 
+        // registerType("messageId");
+        const registerType = ts.createCall(RegisterTypeFunc, undefined, [ts.createIdentifier(MyMessage)]);
+
+
         // add to our file
         source.addStatement(classDec);
         source.addStatement(exportConst);
+        source.addStatement(registerType);
 
 
         // add comments

--- a/packages/plugin/src/code-gen/message-type-generator.ts
+++ b/packages/plugin/src/code-gen/message-type-generator.ts
@@ -148,7 +148,9 @@ export class MessageTypeGenerator extends GeneratorBase {
 
 
         // registerType("messageId");
-        const registerType = ts.createCall(RegisterTypeFunc, undefined, [ts.createIdentifier(MyMessage)]);
+        const registerType = ts.createExpressionStatement(
+            ts.createCall(RegisterTypeFunc, undefined, [ts.createIdentifier(MyMessage)])
+        );
 
 
         // add to our file

--- a/packages/runtime/spec/json-format-contract.spec.ts
+++ b/packages/runtime/spec/json-format-contract.spec.ts
@@ -18,6 +18,7 @@ describe('jsonWriteOptions()', () => {
             enumAsInteger: true,
             useProtoFieldName: false,
             prettySpaces: 0,
+            typeRegistry: [],
         });
         expect(jsonWriteOptions({
             useProtoFieldName: true,
@@ -27,6 +28,7 @@ describe('jsonWriteOptions()', () => {
             enumAsInteger: false,
             useProtoFieldName: true,
             prettySpaces: 99,
+            typeRegistry: [],
         });
         expect(jsonWriteOptions({
             emitDefaultValues: true,
@@ -38,6 +40,7 @@ describe('jsonWriteOptions()', () => {
             enumAsInteger: true,
             useProtoFieldName: true,
             prettySpaces: 99,
+            typeRegistry: [],
         });
         expect(jsonWriteOptions({
             typeRegistry: [],

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -33,7 +33,13 @@ export {PbLong, PbULong} from './pb-long';
 
 // JSON format contracts, options for reading and writing, for example
 export {
-    JsonReadOptions, JsonWriteOptions, JsonWriteStringOptions, jsonReadOptions, jsonWriteOptions, mergeJsonOptions
+    JsonReadOptions,
+    JsonWriteOptions,
+    JsonWriteStringOptions,
+    jsonReadOptions,
+    jsonWriteOptions,
+    mergeJsonOptions,
+    registerType,
 } from './json-format-contract';
 
 // Message type contract

--- a/packages/runtime/src/json-format-contract.ts
+++ b/packages/runtime/src/json-format-contract.ts
@@ -66,6 +66,20 @@ export interface JsonWriteStringOptions extends JsonWriteOptions {
     prettySpaces: number;
 }
 
+/**
+ * Globally stores message types to read and write `google.protobuf.Any` from
+ * and to JSON format.
+ */
+const typeRegistry: IMessageType<any>[] = [];
+
+/**
+ * Registers a message type to the global type registry. Registered types are
+ * used reading and writing `google.protobuf.Any` from and to JSON format.
+ */
+export function registerType(t: IMessageType<any>) {
+  typeRegistry.push(t)
+}
+
 const defaultsWrite: Readonly<JsonWriteStringOptions> = {
         emitDefaultValues: false,
         enumAsInteger: false,
@@ -80,14 +94,16 @@ const defaultsWrite: Readonly<JsonWriteStringOptions> = {
  * Make options for reading JSON data from partial options.
  */
 export function jsonReadOptions(options?: Partial<JsonReadOptions>): Readonly<JsonReadOptions> {
-    return options ? {...defaultsRead, ...options} : defaultsRead;
+    const opts = options ? {...defaultsRead, ...options} : defaultsRead;
+    return mergeJsonOptions({typeRegistry}, opts) as Readonly<JsonReadOptions>;
 }
 
 /**
  * Make options for writing JSON data from partial options.
  */
 export function jsonWriteOptions(options?: Partial<JsonWriteStringOptions>): JsonWriteStringOptions {
-    return options ? {...defaultsWrite, ...options} : defaultsWrite;
+    const opts = options ? {...defaultsWrite, ...options} : defaultsWrite;
+    return mergeJsonOptions({typeRegistry}, opts) as JsonWriteStringOptions;
 }
 
 

--- a/packages/test-generated/spec/google.protobuf.any.spec.ts
+++ b/packages/test-generated/spec/google.protobuf.any.spec.ts
@@ -90,7 +90,7 @@ describe('google.protobuf.Any', function () {
             });
         });
 
-        it('creates expected JSON from global type registry', function () {
+        it('creates expected JSON with global type registry', function () {
             let json = Any.toJson(scalarMsgAny);
             expect(json).toEqual({
                 "@type": "type.googleapis.com/spec.ScalarValuesMessage",
@@ -128,19 +128,14 @@ describe('google.protobuf.Any', function () {
             boolField: true,
         };
 
-        it('throws without type registry', function () {
-            expect(() => Any.fromJson(scalarMsgAnyJson)).toThrow();
-        });
-
-        it('throws when type not in registry', function () {
-            expect(
-                () => Any.fromJson(scalarMsgAnyJson, {typeRegistry: [StructMessage]})
-            ).toThrow();
-        });
-
         it('can read JSON', function () {
             let registry = [StructMessage, ScalarValuesMessage];
             let scalarMsgAny = Any.fromJson(scalarMsgAnyJson, {typeRegistry: registry});
+            expect(scalarMsgAny).toEqual(Any.pack(scalarMsg, ScalarValuesMessage));
+        });
+
+        it('can read JSON with global type registry', function () {
+            let scalarMsgAny = Any.fromJson(scalarMsgAnyJson);
             expect(scalarMsgAny).toEqual(Any.pack(scalarMsg, ScalarValuesMessage));
         });
 

--- a/packages/test-generated/spec/google.protobuf.any.spec.ts
+++ b/packages/test-generated/spec/google.protobuf.any.spec.ts
@@ -79,19 +79,19 @@ describe('google.protobuf.Any', function () {
 
         let scalarMsgAny = Any.pack(scalarMsg, ScalarValuesMessage);
 
-        it('throws without type registry', function () {
-            expect(() => Any.toJson(scalarMsgAny)).toThrow();
-        });
-
-        it('throws when type not in registry', function () {
-            expect(
-                () => Any.toJson(scalarMsgAny, {typeRegistry: [StructMessage]})
-            ).toThrow();
-        });
-
         it('creates expected JSON', function () {
             let registry = [StructMessage, ScalarValuesMessage];
             let json = Any.toJson(scalarMsgAny, {typeRegistry: registry});
+            expect(json).toEqual({
+                "@type": "type.googleapis.com/spec.ScalarValuesMessage",
+                doubleField: 0.5,
+                stringField: "hello",
+                boolField: true,
+            });
+        });
+
+        it('creates expected JSON from global type registry', function () {
+            let json = Any.toJson(scalarMsgAny);
             expect(json).toEqual({
                 "@type": "type.googleapis.com/spec.ScalarValuesMessage",
                 doubleField: 0.5,


### PR DESCRIPTION
When messages are imported, add them to a global type registry as a side-effect. That allows users to omit `typeRegistry` when interacting with `Any`.

I'm adding this a draft right now, because this definitely requires changes to the docs, and probably another test case. I'm also not sure about the typecast I'm using in `jsonReadOptions` and `jsonWriteOptions`. I originally did this implementation as a patch to the compiled package, so there were no types.

Closes #131