### PR TITLE
Use details from service error as RpcError message

### DIFF
--- a/packages/grpc-transport/src/grpc-transport.ts
+++ b/packages/grpc-transport/src/grpc-transport.ts
@@ -78,7 +78,7 @@ export class GrpcTransport implements RpcTransport {
                     defMessage.resolve(value);
                 }
                 if (err) {
-                    const e = new RpcError(err.message, GrpcStatus[err.code], metadataFromGrpc(err.metadata));
+                    const e = new RpcError(err.details, GrpcStatus[err.code], metadataFromGrpc(err.metadata));
                     e.methodName = method.name;
                     e.serviceName  = method.service.typeName;
                     defHeader.rejectPending(e);
@@ -151,7 +151,7 @@ export class GrpcTransport implements RpcTransport {
         }
 
         gCall.addListener('error', err => {
-            const e = isServiceError(err) ? new RpcError(err.message, GrpcStatus[err.code], metadataFromGrpc(err.metadata)) : new RpcError(err.message);
+            const e = isServiceError(err) ? new RpcError(err.details, GrpcStatus[err.code], metadataFromGrpc(err.metadata)) : new RpcError(err.message);
             e.methodName = method.name;
             e.serviceName  = method.service.typeName;
             defHeader.rejectPending(e);
@@ -209,7 +209,7 @@ export class GrpcTransport implements RpcTransport {
                         defMessage.resolve(value);
                     }
                     if (err) {
-                        const e = new RpcError(err.message, GrpcStatus[err.code], metadataFromGrpc(err.metadata));
+                        const e = new RpcError(err.details, GrpcStatus[err.code], metadataFromGrpc(err.metadata));
                         e.methodName = method.name;
                         e.serviceName  = method.service.typeName;
                         defHeader.rejectPending(e);
@@ -272,7 +272,7 @@ export class GrpcTransport implements RpcTransport {
         }
 
         gCall.addListener('error', err => {
-            const e = isServiceError(err) ? new RpcError(err.message, GrpcStatus[err.code], metadataFromGrpc(err.metadata)) : new RpcError(err.message);
+            const e = isServiceError(err) ? new RpcError(err.details, GrpcStatus[err.code], metadataFromGrpc(err.metadata)) : new RpcError(err.message);
             e.methodName = method.name;
             e.serviceName  = method.service.typeName;
             defHeader.rejectPending(e);


### PR DESCRIPTION
It seems that the `message` field of grpc-js errors contains the status code concatenated with the message. An error with invalid argument for example contains the following in `message`: `3 INVALID_ARGUMENT: something`.

It seems that the `details` field in the service error does not include that prefix, so I think that field should be used when constructing the RpcError.