### PR TITLE
Enable working on docker running on M1

### DIFF
--- a/packages/protoc/protoc.js
+++ b/packages/protoc/protoc.js
@@ -92,7 +92,7 @@ async function ensureInstalled(version) {
     // make the release name for the current platform and the requested version number
     let releaseName = makeReleaseName({
         platform: os.platform(),
-        arch: os.arch(),
+        arch: os.arch().replace('arm64', 'aarch_64'),
         version: version
     });
 


### PR DESCRIPTION
Protobuf does not create releases under arm64 architecture, instead aarch_64 postfix is used