### PR TITLE
CI update follow-ups

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,8 @@
 name: ci
 on:
+  push:
+    branches: [main]
+    tags: ['v*']
   pull_request:
     branches: [main]
   workflow_dispatch:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-protobuf-ts [![<timostamm>](https://circleci.com/gh/timostamm/protobuf-ts.svg?style=svg)](https://app.circleci.com/pipelines/github/timostamm/protobuf-ts) [![npm](https://img.shields.io/npm/v/@protobuf-ts/plugin?x)](https://www.npmjs.com/package/@protobuf-ts/plugin)
+protobuf-ts [![npm](https://img.shields.io/npm/v/@protobuf-ts/plugin?x)](https://www.npmjs.com/package/@protobuf-ts/plugin)
 ===========
 
 


### PR DESCRIPTION
- Enable CI on push to main and on tag.
- Remove CircleCI badge.
