### PR TITLE
Make protobuf-ts as conformant as protobuf-es

### DIFF
--- a/packages/runtime/src/reflection-json-reader.ts
+++ b/packages/runtime/src/reflection-json-reader.ts
@@ -78,6 +78,9 @@ export class ReflectionJsonReader {
             // handle oneof ADT
             let target: UnknownMessage | UnknownOneofGroup; // this will be the target for the field value, whether it is member of a oneof or not
             if (field.oneof) {
+                if (jsonValue === null && (field.kind !== 'enum' || field.T()[0] !== 'google.protobuf.NullValue')) {
+                    continue;
+                }
                 // since json objects are unordered by specification, it is not possible to take the last of multiple oneofs
                 if (oneofsHandled.includes(field.oneof)) throw new Error(`Multiple members of the oneof group "${field.oneof}" of ${this.info.typeName} are present in JSON.`);
                 oneofsHandled.push(field.oneof);
@@ -202,11 +205,11 @@ export class ReflectionJsonReader {
     /**
      * Returns `false` for unrecognized string representations.
      *
-     * google.protobuf.NullValue accepts only JSON `null`.
+     * google.protobuf.NullValue accepts only JSON `null` (or the old `"NULL_VALUE"`).
      */
     enum(type: EnumInfo, json: unknown, fieldName: string, ignoreUnknownFields: boolean): UnknownEnum | false {
         if (type[0] == 'google.protobuf.NullValue')
-            assert(json === null, `Unable to parse field ${this.info.typeName}#${fieldName}, enum ${type[0]} only accepts null.`);
+            assert(json === null || json === "NULL_VALUE", `Unable to parse field ${this.info.typeName}#${fieldName}, enum ${type[0]} only accepts null.`);
         if (json === null)
             // we require 0 to be default value for all enums
             return 0;

--- a/packages/runtime/src/reflection-json-writer.ts
+++ b/packages/runtime/src/reflection-json-writer.ts
@@ -169,11 +169,11 @@ export class ReflectionJsonWriter {
     }
 
     /**
-     * Returns `null` for google.protobuf.NullValue.
+     * Returns `null` as the default for google.protobuf.NullValue.
      */
     enum(type: EnumInfo, value: unknown, fieldName: string, optional: boolean, emitDefaultValues: boolean, enumAsInteger: boolean): JsonValue | undefined {
         if (type[0] == 'google.protobuf.NullValue')
-            return null;
+            return !emitDefaultValues && !optional ? undefined : null;
         if (value === undefined) {
             assert(optional);
             return undefined;

--- a/packages/test-conformance/failing_tests_optimize_code_size-long_type_bigint.txt
+++ b/packages/test-conformance/failing_tests_optimize_code_size-long_type_bigint.txt
@@ -1,16 +1,1 @@
 Recommended.Proto2.JsonInput.FieldNameExtension.Validator
-Recommended.Proto3.JsonInput.NullValueInNormalMessage.Validator
-Recommended.Proto3.JsonInput.NullValueInOtherOneofNewFormat.Validator
-Recommended.Proto3.JsonInput.NullValueInOtherOneofOldFormat.Validator
-Recommended.ValueRejectInfNumberValue.JsonOutput
-Recommended.ValueRejectNanNumberValue.JsonOutput
-Required.Proto3.JsonInput.DurationNegativeNanos.JsonOutput
-Required.Proto3.JsonInput.DurationNegativeNanos.ProtobufOutput
-Required.Proto3.JsonInput.EnumFieldWithAliasLowerCase.JsonOutput
-Required.Proto3.JsonInput.EnumFieldWithAliasLowerCase.ProtobufOutput
-Required.Proto3.JsonInput.EnumFieldWithAliasUseAlias.JsonOutput
-Required.Proto3.JsonInput.EnumFieldWithAliasUseAlias.ProtobufOutput
-Required.Proto3.JsonInput.OneofFieldNullFirst.JsonOutput
-Required.Proto3.JsonInput.OneofFieldNullFirst.ProtobufOutput
-Required.Proto3.JsonInput.OneofFieldNullSecond.JsonOutput
-Required.Proto3.JsonInput.OneofFieldNullSecond.ProtobufOutput

--- a/packages/test-conformance/failing_tests_optimize_code_size-long_type_string.txt
+++ b/packages/test-conformance/failing_tests_optimize_code_size-long_type_string.txt
@@ -1,16 +1,1 @@
 Recommended.Proto2.JsonInput.FieldNameExtension.Validator
-Recommended.Proto3.JsonInput.NullValueInNormalMessage.Validator
-Recommended.Proto3.JsonInput.NullValueInOtherOneofNewFormat.Validator
-Recommended.Proto3.JsonInput.NullValueInOtherOneofOldFormat.Validator
-Recommended.ValueRejectInfNumberValue.JsonOutput
-Recommended.ValueRejectNanNumberValue.JsonOutput
-Required.Proto3.JsonInput.DurationNegativeNanos.JsonOutput
-Required.Proto3.JsonInput.DurationNegativeNanos.ProtobufOutput
-Required.Proto3.JsonInput.EnumFieldWithAliasLowerCase.JsonOutput
-Required.Proto3.JsonInput.EnumFieldWithAliasLowerCase.ProtobufOutput
-Required.Proto3.JsonInput.EnumFieldWithAliasUseAlias.JsonOutput
-Required.Proto3.JsonInput.EnumFieldWithAliasUseAlias.ProtobufOutput
-Required.Proto3.JsonInput.OneofFieldNullFirst.JsonOutput
-Required.Proto3.JsonInput.OneofFieldNullFirst.ProtobufOutput
-Required.Proto3.JsonInput.OneofFieldNullSecond.JsonOutput
-Required.Proto3.JsonInput.OneofFieldNullSecond.ProtobufOutput

--- a/packages/test-conformance/failing_tests_optimize_speed-long_type_bigint.txt
+++ b/packages/test-conformance/failing_tests_optimize_speed-long_type_bigint.txt
@@ -1,16 +1,1 @@
 Recommended.Proto2.JsonInput.FieldNameExtension.Validator
-Recommended.Proto3.JsonInput.NullValueInNormalMessage.Validator
-Recommended.Proto3.JsonInput.NullValueInOtherOneofNewFormat.Validator
-Recommended.Proto3.JsonInput.NullValueInOtherOneofOldFormat.Validator
-Recommended.ValueRejectInfNumberValue.JsonOutput
-Recommended.ValueRejectNanNumberValue.JsonOutput
-Required.Proto3.JsonInput.DurationNegativeNanos.JsonOutput
-Required.Proto3.JsonInput.DurationNegativeNanos.ProtobufOutput
-Required.Proto3.JsonInput.EnumFieldWithAliasLowerCase.JsonOutput
-Required.Proto3.JsonInput.EnumFieldWithAliasLowerCase.ProtobufOutput
-Required.Proto3.JsonInput.EnumFieldWithAliasUseAlias.JsonOutput
-Required.Proto3.JsonInput.EnumFieldWithAliasUseAlias.ProtobufOutput
-Required.Proto3.JsonInput.OneofFieldNullFirst.JsonOutput
-Required.Proto3.JsonInput.OneofFieldNullFirst.ProtobufOutput
-Required.Proto3.JsonInput.OneofFieldNullSecond.JsonOutput
-Required.Proto3.JsonInput.OneofFieldNullSecond.ProtobufOutput

--- a/packages/test-conformance/failing_tests_optimize_speed-long_type_string.txt
+++ b/packages/test-conformance/failing_tests_optimize_speed-long_type_string.txt
@@ -1,16 +1,1 @@
 Recommended.Proto2.JsonInput.FieldNameExtension.Validator
-Recommended.Proto3.JsonInput.NullValueInNormalMessage.Validator
-Recommended.Proto3.JsonInput.NullValueInOtherOneofNewFormat.Validator
-Recommended.Proto3.JsonInput.NullValueInOtherOneofOldFormat.Validator
-Recommended.ValueRejectInfNumberValue.JsonOutput
-Recommended.ValueRejectNanNumberValue.JsonOutput
-Required.Proto3.JsonInput.DurationNegativeNanos.JsonOutput
-Required.Proto3.JsonInput.DurationNegativeNanos.ProtobufOutput
-Required.Proto3.JsonInput.EnumFieldWithAliasLowerCase.JsonOutput
-Required.Proto3.JsonInput.EnumFieldWithAliasLowerCase.ProtobufOutput
-Required.Proto3.JsonInput.EnumFieldWithAliasUseAlias.JsonOutput
-Required.Proto3.JsonInput.EnumFieldWithAliasUseAlias.ProtobufOutput
-Required.Proto3.JsonInput.OneofFieldNullFirst.JsonOutput
-Required.Proto3.JsonInput.OneofFieldNullFirst.ProtobufOutput
-Required.Proto3.JsonInput.OneofFieldNullSecond.JsonOutput
-Required.Proto3.JsonInput.OneofFieldNullSecond.ProtobufOutput

--- a/packages/test-conformance/proto/conformance/conformance.proto
+++ b/packages/test-conformance/proto/conformance/conformance.proto
@@ -29,8 +29,11 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 syntax = "proto3";
+
 package conformance;
+
 option java_package = "com.google.protobuf.conformance";
+option objc_class_prefix = "Conformance";
 
 // This defines the conformance testing protocol.  This protocol exists between
 // the conformance test suite itself and the code being tested.  For each test,
@@ -55,7 +58,7 @@ enum WireFormat {
   UNSPECIFIED = 0;
   PROTOBUF = 1;
   JSON = 2;
-  JSPB = 3;  // Google internal only. Opensource testees just skip it.
+  JSPB = 3;  // Only used inside Google. Opensource testees just skip it.
   TEXT_FORMAT = 4;
 }
 
@@ -69,7 +72,8 @@ enum TestCategory {
   // https://developers.google.com/protocol-buffers/docs/proto3#json_options
   // for more detail.
   JSON_IGNORE_UNKNOWN_PARSING_TEST = 3;
-  // Test jspb wire format. Google internal only. Opensource testees just skip it.
+  // Test jspb wire format. Only used inside Google. Opensource testees just
+  // skip it.
   JSPB_TEST = 4;
   // Test text format. For cpp, java and python, testees can already deal with
   // this type. Testees of other languages can simply skip it.
@@ -92,14 +96,10 @@ message ConformanceRequest {
   // The payload (whether protobuf of JSON) is always for a
   // protobuf_test_messages.proto3.TestAllTypes proto (as defined in
   // src/google/protobuf/proto3_test_messages.proto).
-  //
-  // TODO(haberman): if/when we expand the conformance tests to support proto2,
-  // we will want to include a field that lets the payload/response be a
-  // protobuf_test_messages.proto2.TestAllTypes message instead.
   oneof payload {
     bytes protobuf_payload = 1;
     string json_payload = 2;
-    // Google internal only.  Opensource testees just skip it.
+    // Only used inside Google.  Opensource testees just skip it.
     string jspb_payload = 7;
     string text_payload = 8;
   }
@@ -109,12 +109,12 @@ message ConformanceRequest {
 
   // The full name for the test message to use; for the moment, either:
   // protobuf_test_messages.proto3.TestAllTypesProto3 or
-  // protobuf_test_messages.proto2.TestAllTypesProto2.
+  // protobuf_test_messages.google.protobuf.TestAllTypesProto2.
   string message_type = 4;
 
   // Each test is given a specific test category. Some category may need
-  // specific support in testee programs. Refer to the definition of TestCategory
-  // for more information.
+  // specific support in testee programs. Refer to the definition of
+  // TestCategory for more information.
   TestCategory test_category = 5;
 
   // Specify details for how to encode jspb.
@@ -140,6 +140,11 @@ message ConformanceResponse {
     // this field.
     string serialize_error = 6;
 
+    // This should be set if the test program timed out.  The string should
+    // provide more information about what the child process was doing when it
+    // was killed.
+    string timeout_error = 9;
+
     // This should be set if some other error occurred.  This will always
     // indicate that the test failed.  The string can provide more information
     // about the failure.
@@ -158,8 +163,8 @@ message ConformanceResponse {
     string skipped = 5;
 
     // If the input was successfully parsed and the requested output was JSPB,
-    // serialize to JSPB and set it in this field. JSPB is google internal only
-    // format. Opensource testees can just skip it.
+    // serialize to JSPB and set it in this field. JSPB is only used inside
+    // Google. Opensource testees can just skip it.
     string jspb_payload = 7;
 
     // If the input was successfully parsed and the requested output was
@@ -173,4 +178,3 @@ message JspbEncodingConfig {
   // Encode the value field of Any as jspb array if true, otherwise binary.
   bool use_jspb_array_any_format = 1;
 }
-

--- a/packages/test-conformance/proto/google/protobuf/test_messages_proto2.proto
+++ b/packages/test-conformance/proto/google/protobuf/test_messages_proto2.proto
@@ -40,6 +40,7 @@ syntax = "proto2";
 package protobuf_test_messages.proto2;
 
 option java_package = "com.google.protobuf_test_messages.proto2";
+option objc_class_prefix = "Proto2";
 
 // This is the default, but we specify it here explicitly.
 option optimize_for = SPEED;
@@ -194,6 +195,23 @@ message TestAllTypesProto2 {
     optional uint32 group_uint32 = 203;
   }
 
+  // default values
+  optional int32 default_int32 = 241 [default = -123456789];
+  optional int64 default_int64 = 242 [default = -9123456789123456789];
+  optional uint32 default_uint32 = 243 [default = 2123456789];
+  optional uint64 default_uint64 = 244 [default = 10123456789123456789];
+  optional sint32 default_sint32 = 245 [default = -123456789];
+  optional sint64 default_sint64 = 246 [default = -9123456789123456789];
+  optional fixed32 default_fixed32 = 247 [default = 2123456789];
+  optional fixed64 default_fixed64 = 248 [default = 10123456789123456789];
+  optional sfixed32 default_sfixed32 = 249 [default = -123456789];
+  optional sfixed64 default_sfixed64 = 250 [default = -9123456789123456789];
+  optional float default_float = 251 [default = 9e9];
+  optional double default_double = 252 [default = 7e22];
+  optional bool default_bool = 253 [default = true];
+  optional string default_string = 254 [default = "Rosebud"];
+  optional bytes default_bytes = 255 [default = "joshua"];
+
   // Test field-name-to-JSON-name convention.
   // (protobuf says names can be any valid C/C++ identifier.)
   optional int32 fieldname1 = 401;
@@ -263,4 +281,23 @@ message UnknownToTestAllTypes {
   }
   optional bool optional_bool = 1006;
   repeated int32 repeated_int32 = 1011;
+}
+
+message NullHypothesisProto2 {}
+
+message EnumOnlyProto2 {
+  enum Bool {
+    kFalse = 0;
+    kTrue = 1;
+  }
+}
+
+message OneStringProto2 {
+  optional string data = 1;
+}
+
+message ProtoWithKeywords {
+  optional int32 inline = 1;
+  optional string concept = 2;
+  repeated string requires = 3;
 }

--- a/packages/test-conformance/proto/google/protobuf/test_messages_proto3.proto
+++ b/packages/test-conformance/proto/google/protobuf/test_messages_proto3.proto
@@ -80,8 +80,8 @@ message TestAllTypesProto3 {
     ALIAS_FOO = 0;
     ALIAS_BAR = 1;
     ALIAS_BAZ = 2;
-    QUX = 2;
-    qux = 2;
+    MOO = 2;
+    moo = 2;
     bAz = 2;
   }
 
@@ -203,6 +203,7 @@ message TestAllTypesProto3 {
     float oneof_float = 117;
     double oneof_double = 118;
     NestedEnum oneof_enum = 119;
+    google.protobuf.NullValue oneof_null_value = 120;
   }
 
   // Well-known types
@@ -232,6 +233,7 @@ message TestAllTypesProto3 {
   google.protobuf.Struct optional_struct = 304;
   google.protobuf.Any optional_any = 305;
   google.protobuf.Value optional_value = 306;
+  google.protobuf.NullValue optional_null_value = 307;
 
   repeated google.protobuf.Duration repeated_duration = 311;
   repeated google.protobuf.Timestamp repeated_timestamp = 312;
@@ -274,4 +276,13 @@ enum ForeignEnum {
   FOREIGN_FOO = 0;
   FOREIGN_BAR = 1;
   FOREIGN_BAZ = 2;
+}
+
+message NullHypothesisProto3 {}
+
+message EnumOnlyProto3 {
+  enum Bool {
+    kFalse = 0;
+    kTrue = 1;
+  }
 }

--- a/packages/test-conformance/src/gen/optimize_code_size-long_type_bigint/conformance/conformance.ts
+++ b/packages/test-conformance/src/gen/optimize_code_size-long_type_bigint/conformance/conformance.ts
@@ -74,7 +74,7 @@ export interface ConformanceRequest {
     } | {
         oneofKind: "jspbPayload";
         /**
-         * Google internal only.  Opensource testees just skip it.
+         * Only used inside Google.  Opensource testees just skip it.
          *
          * @generated from protobuf field: string jspb_payload = 7;
          */
@@ -97,15 +97,15 @@ export interface ConformanceRequest {
     /**
      * The full name for the test message to use; for the moment, either:
      * protobuf_test_messages.proto3.TestAllTypesProto3 or
-     * protobuf_test_messages.proto2.TestAllTypesProto2.
+     * protobuf_test_messages.google.protobuf.TestAllTypesProto2.
      *
      * @generated from protobuf field: string message_type = 4;
      */
     messageType: string;
     /**
      * Each test is given a specific test category. Some category may need
-     * specific support in testee programs. Refer to the definition of TestCategory
-     * for more information.
+     * specific support in testee programs. Refer to the definition of
+     * TestCategory for more information.
      *
      * @generated from protobuf field: conformance.TestCategory test_category = 5;
      */
@@ -156,6 +156,16 @@ export interface ConformanceResponse {
          */
         serializeError: string;
     } | {
+        oneofKind: "timeoutError";
+        /**
+         * This should be set if the test program timed out.  The string should
+         * provide more information about what the child process was doing when it
+         * was killed.
+         *
+         * @generated from protobuf field: string timeout_error = 9;
+         */
+        timeoutError: string;
+    } | {
         oneofKind: "runtimeError";
         /**
          * This should be set if some other error occurred.  This will always
@@ -196,8 +206,8 @@ export interface ConformanceResponse {
         oneofKind: "jspbPayload";
         /**
          * If the input was successfully parsed and the requested output was JSPB,
-         * serialize to JSPB and set it in this field. JSPB is google internal only
-         * format. Opensource testees can just skip it.
+         * serialize to JSPB and set it in this field. JSPB is only used inside
+         * Google. Opensource testees can just skip it.
          *
          * @generated from protobuf field: string jspb_payload = 7;
          */
@@ -264,7 +274,7 @@ export enum WireFormat {
      */
     JSON = 2,
     /**
-     * Google internal only. Opensource testees just skip it.
+     * Only used inside Google. Opensource testees just skip it.
      *
      * @generated from protobuf enum value: JSPB = 3;
      */
@@ -305,7 +315,8 @@ export enum TestCategory {
      */
     JSON_IGNORE_UNKNOWN_PARSING_TEST = 3,
     /**
-     * Test jspb wire format. Google internal only. Opensource testees just skip it.
+     * Test jspb wire format. Only used inside Google. Opensource testees just
+     * skip it.
      *
      * @generated from protobuf enum value: JSPB_TEST = 4;
      */
@@ -356,6 +367,7 @@ class ConformanceResponse$Type extends MessageType<ConformanceResponse> {
         super("conformance.ConformanceResponse", [
             { no: 1, name: "parse_error", kind: "scalar", oneof: "result", T: 9 /*ScalarType.STRING*/ },
             { no: 6, name: "serialize_error", kind: "scalar", oneof: "result", T: 9 /*ScalarType.STRING*/ },
+            { no: 9, name: "timeout_error", kind: "scalar", oneof: "result", T: 9 /*ScalarType.STRING*/ },
             { no: 2, name: "runtime_error", kind: "scalar", oneof: "result", T: 9 /*ScalarType.STRING*/ },
             { no: 3, name: "protobuf_payload", kind: "scalar", oneof: "result", T: 12 /*ScalarType.BYTES*/ },
             { no: 4, name: "json_payload", kind: "scalar", oneof: "result", T: 9 /*ScalarType.STRING*/ },

--- a/packages/test-conformance/src/gen/optimize_code_size-long_type_bigint/google/protobuf/duration.ts
+++ b/packages/test-conformance/src/gen/optimize_code_size-long_type_bigint/google/protobuf/duration.ts
@@ -138,6 +138,8 @@ class Duration$Type extends MessageType<Duration> {
         if (s > 315576000000 || s < -315576000000)
             throw new Error("Duration value out of range.");
         let text = message.seconds.toString();
+        if (s === 0 && message.nanos < 0)
+            text = "-" + text;
         if (message.nanos !== 0) {
             let nanosStr = Math.abs(message.nanos).toString();
             nanosStr = "0".repeat(9 - nanosStr.length) + nanosStr;
@@ -155,21 +157,19 @@ class Duration$Type extends MessageType<Duration> {
     internalJsonRead(json: JsonValue, options: JsonReadOptions, target?: Duration): Duration {
         if (typeof json !== "string")
             throw new Error("Unable to parse Duration from JSON " + typeofJsonValue(json) + ". Expected string.");
-        let match = json.match(/^(-?[0-9]+)(?:\.([0-9]+))?s/);
+        let match = json.match(/^(-?)([0-9]+)(?:\.([0-9]+))?s/);
         if (match === null)
             throw new Error("Unable to parse Duration from JSON string. Invalid format.");
         if (!target)
             target = this.create();
-        let longSeconds = PbLong.from(match[1]);
+        let [, sign, secs, nanos] = match;
+        let longSeconds = PbLong.from(sign + secs);
         if (longSeconds.toNumber() > 315576000000 || longSeconds.toNumber() < -315576000000)
             throw new Error("Unable to parse Duration from JSON string. Value out of range.");
         target.seconds = longSeconds.toBigInt();
-        if (typeof match[2] == "string") {
-            let nanosStr = match[2] + "0".repeat(9 - match[2].length);
+        if (typeof nanos == "string") {
+            let nanosStr = sign + nanos + "0".repeat(9 - nanos.length);
             target.nanos = parseInt(nanosStr);
-            if (longSeconds.isNegative()) {
-                target.nanos = -target.nanos;
-            }
         }
         return target;
     }

--- a/packages/test-conformance/src/gen/optimize_code_size-long_type_bigint/google/protobuf/struct.ts
+++ b/packages/test-conformance/src/gen/optimize_code_size-long_type_bigint/google/protobuf/struct.ts
@@ -215,7 +215,11 @@ class Value$Type extends MessageType<Value> {
             case undefined: throw new globalThis.Error();
             case "boolValue": return message.kind.boolValue;
             case "nullValue": return null;
-            case "numberValue": return message.kind.numberValue;
+            case "numberValue":
+                let numberValue = message.kind.numberValue;
+                if (typeof numberValue == "number" && !Number.isFinite(numberValue))
+                    throw new globalThis.Error();
+                return numberValue;
             case "stringValue": return message.kind.stringValue;
             case "listValue":
                 let listValueField = this.fields.find(f => f.no === 6);

--- a/packages/test-conformance/src/gen/optimize_code_size-long_type_bigint/google/protobuf/test_messages_proto2.ts
+++ b/packages/test-conformance/src/gen/optimize_code_size-long_type_bigint/google/protobuf/test_messages_proto2.ts
@@ -531,6 +531,68 @@ export interface TestAllTypesProto2 {
         oneofKind: undefined;
     };
     /**
+     * default values
+     *
+     * @generated from protobuf field: optional int32 default_int32 = 241;
+     */
+    defaultInt32?: number;
+    /**
+     * @generated from protobuf field: optional int64 default_int64 = 242;
+     */
+    defaultInt64?: bigint;
+    /**
+     * @generated from protobuf field: optional uint32 default_uint32 = 243;
+     */
+    defaultUint32?: number;
+    /**
+     * @generated from protobuf field: optional uint64 default_uint64 = 244;
+     */
+    defaultUint64?: bigint;
+    /**
+     * @generated from protobuf field: optional sint32 default_sint32 = 245;
+     */
+    defaultSint32?: number;
+    /**
+     * @generated from protobuf field: optional sint64 default_sint64 = 246;
+     */
+    defaultSint64?: bigint;
+    /**
+     * @generated from protobuf field: optional fixed32 default_fixed32 = 247;
+     */
+    defaultFixed32?: number;
+    /**
+     * @generated from protobuf field: optional fixed64 default_fixed64 = 248;
+     */
+    defaultFixed64?: bigint;
+    /**
+     * @generated from protobuf field: optional sfixed32 default_sfixed32 = 249;
+     */
+    defaultSfixed32?: number;
+    /**
+     * @generated from protobuf field: optional sfixed64 default_sfixed64 = 250;
+     */
+    defaultSfixed64?: bigint;
+    /**
+     * @generated from protobuf field: optional float default_float = 251;
+     */
+    defaultFloat?: number;
+    /**
+     * @generated from protobuf field: optional double default_double = 252;
+     */
+    defaultDouble?: number;
+    /**
+     * @generated from protobuf field: optional bool default_bool = 253;
+     */
+    defaultBool?: boolean;
+    /**
+     * @generated from protobuf field: optional string default_string = 254;
+     */
+    defaultString?: string;
+    /**
+     * @generated from protobuf field: optional bytes default_bytes = 255;
+     */
+    defaultBytes?: Uint8Array;
+    /**
      * Test field-name-to-JSON-name convention.
      * (protobuf says names can be any valid C/C++ identifier.)
      *
@@ -726,6 +788,55 @@ export interface UnknownToTestAllTypes_OptionalGroup {
     a?: number;
 }
 /**
+ * @generated from protobuf message protobuf_test_messages.proto2.NullHypothesisProto2
+ */
+export interface NullHypothesisProto2 {
+}
+/**
+ * @generated from protobuf message protobuf_test_messages.proto2.EnumOnlyProto2
+ */
+export interface EnumOnlyProto2 {
+}
+/**
+ * @generated from protobuf enum protobuf_test_messages.proto2.EnumOnlyProto2.Bool
+ */
+export enum EnumOnlyProto2_Bool {
+    /**
+     * @generated from protobuf enum value: kFalse = 0;
+     */
+    kFalse = 0,
+    /**
+     * @generated from protobuf enum value: kTrue = 1;
+     */
+    kTrue = 1
+}
+/**
+ * @generated from protobuf message protobuf_test_messages.proto2.OneStringProto2
+ */
+export interface OneStringProto2 {
+    /**
+     * @generated from protobuf field: optional string data = 1;
+     */
+    data?: string;
+}
+/**
+ * @generated from protobuf message protobuf_test_messages.proto2.ProtoWithKeywords
+ */
+export interface ProtoWithKeywords {
+    /**
+     * @generated from protobuf field: optional int32 inline = 1;
+     */
+    inline?: number;
+    /**
+     * @generated from protobuf field: optional string concept = 2;
+     */
+    concept?: string;
+    /**
+     * @generated from protobuf field: repeated string requires = 3;
+     */
+    requires: string[];
+}
+/**
  * @generated from protobuf enum protobuf_test_messages.proto2.ForeignEnumProto2
  */
 export enum ForeignEnumProto2 {
@@ -845,6 +956,21 @@ class TestAllTypesProto2$Type extends MessageType<TestAllTypesProto2> {
             { no: 117, name: "oneof_float", kind: "scalar", oneof: "oneofField", T: 2 /*ScalarType.FLOAT*/ },
             { no: 118, name: "oneof_double", kind: "scalar", oneof: "oneofField", T: 1 /*ScalarType.DOUBLE*/ },
             { no: 119, name: "oneof_enum", kind: "enum", oneof: "oneofField", T: () => ["protobuf_test_messages.proto2.TestAllTypesProto2.NestedEnum", TestAllTypesProto2_NestedEnum] },
+            { no: 241, name: "default_int32", kind: "scalar", opt: true, T: 5 /*ScalarType.INT32*/ },
+            { no: 242, name: "default_int64", kind: "scalar", opt: true, T: 3 /*ScalarType.INT64*/, L: 0 /*LongType.BIGINT*/ },
+            { no: 243, name: "default_uint32", kind: "scalar", opt: true, T: 13 /*ScalarType.UINT32*/ },
+            { no: 244, name: "default_uint64", kind: "scalar", opt: true, T: 4 /*ScalarType.UINT64*/, L: 0 /*LongType.BIGINT*/ },
+            { no: 245, name: "default_sint32", kind: "scalar", opt: true, T: 17 /*ScalarType.SINT32*/ },
+            { no: 246, name: "default_sint64", kind: "scalar", opt: true, T: 18 /*ScalarType.SINT64*/, L: 0 /*LongType.BIGINT*/ },
+            { no: 247, name: "default_fixed32", kind: "scalar", opt: true, T: 7 /*ScalarType.FIXED32*/ },
+            { no: 248, name: "default_fixed64", kind: "scalar", opt: true, T: 6 /*ScalarType.FIXED64*/, L: 0 /*LongType.BIGINT*/ },
+            { no: 249, name: "default_sfixed32", kind: "scalar", opt: true, T: 15 /*ScalarType.SFIXED32*/ },
+            { no: 250, name: "default_sfixed64", kind: "scalar", opt: true, T: 16 /*ScalarType.SFIXED64*/, L: 0 /*LongType.BIGINT*/ },
+            { no: 251, name: "default_float", kind: "scalar", opt: true, T: 2 /*ScalarType.FLOAT*/ },
+            { no: 252, name: "default_double", kind: "scalar", opt: true, T: 1 /*ScalarType.DOUBLE*/ },
+            { no: 253, name: "default_bool", kind: "scalar", opt: true, T: 8 /*ScalarType.BOOL*/ },
+            { no: 254, name: "default_string", kind: "scalar", opt: true, T: 9 /*ScalarType.STRING*/ },
+            { no: 255, name: "default_bytes", kind: "scalar", opt: true, T: 12 /*ScalarType.BYTES*/ },
             { no: 401, name: "fieldname1", kind: "scalar", opt: true, T: 5 /*ScalarType.INT32*/ },
             { no: 402, name: "field_name2", kind: "scalar", opt: true, T: 5 /*ScalarType.INT32*/ },
             { no: 403, name: "_field_name3", kind: "scalar", opt: true, T: 5 /*ScalarType.INT32*/ },
@@ -1372,6 +1498,51 @@ class TestAllTypesProto2$Type extends MessageType<TestAllTypesProto2> {
                         oneofKind: "oneofEnum",
                         oneofEnum: reader.int32()
                     };
+                    break;
+                case /* optional int32 default_int32 */ 241:
+                    message.defaultInt32 = reader.int32();
+                    break;
+                case /* optional int64 default_int64 */ 242:
+                    message.defaultInt64 = reader.int64().toBigInt();
+                    break;
+                case /* optional uint32 default_uint32 */ 243:
+                    message.defaultUint32 = reader.uint32();
+                    break;
+                case /* optional uint64 default_uint64 */ 244:
+                    message.defaultUint64 = reader.uint64().toBigInt();
+                    break;
+                case /* optional sint32 default_sint32 */ 245:
+                    message.defaultSint32 = reader.sint32();
+                    break;
+                case /* optional sint64 default_sint64 */ 246:
+                    message.defaultSint64 = reader.sint64().toBigInt();
+                    break;
+                case /* optional fixed32 default_fixed32 */ 247:
+                    message.defaultFixed32 = reader.fixed32();
+                    break;
+                case /* optional fixed64 default_fixed64 */ 248:
+                    message.defaultFixed64 = reader.fixed64().toBigInt();
+                    break;
+                case /* optional sfixed32 default_sfixed32 */ 249:
+                    message.defaultSfixed32 = reader.sfixed32();
+                    break;
+                case /* optional sfixed64 default_sfixed64 */ 250:
+                    message.defaultSfixed64 = reader.sfixed64().toBigInt();
+                    break;
+                case /* optional float default_float */ 251:
+                    message.defaultFloat = reader.float();
+                    break;
+                case /* optional double default_double */ 252:
+                    message.defaultDouble = reader.double();
+                    break;
+                case /* optional bool default_bool */ 253:
+                    message.defaultBool = reader.bool();
+                    break;
+                case /* optional string default_string */ 254:
+                    message.defaultString = reader.string();
+                    break;
+                case /* optional bytes default_bytes */ 255:
+                    message.defaultBytes = reader.bytes();
                     break;
                 case /* optional int32 fieldname1 */ 401:
                     message.fieldname1 = reader.int32();
@@ -2104,6 +2275,51 @@ class TestAllTypesProto2$Type extends MessageType<TestAllTypesProto2> {
         /* protobuf_test_messages.proto2.TestAllTypesProto2.NestedEnum oneof_enum = 119; */
         if (message.oneofField.oneofKind === "oneofEnum")
             writer.tag(119, WireType.Varint).int32(message.oneofField.oneofEnum);
+        /* optional int32 default_int32 = 241; */
+        if (message.defaultInt32 !== undefined)
+            writer.tag(241, WireType.Varint).int32(message.defaultInt32);
+        /* optional int64 default_int64 = 242; */
+        if (message.defaultInt64 !== undefined)
+            writer.tag(242, WireType.Varint).int64(message.defaultInt64);
+        /* optional uint32 default_uint32 = 243; */
+        if (message.defaultUint32 !== undefined)
+            writer.tag(243, WireType.Varint).uint32(message.defaultUint32);
+        /* optional uint64 default_uint64 = 244; */
+        if (message.defaultUint64 !== undefined)
+            writer.tag(244, WireType.Varint).uint64(message.defaultUint64);
+        /* optional sint32 default_sint32 = 245; */
+        if (message.defaultSint32 !== undefined)
+            writer.tag(245, WireType.Varint).sint32(message.defaultSint32);
+        /* optional sint64 default_sint64 = 246; */
+        if (message.defaultSint64 !== undefined)
+            writer.tag(246, WireType.Varint).sint64(message.defaultSint64);
+        /* optional fixed32 default_fixed32 = 247; */
+        if (message.defaultFixed32 !== undefined)
+            writer.tag(247, WireType.Bit32).fixed32(message.defaultFixed32);
+        /* optional fixed64 default_fixed64 = 248; */
+        if (message.defaultFixed64 !== undefined)
+            writer.tag(248, WireType.Bit64).fixed64(message.defaultFixed64);
+        /* optional sfixed32 default_sfixed32 = 249; */
+        if (message.defaultSfixed32 !== undefined)
+            writer.tag(249, WireType.Bit32).sfixed32(message.defaultSfixed32);
+        /* optional sfixed64 default_sfixed64 = 250; */
+        if (message.defaultSfixed64 !== undefined)
+            writer.tag(250, WireType.Bit64).sfixed64(message.defaultSfixed64);
+        /* optional float default_float = 251; */
+        if (message.defaultFloat !== undefined)
+            writer.tag(251, WireType.Bit32).float(message.defaultFloat);
+        /* optional double default_double = 252; */
+        if (message.defaultDouble !== undefined)
+            writer.tag(252, WireType.Bit64).double(message.defaultDouble);
+        /* optional bool default_bool = 253; */
+        if (message.defaultBool !== undefined)
+            writer.tag(253, WireType.Varint).bool(message.defaultBool);
+        /* optional string default_string = 254; */
+        if (message.defaultString !== undefined)
+            writer.tag(254, WireType.LengthDelimited).string(message.defaultString);
+        /* optional bytes default_bytes = 255; */
+        if (message.defaultBytes !== undefined)
+            writer.tag(255, WireType.LengthDelimited).bytes(message.defaultBytes);
         /* optional int32 fieldname1 = 401; */
         if (message.fieldname1 !== undefined)
             writer.tag(401, WireType.Varint).int32(message.fieldname1);
@@ -2569,3 +2785,163 @@ class UnknownToTestAllTypes_OptionalGroup$Type extends MessageType<UnknownToTest
  * @generated MessageType for protobuf message protobuf_test_messages.proto2.UnknownToTestAllTypes.OptionalGroup
  */
 export const UnknownToTestAllTypes_OptionalGroup = new UnknownToTestAllTypes_OptionalGroup$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class NullHypothesisProto2$Type extends MessageType<NullHypothesisProto2> {
+    constructor() {
+        super("protobuf_test_messages.proto2.NullHypothesisProto2", []);
+    }
+    create(value?: PartialMessage<NullHypothesisProto2>): NullHypothesisProto2 {
+        const message = {};
+        globalThis.Object.defineProperty(message, MESSAGE_TYPE, { enumerable: false, value: this });
+        if (value !== undefined)
+            reflectionMergePartial<NullHypothesisProto2>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: NullHypothesisProto2): NullHypothesisProto2 {
+        return target ?? this.create();
+    }
+    internalBinaryWrite(message: NullHypothesisProto2, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message protobuf_test_messages.proto2.NullHypothesisProto2
+ */
+export const NullHypothesisProto2 = new NullHypothesisProto2$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class EnumOnlyProto2$Type extends MessageType<EnumOnlyProto2> {
+    constructor() {
+        super("protobuf_test_messages.proto2.EnumOnlyProto2", []);
+    }
+    create(value?: PartialMessage<EnumOnlyProto2>): EnumOnlyProto2 {
+        const message = {};
+        globalThis.Object.defineProperty(message, MESSAGE_TYPE, { enumerable: false, value: this });
+        if (value !== undefined)
+            reflectionMergePartial<EnumOnlyProto2>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: EnumOnlyProto2): EnumOnlyProto2 {
+        return target ?? this.create();
+    }
+    internalBinaryWrite(message: EnumOnlyProto2, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message protobuf_test_messages.proto2.EnumOnlyProto2
+ */
+export const EnumOnlyProto2 = new EnumOnlyProto2$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class OneStringProto2$Type extends MessageType<OneStringProto2> {
+    constructor() {
+        super("protobuf_test_messages.proto2.OneStringProto2", [
+            { no: 1, name: "data", kind: "scalar", opt: true, T: 9 /*ScalarType.STRING*/ }
+        ]);
+    }
+    create(value?: PartialMessage<OneStringProto2>): OneStringProto2 {
+        const message = {};
+        globalThis.Object.defineProperty(message, MESSAGE_TYPE, { enumerable: false, value: this });
+        if (value !== undefined)
+            reflectionMergePartial<OneStringProto2>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: OneStringProto2): OneStringProto2 {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                case /* optional string data */ 1:
+                    message.data = reader.string();
+                    break;
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: OneStringProto2, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* optional string data = 1; */
+        if (message.data !== undefined)
+            writer.tag(1, WireType.LengthDelimited).string(message.data);
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message protobuf_test_messages.proto2.OneStringProto2
+ */
+export const OneStringProto2 = new OneStringProto2$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class ProtoWithKeywords$Type extends MessageType<ProtoWithKeywords> {
+    constructor() {
+        super("protobuf_test_messages.proto2.ProtoWithKeywords", [
+            { no: 1, name: "inline", kind: "scalar", opt: true, T: 5 /*ScalarType.INT32*/ },
+            { no: 2, name: "concept", kind: "scalar", opt: true, T: 9 /*ScalarType.STRING*/ },
+            { no: 3, name: "requires", kind: "scalar", repeat: 2 /*RepeatType.UNPACKED*/, T: 9 /*ScalarType.STRING*/ }
+        ]);
+    }
+    create(value?: PartialMessage<ProtoWithKeywords>): ProtoWithKeywords {
+        const message = { requires: [] };
+        globalThis.Object.defineProperty(message, MESSAGE_TYPE, { enumerable: false, value: this });
+        if (value !== undefined)
+            reflectionMergePartial<ProtoWithKeywords>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: ProtoWithKeywords): ProtoWithKeywords {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                case /* optional int32 inline */ 1:
+                    message.inline = reader.int32();
+                    break;
+                case /* optional string concept */ 2:
+                    message.concept = reader.string();
+                    break;
+                case /* repeated string requires */ 3:
+                    message.requires.push(reader.string());
+                    break;
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: ProtoWithKeywords, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* optional int32 inline = 1; */
+        if (message.inline !== undefined)
+            writer.tag(1, WireType.Varint).int32(message.inline);
+        /* optional string concept = 2; */
+        if (message.concept !== undefined)
+            writer.tag(2, WireType.LengthDelimited).string(message.concept);
+        /* repeated string requires = 3; */
+        for (let i = 0; i < message.requires.length; i++)
+            writer.tag(3, WireType.LengthDelimited).string(message.requires[i]);
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message protobuf_test_messages.proto2.ProtoWithKeywords
+ */
+export const ProtoWithKeywords = new ProtoWithKeywords$Type();

--- a/packages/test-conformance/src/gen/optimize_code_size-long_type_bigint/google/protobuf/test_messages_proto3.ts
+++ b/packages/test-conformance/src/gen/optimize_code_size-long_type_bigint/google/protobuf/test_messages_proto3.ts
@@ -65,6 +65,7 @@ import { UInt32Value } from "./wrappers";
 import { Int64Value } from "./wrappers";
 import { Int32Value } from "./wrappers";
 import { BoolValue } from "./wrappers";
+import { NullValue } from "./struct";
 /**
  * This proto includes every type of field in both singular and repeated
  * forms.
@@ -547,6 +548,12 @@ export interface TestAllTypesProto3 {
          */
         oneofEnum: TestAllTypesProto3_NestedEnum;
     } | {
+        oneofKind: "oneofNullValue";
+        /**
+         * @generated from protobuf field: google.protobuf.NullValue oneof_null_value = 120;
+         */
+        oneofNullValue: NullValue;
+    } | {
         oneofKind: undefined;
     };
     /**
@@ -647,6 +654,10 @@ export interface TestAllTypesProto3 {
      * @generated from protobuf field: google.protobuf.Value optional_value = 306;
      */
     optionalValue?: Value;
+    /**
+     * @generated from protobuf field: google.protobuf.NullValue optional_null_value = 307;
+     */
+    optionalNullValue: NullValue;
     /**
      * @generated from protobuf field: repeated google.protobuf.Duration repeated_duration = 311;
      */
@@ -806,11 +817,11 @@ export enum TestAllTypesProto3_AliasedEnum {
     /**
      * @generated from protobuf enum value: ALIAS_BAZ = 2;
      */
-    QUX = 2,
+    MOO = 2,
     /**
      * @generated from protobuf enum value: ALIAS_BAZ = 2;
      */
-    qux = 2,
+    moo = 2,
     /**
      * @generated from protobuf enum value: ALIAS_BAZ = 2;
      */
@@ -824,6 +835,29 @@ export interface ForeignMessage {
      * @generated from protobuf field: int32 c = 1;
      */
     c: number;
+}
+/**
+ * @generated from protobuf message protobuf_test_messages.proto3.NullHypothesisProto3
+ */
+export interface NullHypothesisProto3 {
+}
+/**
+ * @generated from protobuf message protobuf_test_messages.proto3.EnumOnlyProto3
+ */
+export interface EnumOnlyProto3 {
+}
+/**
+ * @generated from protobuf enum protobuf_test_messages.proto3.EnumOnlyProto3.Bool
+ */
+export enum EnumOnlyProto3_Bool {
+    /**
+     * @generated from protobuf enum value: kFalse = 0;
+     */
+    kFalse = 0,
+    /**
+     * @generated from protobuf enum value: kTrue = 1;
+     */
+    kTrue = 1
 }
 /**
  * @generated from protobuf enum protobuf_test_messages.proto3.ForeignEnum
@@ -946,6 +980,7 @@ class TestAllTypesProto3$Type extends MessageType<TestAllTypesProto3> {
             { no: 117, name: "oneof_float", kind: "scalar", oneof: "oneofField", T: 2 /*ScalarType.FLOAT*/ },
             { no: 118, name: "oneof_double", kind: "scalar", oneof: "oneofField", T: 1 /*ScalarType.DOUBLE*/ },
             { no: 119, name: "oneof_enum", kind: "enum", oneof: "oneofField", T: () => ["protobuf_test_messages.proto3.TestAllTypesProto3.NestedEnum", TestAllTypesProto3_NestedEnum] },
+            { no: 120, name: "oneof_null_value", kind: "enum", oneof: "oneofField", T: () => ["google.protobuf.NullValue", NullValue] },
             { no: 201, name: "optional_bool_wrapper", kind: "message", T: () => BoolValue },
             { no: 202, name: "optional_int32_wrapper", kind: "message", T: () => Int32Value },
             { no: 203, name: "optional_int64_wrapper", kind: "message", T: () => Int64Value },
@@ -970,6 +1005,7 @@ class TestAllTypesProto3$Type extends MessageType<TestAllTypesProto3> {
             { no: 304, name: "optional_struct", kind: "message", T: () => Struct },
             { no: 305, name: "optional_any", kind: "message", T: () => Any },
             { no: 306, name: "optional_value", kind: "message", T: () => Value },
+            { no: 307, name: "optional_null_value", kind: "enum", T: () => ["google.protobuf.NullValue", NullValue] },
             { no: 311, name: "repeated_duration", kind: "message", repeat: 1 /*RepeatType.PACKED*/, T: () => Duration },
             { no: 312, name: "repeated_timestamp", kind: "message", repeat: 1 /*RepeatType.PACKED*/, T: () => Timestamp },
             { no: 313, name: "repeated_fieldmask", kind: "message", repeat: 1 /*RepeatType.PACKED*/, T: () => FieldMask },
@@ -998,7 +1034,7 @@ class TestAllTypesProto3$Type extends MessageType<TestAllTypesProto3> {
         ]);
     }
     create(value?: PartialMessage<TestAllTypesProto3>): TestAllTypesProto3 {
-        const message = { optionalInt32: 0, optionalInt64: 0n, optionalUint32: 0, optionalUint64: 0n, optionalSint32: 0, optionalSint64: 0n, optionalFixed32: 0, optionalFixed64: 0n, optionalSfixed32: 0, optionalSfixed64: 0n, optionalFloat: 0, optionalDouble: 0, optionalBool: false, optionalString: "", optionalBytes: new Uint8Array(0), optionalNestedEnum: 0, optionalForeignEnum: 0, optionalAliasedEnum: 0, optionalStringPiece: "", optionalCord: "", repeatedInt32: [], repeatedInt64: [], repeatedUint32: [], repeatedUint64: [], repeatedSint32: [], repeatedSint64: [], repeatedFixed32: [], repeatedFixed64: [], repeatedSfixed32: [], repeatedSfixed64: [], repeatedFloat: [], repeatedDouble: [], repeatedBool: [], repeatedString: [], repeatedBytes: [], repeatedNestedMessage: [], repeatedForeignMessage: [], repeatedNestedEnum: [], repeatedForeignEnum: [], repeatedStringPiece: [], repeatedCord: [], packedInt32: [], packedInt64: [], packedUint32: [], packedUint64: [], packedSint32: [], packedSint64: [], packedFixed32: [], packedFixed64: [], packedSfixed32: [], packedSfixed64: [], packedFloat: [], packedDouble: [], packedBool: [], packedNestedEnum: [], unpackedInt32: [], unpackedInt64: [], unpackedUint32: [], unpackedUint64: [], unpackedSint32: [], unpackedSint64: [], unpackedFixed32: [], unpackedFixed64: [], unpackedSfixed32: [], unpackedSfixed64: [], unpackedFloat: [], unpackedDouble: [], unpackedBool: [], unpackedNestedEnum: [], mapInt32Int32: {}, mapInt64Int64: {}, mapUint32Uint32: {}, mapUint64Uint64: {}, mapSint32Sint32: {}, mapSint64Sint64: {}, mapFixed32Fixed32: {}, mapFixed64Fixed64: {}, mapSfixed32Sfixed32: {}, mapSfixed64Sfixed64: {}, mapInt32Float: {}, mapInt32Double: {}, mapBoolBool: {}, mapStringString: {}, mapStringBytes: {}, mapStringNestedMessage: {}, mapStringForeignMessage: {}, mapStringNestedEnum: {}, mapStringForeignEnum: {}, oneofField: { oneofKind: undefined }, repeatedBoolWrapper: [], repeatedInt32Wrapper: [], repeatedInt64Wrapper: [], repeatedUint32Wrapper: [], repeatedUint64Wrapper: [], repeatedFloatWrapper: [], repeatedDoubleWrapper: [], repeatedStringWrapper: [], repeatedBytesWrapper: [], repeatedDuration: [], repeatedTimestamp: [], repeatedFieldmask: [], repeatedStruct: [], repeatedAny: [], repeatedValue: [], repeatedListValue: [], fieldname1: 0, fieldName2: 0, FieldName3: 0, fieldName4: 0, field0Name5: 0, field0Name6: 0, fieldName7: 0, fieldName8: 0, fieldName9: 0, fieldName10: 0, fIELDNAME11: 0, fIELDName12: 0, FieldName13: 0, FieldName14: 0, fieldName15: 0, fieldName16: 0, fieldName17: 0, fieldName18: 0 };
+        const message = { optionalInt32: 0, optionalInt64: 0n, optionalUint32: 0, optionalUint64: 0n, optionalSint32: 0, optionalSint64: 0n, optionalFixed32: 0, optionalFixed64: 0n, optionalSfixed32: 0, optionalSfixed64: 0n, optionalFloat: 0, optionalDouble: 0, optionalBool: false, optionalString: "", optionalBytes: new Uint8Array(0), optionalNestedEnum: 0, optionalForeignEnum: 0, optionalAliasedEnum: 0, optionalStringPiece: "", optionalCord: "", repeatedInt32: [], repeatedInt64: [], repeatedUint32: [], repeatedUint64: [], repeatedSint32: [], repeatedSint64: [], repeatedFixed32: [], repeatedFixed64: [], repeatedSfixed32: [], repeatedSfixed64: [], repeatedFloat: [], repeatedDouble: [], repeatedBool: [], repeatedString: [], repeatedBytes: [], repeatedNestedMessage: [], repeatedForeignMessage: [], repeatedNestedEnum: [], repeatedForeignEnum: [], repeatedStringPiece: [], repeatedCord: [], packedInt32: [], packedInt64: [], packedUint32: [], packedUint64: [], packedSint32: [], packedSint64: [], packedFixed32: [], packedFixed64: [], packedSfixed32: [], packedSfixed64: [], packedFloat: [], packedDouble: [], packedBool: [], packedNestedEnum: [], unpackedInt32: [], unpackedInt64: [], unpackedUint32: [], unpackedUint64: [], unpackedSint32: [], unpackedSint64: [], unpackedFixed32: [], unpackedFixed64: [], unpackedSfixed32: [], unpackedSfixed64: [], unpackedFloat: [], unpackedDouble: [], unpackedBool: [], unpackedNestedEnum: [], mapInt32Int32: {}, mapInt64Int64: {}, mapUint32Uint32: {}, mapUint64Uint64: {}, mapSint32Sint32: {}, mapSint64Sint64: {}, mapFixed32Fixed32: {}, mapFixed64Fixed64: {}, mapSfixed32Sfixed32: {}, mapSfixed64Sfixed64: {}, mapInt32Float: {}, mapInt32Double: {}, mapBoolBool: {}, mapStringString: {}, mapStringBytes: {}, mapStringNestedMessage: {}, mapStringForeignMessage: {}, mapStringNestedEnum: {}, mapStringForeignEnum: {}, oneofField: { oneofKind: undefined }, repeatedBoolWrapper: [], repeatedInt32Wrapper: [], repeatedInt64Wrapper: [], repeatedUint32Wrapper: [], repeatedUint64Wrapper: [], repeatedFloatWrapper: [], repeatedDoubleWrapper: [], repeatedStringWrapper: [], repeatedBytesWrapper: [], optionalNullValue: 0, repeatedDuration: [], repeatedTimestamp: [], repeatedFieldmask: [], repeatedStruct: [], repeatedAny: [], repeatedValue: [], repeatedListValue: [], fieldname1: 0, fieldName2: 0, FieldName3: 0, fieldName4: 0, field0Name5: 0, field0Name6: 0, fieldName7: 0, fieldName8: 0, fieldName9: 0, fieldName10: 0, fIELDNAME11: 0, fIELDName12: 0, FieldName13: 0, FieldName14: 0, fieldName15: 0, fieldName16: 0, fieldName17: 0, fieldName18: 0 };
         globalThis.Object.defineProperty(message, MESSAGE_TYPE, { enumerable: false, value: this });
         if (value !== undefined)
             reflectionMergePartial<TestAllTypesProto3>(this, message, value);
@@ -1508,6 +1544,12 @@ class TestAllTypesProto3$Type extends MessageType<TestAllTypesProto3> {
                         oneofEnum: reader.int32()
                     };
                     break;
+                case /* google.protobuf.NullValue oneof_null_value */ 120:
+                    message.oneofField = {
+                        oneofKind: "oneofNullValue",
+                        oneofNullValue: reader.int32()
+                    };
+                    break;
                 case /* google.protobuf.BoolValue optional_bool_wrapper */ 201:
                     message.optionalBoolWrapper = BoolValue.internalBinaryRead(reader, reader.uint32(), options, message.optionalBoolWrapper);
                     break;
@@ -1579,6 +1621,9 @@ class TestAllTypesProto3$Type extends MessageType<TestAllTypesProto3> {
                     break;
                 case /* google.protobuf.Value optional_value */ 306:
                     message.optionalValue = Value.internalBinaryRead(reader, reader.uint32(), options, message.optionalValue);
+                    break;
+                case /* google.protobuf.NullValue optional_null_value */ 307:
+                    message.optionalNullValue = reader.int32();
                     break;
                 case /* repeated google.protobuf.Duration repeated_duration */ 311:
                     message.repeatedDuration.push(Duration.internalBinaryRead(reader, reader.uint32(), options));
@@ -2395,6 +2440,9 @@ class TestAllTypesProto3$Type extends MessageType<TestAllTypesProto3> {
         /* protobuf_test_messages.proto3.TestAllTypesProto3.NestedEnum oneof_enum = 119; */
         if (message.oneofField.oneofKind === "oneofEnum")
             writer.tag(119, WireType.Varint).int32(message.oneofField.oneofEnum);
+        /* google.protobuf.NullValue oneof_null_value = 120; */
+        if (message.oneofField.oneofKind === "oneofNullValue")
+            writer.tag(120, WireType.Varint).int32(message.oneofField.oneofNullValue);
         /* google.protobuf.BoolValue optional_bool_wrapper = 201; */
         if (message.optionalBoolWrapper)
             BoolValue.internalBinaryWrite(message.optionalBoolWrapper, writer.tag(201, WireType.LengthDelimited).fork(), options).join();
@@ -2467,6 +2515,9 @@ class TestAllTypesProto3$Type extends MessageType<TestAllTypesProto3> {
         /* google.protobuf.Value optional_value = 306; */
         if (message.optionalValue)
             Value.internalBinaryWrite(message.optionalValue, writer.tag(306, WireType.LengthDelimited).fork(), options).join();
+        /* google.protobuf.NullValue optional_null_value = 307; */
+        if (message.optionalNullValue !== 0)
+            writer.tag(307, WireType.Varint).int32(message.optionalNullValue);
         /* repeated google.protobuf.Duration repeated_duration = 311; */
         for (let i = 0; i < message.repeatedDuration.length; i++)
             Duration.internalBinaryWrite(message.repeatedDuration[i], writer.tag(311, WireType.LengthDelimited).fork(), options).join();
@@ -2653,3 +2704,55 @@ class ForeignMessage$Type extends MessageType<ForeignMessage> {
  * @generated MessageType for protobuf message protobuf_test_messages.proto3.ForeignMessage
  */
 export const ForeignMessage = new ForeignMessage$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class NullHypothesisProto3$Type extends MessageType<NullHypothesisProto3> {
+    constructor() {
+        super("protobuf_test_messages.proto3.NullHypothesisProto3", []);
+    }
+    create(value?: PartialMessage<NullHypothesisProto3>): NullHypothesisProto3 {
+        const message = {};
+        globalThis.Object.defineProperty(message, MESSAGE_TYPE, { enumerable: false, value: this });
+        if (value !== undefined)
+            reflectionMergePartial<NullHypothesisProto3>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: NullHypothesisProto3): NullHypothesisProto3 {
+        return target ?? this.create();
+    }
+    internalBinaryWrite(message: NullHypothesisProto3, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message protobuf_test_messages.proto3.NullHypothesisProto3
+ */
+export const NullHypothesisProto3 = new NullHypothesisProto3$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class EnumOnlyProto3$Type extends MessageType<EnumOnlyProto3> {
+    constructor() {
+        super("protobuf_test_messages.proto3.EnumOnlyProto3", []);
+    }
+    create(value?: PartialMessage<EnumOnlyProto3>): EnumOnlyProto3 {
+        const message = {};
+        globalThis.Object.defineProperty(message, MESSAGE_TYPE, { enumerable: false, value: this });
+        if (value !== undefined)
+            reflectionMergePartial<EnumOnlyProto3>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: EnumOnlyProto3): EnumOnlyProto3 {
+        return target ?? this.create();
+    }
+    internalBinaryWrite(message: EnumOnlyProto3, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message protobuf_test_messages.proto3.EnumOnlyProto3
+ */
+export const EnumOnlyProto3 = new EnumOnlyProto3$Type();

--- a/packages/test-conformance/src/gen/optimize_code_size-long_type_string/conformance/conformance.ts
+++ b/packages/test-conformance/src/gen/optimize_code_size-long_type_string/conformance/conformance.ts
@@ -74,7 +74,7 @@ export interface ConformanceRequest {
     } | {
         oneofKind: "jspbPayload";
         /**
-         * Google internal only.  Opensource testees just skip it.
+         * Only used inside Google.  Opensource testees just skip it.
          *
          * @generated from protobuf field: string jspb_payload = 7;
          */
@@ -97,15 +97,15 @@ export interface ConformanceRequest {
     /**
      * The full name for the test message to use; for the moment, either:
      * protobuf_test_messages.proto3.TestAllTypesProto3 or
-     * protobuf_test_messages.proto2.TestAllTypesProto2.
+     * protobuf_test_messages.google.protobuf.TestAllTypesProto2.
      *
      * @generated from protobuf field: string message_type = 4;
      */
     messageType: string;
     /**
      * Each test is given a specific test category. Some category may need
-     * specific support in testee programs. Refer to the definition of TestCategory
-     * for more information.
+     * specific support in testee programs. Refer to the definition of
+     * TestCategory for more information.
      *
      * @generated from protobuf field: conformance.TestCategory test_category = 5;
      */
@@ -156,6 +156,16 @@ export interface ConformanceResponse {
          */
         serializeError: string;
     } | {
+        oneofKind: "timeoutError";
+        /**
+         * This should be set if the test program timed out.  The string should
+         * provide more information about what the child process was doing when it
+         * was killed.
+         *
+         * @generated from protobuf field: string timeout_error = 9;
+         */
+        timeoutError: string;
+    } | {
         oneofKind: "runtimeError";
         /**
          * This should be set if some other error occurred.  This will always
@@ -196,8 +206,8 @@ export interface ConformanceResponse {
         oneofKind: "jspbPayload";
         /**
          * If the input was successfully parsed and the requested output was JSPB,
-         * serialize to JSPB and set it in this field. JSPB is google internal only
-         * format. Opensource testees can just skip it.
+         * serialize to JSPB and set it in this field. JSPB is only used inside
+         * Google. Opensource testees can just skip it.
          *
          * @generated from protobuf field: string jspb_payload = 7;
          */
@@ -264,7 +274,7 @@ export enum WireFormat {
      */
     JSON = 2,
     /**
-     * Google internal only. Opensource testees just skip it.
+     * Only used inside Google. Opensource testees just skip it.
      *
      * @generated from protobuf enum value: JSPB = 3;
      */
@@ -305,7 +315,8 @@ export enum TestCategory {
      */
     JSON_IGNORE_UNKNOWN_PARSING_TEST = 3,
     /**
-     * Test jspb wire format. Google internal only. Opensource testees just skip it.
+     * Test jspb wire format. Only used inside Google. Opensource testees just
+     * skip it.
      *
      * @generated from protobuf enum value: JSPB_TEST = 4;
      */
@@ -356,6 +367,7 @@ class ConformanceResponse$Type extends MessageType<ConformanceResponse> {
         super("conformance.ConformanceResponse", [
             { no: 1, name: "parse_error", kind: "scalar", oneof: "result", T: 9 /*ScalarType.STRING*/ },
             { no: 6, name: "serialize_error", kind: "scalar", oneof: "result", T: 9 /*ScalarType.STRING*/ },
+            { no: 9, name: "timeout_error", kind: "scalar", oneof: "result", T: 9 /*ScalarType.STRING*/ },
             { no: 2, name: "runtime_error", kind: "scalar", oneof: "result", T: 9 /*ScalarType.STRING*/ },
             { no: 3, name: "protobuf_payload", kind: "scalar", oneof: "result", T: 12 /*ScalarType.BYTES*/ },
             { no: 4, name: "json_payload", kind: "scalar", oneof: "result", T: 9 /*ScalarType.STRING*/ },

--- a/packages/test-conformance/src/gen/optimize_code_size-long_type_string/google/protobuf/duration.ts
+++ b/packages/test-conformance/src/gen/optimize_code_size-long_type_string/google/protobuf/duration.ts
@@ -138,6 +138,8 @@ class Duration$Type extends MessageType<Duration> {
         if (s > 315576000000 || s < -315576000000)
             throw new Error("Duration value out of range.");
         let text = message.seconds.toString();
+        if (s === 0 && message.nanos < 0)
+            text = "-" + text;
         if (message.nanos !== 0) {
             let nanosStr = Math.abs(message.nanos).toString();
             nanosStr = "0".repeat(9 - nanosStr.length) + nanosStr;
@@ -155,21 +157,19 @@ class Duration$Type extends MessageType<Duration> {
     internalJsonRead(json: JsonValue, options: JsonReadOptions, target?: Duration): Duration {
         if (typeof json !== "string")
             throw new Error("Unable to parse Duration from JSON " + typeofJsonValue(json) + ". Expected string.");
-        let match = json.match(/^(-?[0-9]+)(?:\.([0-9]+))?s/);
+        let match = json.match(/^(-?)([0-9]+)(?:\.([0-9]+))?s/);
         if (match === null)
             throw new Error("Unable to parse Duration from JSON string. Invalid format.");
         if (!target)
             target = this.create();
-        let longSeconds = PbLong.from(match[1]);
+        let [, sign, secs, nanos] = match;
+        let longSeconds = PbLong.from(sign + secs);
         if (longSeconds.toNumber() > 315576000000 || longSeconds.toNumber() < -315576000000)
             throw new Error("Unable to parse Duration from JSON string. Value out of range.");
         target.seconds = longSeconds.toString();
-        if (typeof match[2] == "string") {
-            let nanosStr = match[2] + "0".repeat(9 - match[2].length);
+        if (typeof nanos == "string") {
+            let nanosStr = sign + nanos + "0".repeat(9 - nanos.length);
             target.nanos = parseInt(nanosStr);
-            if (longSeconds.isNegative()) {
-                target.nanos = -target.nanos;
-            }
         }
         return target;
     }

--- a/packages/test-conformance/src/gen/optimize_code_size-long_type_string/google/protobuf/struct.ts
+++ b/packages/test-conformance/src/gen/optimize_code_size-long_type_string/google/protobuf/struct.ts
@@ -215,7 +215,11 @@ class Value$Type extends MessageType<Value> {
             case undefined: throw new globalThis.Error();
             case "boolValue": return message.kind.boolValue;
             case "nullValue": return null;
-            case "numberValue": return message.kind.numberValue;
+            case "numberValue":
+                let numberValue = message.kind.numberValue;
+                if (typeof numberValue == "number" && !Number.isFinite(numberValue))
+                    throw new globalThis.Error();
+                return numberValue;
             case "stringValue": return message.kind.stringValue;
             case "listValue":
                 let listValueField = this.fields.find(f => f.no === 6);

--- a/packages/test-conformance/src/gen/optimize_code_size-long_type_string/google/protobuf/test_messages_proto2.ts
+++ b/packages/test-conformance/src/gen/optimize_code_size-long_type_string/google/protobuf/test_messages_proto2.ts
@@ -531,6 +531,68 @@ export interface TestAllTypesProto2 {
         oneofKind: undefined;
     };
     /**
+     * default values
+     *
+     * @generated from protobuf field: optional int32 default_int32 = 241;
+     */
+    defaultInt32?: number;
+    /**
+     * @generated from protobuf field: optional int64 default_int64 = 242;
+     */
+    defaultInt64?: string;
+    /**
+     * @generated from protobuf field: optional uint32 default_uint32 = 243;
+     */
+    defaultUint32?: number;
+    /**
+     * @generated from protobuf field: optional uint64 default_uint64 = 244;
+     */
+    defaultUint64?: string;
+    /**
+     * @generated from protobuf field: optional sint32 default_sint32 = 245;
+     */
+    defaultSint32?: number;
+    /**
+     * @generated from protobuf field: optional sint64 default_sint64 = 246;
+     */
+    defaultSint64?: string;
+    /**
+     * @generated from protobuf field: optional fixed32 default_fixed32 = 247;
+     */
+    defaultFixed32?: number;
+    /**
+     * @generated from protobuf field: optional fixed64 default_fixed64 = 248;
+     */
+    defaultFixed64?: string;
+    /**
+     * @generated from protobuf field: optional sfixed32 default_sfixed32 = 249;
+     */
+    defaultSfixed32?: number;
+    /**
+     * @generated from protobuf field: optional sfixed64 default_sfixed64 = 250;
+     */
+    defaultSfixed64?: string;
+    /**
+     * @generated from protobuf field: optional float default_float = 251;
+     */
+    defaultFloat?: number;
+    /**
+     * @generated from protobuf field: optional double default_double = 252;
+     */
+    defaultDouble?: number;
+    /**
+     * @generated from protobuf field: optional bool default_bool = 253;
+     */
+    defaultBool?: boolean;
+    /**
+     * @generated from protobuf field: optional string default_string = 254;
+     */
+    defaultString?: string;
+    /**
+     * @generated from protobuf field: optional bytes default_bytes = 255;
+     */
+    defaultBytes?: Uint8Array;
+    /**
      * Test field-name-to-JSON-name convention.
      * (protobuf says names can be any valid C/C++ identifier.)
      *
@@ -726,6 +788,55 @@ export interface UnknownToTestAllTypes_OptionalGroup {
     a?: number;
 }
 /**
+ * @generated from protobuf message protobuf_test_messages.proto2.NullHypothesisProto2
+ */
+export interface NullHypothesisProto2 {
+}
+/**
+ * @generated from protobuf message protobuf_test_messages.proto2.EnumOnlyProto2
+ */
+export interface EnumOnlyProto2 {
+}
+/**
+ * @generated from protobuf enum protobuf_test_messages.proto2.EnumOnlyProto2.Bool
+ */
+export enum EnumOnlyProto2_Bool {
+    /**
+     * @generated from protobuf enum value: kFalse = 0;
+     */
+    kFalse = 0,
+    /**
+     * @generated from protobuf enum value: kTrue = 1;
+     */
+    kTrue = 1
+}
+/**
+ * @generated from protobuf message protobuf_test_messages.proto2.OneStringProto2
+ */
+export interface OneStringProto2 {
+    /**
+     * @generated from protobuf field: optional string data = 1;
+     */
+    data?: string;
+}
+/**
+ * @generated from protobuf message protobuf_test_messages.proto2.ProtoWithKeywords
+ */
+export interface ProtoWithKeywords {
+    /**
+     * @generated from protobuf field: optional int32 inline = 1;
+     */
+    inline?: number;
+    /**
+     * @generated from protobuf field: optional string concept = 2;
+     */
+    concept?: string;
+    /**
+     * @generated from protobuf field: repeated string requires = 3;
+     */
+    requires: string[];
+}
+/**
  * @generated from protobuf enum protobuf_test_messages.proto2.ForeignEnumProto2
  */
 export enum ForeignEnumProto2 {
@@ -845,6 +956,21 @@ class TestAllTypesProto2$Type extends MessageType<TestAllTypesProto2> {
             { no: 117, name: "oneof_float", kind: "scalar", oneof: "oneofField", T: 2 /*ScalarType.FLOAT*/ },
             { no: 118, name: "oneof_double", kind: "scalar", oneof: "oneofField", T: 1 /*ScalarType.DOUBLE*/ },
             { no: 119, name: "oneof_enum", kind: "enum", oneof: "oneofField", T: () => ["protobuf_test_messages.proto2.TestAllTypesProto2.NestedEnum", TestAllTypesProto2_NestedEnum] },
+            { no: 241, name: "default_int32", kind: "scalar", opt: true, T: 5 /*ScalarType.INT32*/ },
+            { no: 242, name: "default_int64", kind: "scalar", opt: true, T: 3 /*ScalarType.INT64*/ },
+            { no: 243, name: "default_uint32", kind: "scalar", opt: true, T: 13 /*ScalarType.UINT32*/ },
+            { no: 244, name: "default_uint64", kind: "scalar", opt: true, T: 4 /*ScalarType.UINT64*/ },
+            { no: 245, name: "default_sint32", kind: "scalar", opt: true, T: 17 /*ScalarType.SINT32*/ },
+            { no: 246, name: "default_sint64", kind: "scalar", opt: true, T: 18 /*ScalarType.SINT64*/ },
+            { no: 247, name: "default_fixed32", kind: "scalar", opt: true, T: 7 /*ScalarType.FIXED32*/ },
+            { no: 248, name: "default_fixed64", kind: "scalar", opt: true, T: 6 /*ScalarType.FIXED64*/ },
+            { no: 249, name: "default_sfixed32", kind: "scalar", opt: true, T: 15 /*ScalarType.SFIXED32*/ },
+            { no: 250, name: "default_sfixed64", kind: "scalar", opt: true, T: 16 /*ScalarType.SFIXED64*/ },
+            { no: 251, name: "default_float", kind: "scalar", opt: true, T: 2 /*ScalarType.FLOAT*/ },
+            { no: 252, name: "default_double", kind: "scalar", opt: true, T: 1 /*ScalarType.DOUBLE*/ },
+            { no: 253, name: "default_bool", kind: "scalar", opt: true, T: 8 /*ScalarType.BOOL*/ },
+            { no: 254, name: "default_string", kind: "scalar", opt: true, T: 9 /*ScalarType.STRING*/ },
+            { no: 255, name: "default_bytes", kind: "scalar", opt: true, T: 12 /*ScalarType.BYTES*/ },
             { no: 401, name: "fieldname1", kind: "scalar", opt: true, T: 5 /*ScalarType.INT32*/ },
             { no: 402, name: "field_name2", kind: "scalar", opt: true, T: 5 /*ScalarType.INT32*/ },
             { no: 403, name: "_field_name3", kind: "scalar", opt: true, T: 5 /*ScalarType.INT32*/ },
@@ -1372,6 +1498,51 @@ class TestAllTypesProto2$Type extends MessageType<TestAllTypesProto2> {
                         oneofKind: "oneofEnum",
                         oneofEnum: reader.int32()
                     };
+                    break;
+                case /* optional int32 default_int32 */ 241:
+                    message.defaultInt32 = reader.int32();
+                    break;
+                case /* optional int64 default_int64 */ 242:
+                    message.defaultInt64 = reader.int64().toString();
+                    break;
+                case /* optional uint32 default_uint32 */ 243:
+                    message.defaultUint32 = reader.uint32();
+                    break;
+                case /* optional uint64 default_uint64 */ 244:
+                    message.defaultUint64 = reader.uint64().toString();
+                    break;
+                case /* optional sint32 default_sint32 */ 245:
+                    message.defaultSint32 = reader.sint32();
+                    break;
+                case /* optional sint64 default_sint64 */ 246:
+                    message.defaultSint64 = reader.sint64().toString();
+                    break;
+                case /* optional fixed32 default_fixed32 */ 247:
+                    message.defaultFixed32 = reader.fixed32();
+                    break;
+                case /* optional fixed64 default_fixed64 */ 248:
+                    message.defaultFixed64 = reader.fixed64().toString();
+                    break;
+                case /* optional sfixed32 default_sfixed32 */ 249:
+                    message.defaultSfixed32 = reader.sfixed32();
+                    break;
+                case /* optional sfixed64 default_sfixed64 */ 250:
+                    message.defaultSfixed64 = reader.sfixed64().toString();
+                    break;
+                case /* optional float default_float */ 251:
+                    message.defaultFloat = reader.float();
+                    break;
+                case /* optional double default_double */ 252:
+                    message.defaultDouble = reader.double();
+                    break;
+                case /* optional bool default_bool */ 253:
+                    message.defaultBool = reader.bool();
+                    break;
+                case /* optional string default_string */ 254:
+                    message.defaultString = reader.string();
+                    break;
+                case /* optional bytes default_bytes */ 255:
+                    message.defaultBytes = reader.bytes();
                     break;
                 case /* optional int32 fieldname1 */ 401:
                     message.fieldname1 = reader.int32();
@@ -2104,6 +2275,51 @@ class TestAllTypesProto2$Type extends MessageType<TestAllTypesProto2> {
         /* protobuf_test_messages.proto2.TestAllTypesProto2.NestedEnum oneof_enum = 119; */
         if (message.oneofField.oneofKind === "oneofEnum")
             writer.tag(119, WireType.Varint).int32(message.oneofField.oneofEnum);
+        /* optional int32 default_int32 = 241; */
+        if (message.defaultInt32 !== undefined)
+            writer.tag(241, WireType.Varint).int32(message.defaultInt32);
+        /* optional int64 default_int64 = 242; */
+        if (message.defaultInt64 !== undefined)
+            writer.tag(242, WireType.Varint).int64(message.defaultInt64);
+        /* optional uint32 default_uint32 = 243; */
+        if (message.defaultUint32 !== undefined)
+            writer.tag(243, WireType.Varint).uint32(message.defaultUint32);
+        /* optional uint64 default_uint64 = 244; */
+        if (message.defaultUint64 !== undefined)
+            writer.tag(244, WireType.Varint).uint64(message.defaultUint64);
+        /* optional sint32 default_sint32 = 245; */
+        if (message.defaultSint32 !== undefined)
+            writer.tag(245, WireType.Varint).sint32(message.defaultSint32);
+        /* optional sint64 default_sint64 = 246; */
+        if (message.defaultSint64 !== undefined)
+            writer.tag(246, WireType.Varint).sint64(message.defaultSint64);
+        /* optional fixed32 default_fixed32 = 247; */
+        if (message.defaultFixed32 !== undefined)
+            writer.tag(247, WireType.Bit32).fixed32(message.defaultFixed32);
+        /* optional fixed64 default_fixed64 = 248; */
+        if (message.defaultFixed64 !== undefined)
+            writer.tag(248, WireType.Bit64).fixed64(message.defaultFixed64);
+        /* optional sfixed32 default_sfixed32 = 249; */
+        if (message.defaultSfixed32 !== undefined)
+            writer.tag(249, WireType.Bit32).sfixed32(message.defaultSfixed32);
+        /* optional sfixed64 default_sfixed64 = 250; */
+        if (message.defaultSfixed64 !== undefined)
+            writer.tag(250, WireType.Bit64).sfixed64(message.defaultSfixed64);
+        /* optional float default_float = 251; */
+        if (message.defaultFloat !== undefined)
+            writer.tag(251, WireType.Bit32).float(message.defaultFloat);
+        /* optional double default_double = 252; */
+        if (message.defaultDouble !== undefined)
+            writer.tag(252, WireType.Bit64).double(message.defaultDouble);
+        /* optional bool default_bool = 253; */
+        if (message.defaultBool !== undefined)
+            writer.tag(253, WireType.Varint).bool(message.defaultBool);
+        /* optional string default_string = 254; */
+        if (message.defaultString !== undefined)
+            writer.tag(254, WireType.LengthDelimited).string(message.defaultString);
+        /* optional bytes default_bytes = 255; */
+        if (message.defaultBytes !== undefined)
+            writer.tag(255, WireType.LengthDelimited).bytes(message.defaultBytes);
         /* optional int32 fieldname1 = 401; */
         if (message.fieldname1 !== undefined)
             writer.tag(401, WireType.Varint).int32(message.fieldname1);
@@ -2569,3 +2785,163 @@ class UnknownToTestAllTypes_OptionalGroup$Type extends MessageType<UnknownToTest
  * @generated MessageType for protobuf message protobuf_test_messages.proto2.UnknownToTestAllTypes.OptionalGroup
  */
 export const UnknownToTestAllTypes_OptionalGroup = new UnknownToTestAllTypes_OptionalGroup$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class NullHypothesisProto2$Type extends MessageType<NullHypothesisProto2> {
+    constructor() {
+        super("protobuf_test_messages.proto2.NullHypothesisProto2", []);
+    }
+    create(value?: PartialMessage<NullHypothesisProto2>): NullHypothesisProto2 {
+        const message = {};
+        globalThis.Object.defineProperty(message, MESSAGE_TYPE, { enumerable: false, value: this });
+        if (value !== undefined)
+            reflectionMergePartial<NullHypothesisProto2>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: NullHypothesisProto2): NullHypothesisProto2 {
+        return target ?? this.create();
+    }
+    internalBinaryWrite(message: NullHypothesisProto2, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message protobuf_test_messages.proto2.NullHypothesisProto2
+ */
+export const NullHypothesisProto2 = new NullHypothesisProto2$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class EnumOnlyProto2$Type extends MessageType<EnumOnlyProto2> {
+    constructor() {
+        super("protobuf_test_messages.proto2.EnumOnlyProto2", []);
+    }
+    create(value?: PartialMessage<EnumOnlyProto2>): EnumOnlyProto2 {
+        const message = {};
+        globalThis.Object.defineProperty(message, MESSAGE_TYPE, { enumerable: false, value: this });
+        if (value !== undefined)
+            reflectionMergePartial<EnumOnlyProto2>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: EnumOnlyProto2): EnumOnlyProto2 {
+        return target ?? this.create();
+    }
+    internalBinaryWrite(message: EnumOnlyProto2, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message protobuf_test_messages.proto2.EnumOnlyProto2
+ */
+export const EnumOnlyProto2 = new EnumOnlyProto2$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class OneStringProto2$Type extends MessageType<OneStringProto2> {
+    constructor() {
+        super("protobuf_test_messages.proto2.OneStringProto2", [
+            { no: 1, name: "data", kind: "scalar", opt: true, T: 9 /*ScalarType.STRING*/ }
+        ]);
+    }
+    create(value?: PartialMessage<OneStringProto2>): OneStringProto2 {
+        const message = {};
+        globalThis.Object.defineProperty(message, MESSAGE_TYPE, { enumerable: false, value: this });
+        if (value !== undefined)
+            reflectionMergePartial<OneStringProto2>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: OneStringProto2): OneStringProto2 {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                case /* optional string data */ 1:
+                    message.data = reader.string();
+                    break;
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: OneStringProto2, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* optional string data = 1; */
+        if (message.data !== undefined)
+            writer.tag(1, WireType.LengthDelimited).string(message.data);
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message protobuf_test_messages.proto2.OneStringProto2
+ */
+export const OneStringProto2 = new OneStringProto2$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class ProtoWithKeywords$Type extends MessageType<ProtoWithKeywords> {
+    constructor() {
+        super("protobuf_test_messages.proto2.ProtoWithKeywords", [
+            { no: 1, name: "inline", kind: "scalar", opt: true, T: 5 /*ScalarType.INT32*/ },
+            { no: 2, name: "concept", kind: "scalar", opt: true, T: 9 /*ScalarType.STRING*/ },
+            { no: 3, name: "requires", kind: "scalar", repeat: 2 /*RepeatType.UNPACKED*/, T: 9 /*ScalarType.STRING*/ }
+        ]);
+    }
+    create(value?: PartialMessage<ProtoWithKeywords>): ProtoWithKeywords {
+        const message = { requires: [] };
+        globalThis.Object.defineProperty(message, MESSAGE_TYPE, { enumerable: false, value: this });
+        if (value !== undefined)
+            reflectionMergePartial<ProtoWithKeywords>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: ProtoWithKeywords): ProtoWithKeywords {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                case /* optional int32 inline */ 1:
+                    message.inline = reader.int32();
+                    break;
+                case /* optional string concept */ 2:
+                    message.concept = reader.string();
+                    break;
+                case /* repeated string requires */ 3:
+                    message.requires.push(reader.string());
+                    break;
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: ProtoWithKeywords, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* optional int32 inline = 1; */
+        if (message.inline !== undefined)
+            writer.tag(1, WireType.Varint).int32(message.inline);
+        /* optional string concept = 2; */
+        if (message.concept !== undefined)
+            writer.tag(2, WireType.LengthDelimited).string(message.concept);
+        /* repeated string requires = 3; */
+        for (let i = 0; i < message.requires.length; i++)
+            writer.tag(3, WireType.LengthDelimited).string(message.requires[i]);
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message protobuf_test_messages.proto2.ProtoWithKeywords
+ */
+export const ProtoWithKeywords = new ProtoWithKeywords$Type();

--- a/packages/test-conformance/src/gen/optimize_code_size-long_type_string/google/protobuf/test_messages_proto3.ts
+++ b/packages/test-conformance/src/gen/optimize_code_size-long_type_string/google/protobuf/test_messages_proto3.ts
@@ -65,6 +65,7 @@ import { UInt32Value } from "./wrappers";
 import { Int64Value } from "./wrappers";
 import { Int32Value } from "./wrappers";
 import { BoolValue } from "./wrappers";
+import { NullValue } from "./struct";
 /**
  * This proto includes every type of field in both singular and repeated
  * forms.
@@ -547,6 +548,12 @@ export interface TestAllTypesProto3 {
          */
         oneofEnum: TestAllTypesProto3_NestedEnum;
     } | {
+        oneofKind: "oneofNullValue";
+        /**
+         * @generated from protobuf field: google.protobuf.NullValue oneof_null_value = 120;
+         */
+        oneofNullValue: NullValue;
+    } | {
         oneofKind: undefined;
     };
     /**
@@ -647,6 +654,10 @@ export interface TestAllTypesProto3 {
      * @generated from protobuf field: google.protobuf.Value optional_value = 306;
      */
     optionalValue?: Value;
+    /**
+     * @generated from protobuf field: google.protobuf.NullValue optional_null_value = 307;
+     */
+    optionalNullValue: NullValue;
     /**
      * @generated from protobuf field: repeated google.protobuf.Duration repeated_duration = 311;
      */
@@ -806,11 +817,11 @@ export enum TestAllTypesProto3_AliasedEnum {
     /**
      * @generated from protobuf enum value: ALIAS_BAZ = 2;
      */
-    QUX = 2,
+    MOO = 2,
     /**
      * @generated from protobuf enum value: ALIAS_BAZ = 2;
      */
-    qux = 2,
+    moo = 2,
     /**
      * @generated from protobuf enum value: ALIAS_BAZ = 2;
      */
@@ -824,6 +835,29 @@ export interface ForeignMessage {
      * @generated from protobuf field: int32 c = 1;
      */
     c: number;
+}
+/**
+ * @generated from protobuf message protobuf_test_messages.proto3.NullHypothesisProto3
+ */
+export interface NullHypothesisProto3 {
+}
+/**
+ * @generated from protobuf message protobuf_test_messages.proto3.EnumOnlyProto3
+ */
+export interface EnumOnlyProto3 {
+}
+/**
+ * @generated from protobuf enum protobuf_test_messages.proto3.EnumOnlyProto3.Bool
+ */
+export enum EnumOnlyProto3_Bool {
+    /**
+     * @generated from protobuf enum value: kFalse = 0;
+     */
+    kFalse = 0,
+    /**
+     * @generated from protobuf enum value: kTrue = 1;
+     */
+    kTrue = 1
 }
 /**
  * @generated from protobuf enum protobuf_test_messages.proto3.ForeignEnum
@@ -946,6 +980,7 @@ class TestAllTypesProto3$Type extends MessageType<TestAllTypesProto3> {
             { no: 117, name: "oneof_float", kind: "scalar", oneof: "oneofField", T: 2 /*ScalarType.FLOAT*/ },
             { no: 118, name: "oneof_double", kind: "scalar", oneof: "oneofField", T: 1 /*ScalarType.DOUBLE*/ },
             { no: 119, name: "oneof_enum", kind: "enum", oneof: "oneofField", T: () => ["protobuf_test_messages.proto3.TestAllTypesProto3.NestedEnum", TestAllTypesProto3_NestedEnum] },
+            { no: 120, name: "oneof_null_value", kind: "enum", oneof: "oneofField", T: () => ["google.protobuf.NullValue", NullValue] },
             { no: 201, name: "optional_bool_wrapper", kind: "message", T: () => BoolValue },
             { no: 202, name: "optional_int32_wrapper", kind: "message", T: () => Int32Value },
             { no: 203, name: "optional_int64_wrapper", kind: "message", T: () => Int64Value },
@@ -970,6 +1005,7 @@ class TestAllTypesProto3$Type extends MessageType<TestAllTypesProto3> {
             { no: 304, name: "optional_struct", kind: "message", T: () => Struct },
             { no: 305, name: "optional_any", kind: "message", T: () => Any },
             { no: 306, name: "optional_value", kind: "message", T: () => Value },
+            { no: 307, name: "optional_null_value", kind: "enum", T: () => ["google.protobuf.NullValue", NullValue] },
             { no: 311, name: "repeated_duration", kind: "message", repeat: 1 /*RepeatType.PACKED*/, T: () => Duration },
             { no: 312, name: "repeated_timestamp", kind: "message", repeat: 1 /*RepeatType.PACKED*/, T: () => Timestamp },
             { no: 313, name: "repeated_fieldmask", kind: "message", repeat: 1 /*RepeatType.PACKED*/, T: () => FieldMask },
@@ -998,7 +1034,7 @@ class TestAllTypesProto3$Type extends MessageType<TestAllTypesProto3> {
         ]);
     }
     create(value?: PartialMessage<TestAllTypesProto3>): TestAllTypesProto3 {
-        const message = { optionalInt32: 0, optionalInt64: "0", optionalUint32: 0, optionalUint64: "0", optionalSint32: 0, optionalSint64: "0", optionalFixed32: 0, optionalFixed64: "0", optionalSfixed32: 0, optionalSfixed64: "0", optionalFloat: 0, optionalDouble: 0, optionalBool: false, optionalString: "", optionalBytes: new Uint8Array(0), optionalNestedEnum: 0, optionalForeignEnum: 0, optionalAliasedEnum: 0, optionalStringPiece: "", optionalCord: "", repeatedInt32: [], repeatedInt64: [], repeatedUint32: [], repeatedUint64: [], repeatedSint32: [], repeatedSint64: [], repeatedFixed32: [], repeatedFixed64: [], repeatedSfixed32: [], repeatedSfixed64: [], repeatedFloat: [], repeatedDouble: [], repeatedBool: [], repeatedString: [], repeatedBytes: [], repeatedNestedMessage: [], repeatedForeignMessage: [], repeatedNestedEnum: [], repeatedForeignEnum: [], repeatedStringPiece: [], repeatedCord: [], packedInt32: [], packedInt64: [], packedUint32: [], packedUint64: [], packedSint32: [], packedSint64: [], packedFixed32: [], packedFixed64: [], packedSfixed32: [], packedSfixed64: [], packedFloat: [], packedDouble: [], packedBool: [], packedNestedEnum: [], unpackedInt32: [], unpackedInt64: [], unpackedUint32: [], unpackedUint64: [], unpackedSint32: [], unpackedSint64: [], unpackedFixed32: [], unpackedFixed64: [], unpackedSfixed32: [], unpackedSfixed64: [], unpackedFloat: [], unpackedDouble: [], unpackedBool: [], unpackedNestedEnum: [], mapInt32Int32: {}, mapInt64Int64: {}, mapUint32Uint32: {}, mapUint64Uint64: {}, mapSint32Sint32: {}, mapSint64Sint64: {}, mapFixed32Fixed32: {}, mapFixed64Fixed64: {}, mapSfixed32Sfixed32: {}, mapSfixed64Sfixed64: {}, mapInt32Float: {}, mapInt32Double: {}, mapBoolBool: {}, mapStringString: {}, mapStringBytes: {}, mapStringNestedMessage: {}, mapStringForeignMessage: {}, mapStringNestedEnum: {}, mapStringForeignEnum: {}, oneofField: { oneofKind: undefined }, repeatedBoolWrapper: [], repeatedInt32Wrapper: [], repeatedInt64Wrapper: [], repeatedUint32Wrapper: [], repeatedUint64Wrapper: [], repeatedFloatWrapper: [], repeatedDoubleWrapper: [], repeatedStringWrapper: [], repeatedBytesWrapper: [], repeatedDuration: [], repeatedTimestamp: [], repeatedFieldmask: [], repeatedStruct: [], repeatedAny: [], repeatedValue: [], repeatedListValue: [], fieldname1: 0, fieldName2: 0, FieldName3: 0, fieldName4: 0, field0Name5: 0, field0Name6: 0, fieldName7: 0, fieldName8: 0, fieldName9: 0, fieldName10: 0, fIELDNAME11: 0, fIELDName12: 0, FieldName13: 0, FieldName14: 0, fieldName15: 0, fieldName16: 0, fieldName17: 0, fieldName18: 0 };
+        const message = { optionalInt32: 0, optionalInt64: "0", optionalUint32: 0, optionalUint64: "0", optionalSint32: 0, optionalSint64: "0", optionalFixed32: 0, optionalFixed64: "0", optionalSfixed32: 0, optionalSfixed64: "0", optionalFloat: 0, optionalDouble: 0, optionalBool: false, optionalString: "", optionalBytes: new Uint8Array(0), optionalNestedEnum: 0, optionalForeignEnum: 0, optionalAliasedEnum: 0, optionalStringPiece: "", optionalCord: "", repeatedInt32: [], repeatedInt64: [], repeatedUint32: [], repeatedUint64: [], repeatedSint32: [], repeatedSint64: [], repeatedFixed32: [], repeatedFixed64: [], repeatedSfixed32: [], repeatedSfixed64: [], repeatedFloat: [], repeatedDouble: [], repeatedBool: [], repeatedString: [], repeatedBytes: [], repeatedNestedMessage: [], repeatedForeignMessage: [], repeatedNestedEnum: [], repeatedForeignEnum: [], repeatedStringPiece: [], repeatedCord: [], packedInt32: [], packedInt64: [], packedUint32: [], packedUint64: [], packedSint32: [], packedSint64: [], packedFixed32: [], packedFixed64: [], packedSfixed32: [], packedSfixed64: [], packedFloat: [], packedDouble: [], packedBool: [], packedNestedEnum: [], unpackedInt32: [], unpackedInt64: [], unpackedUint32: [], unpackedUint64: [], unpackedSint32: [], unpackedSint64: [], unpackedFixed32: [], unpackedFixed64: [], unpackedSfixed32: [], unpackedSfixed64: [], unpackedFloat: [], unpackedDouble: [], unpackedBool: [], unpackedNestedEnum: [], mapInt32Int32: {}, mapInt64Int64: {}, mapUint32Uint32: {}, mapUint64Uint64: {}, mapSint32Sint32: {}, mapSint64Sint64: {}, mapFixed32Fixed32: {}, mapFixed64Fixed64: {}, mapSfixed32Sfixed32: {}, mapSfixed64Sfixed64: {}, mapInt32Float: {}, mapInt32Double: {}, mapBoolBool: {}, mapStringString: {}, mapStringBytes: {}, mapStringNestedMessage: {}, mapStringForeignMessage: {}, mapStringNestedEnum: {}, mapStringForeignEnum: {}, oneofField: { oneofKind: undefined }, repeatedBoolWrapper: [], repeatedInt32Wrapper: [], repeatedInt64Wrapper: [], repeatedUint32Wrapper: [], repeatedUint64Wrapper: [], repeatedFloatWrapper: [], repeatedDoubleWrapper: [], repeatedStringWrapper: [], repeatedBytesWrapper: [], optionalNullValue: 0, repeatedDuration: [], repeatedTimestamp: [], repeatedFieldmask: [], repeatedStruct: [], repeatedAny: [], repeatedValue: [], repeatedListValue: [], fieldname1: 0, fieldName2: 0, FieldName3: 0, fieldName4: 0, field0Name5: 0, field0Name6: 0, fieldName7: 0, fieldName8: 0, fieldName9: 0, fieldName10: 0, fIELDNAME11: 0, fIELDName12: 0, FieldName13: 0, FieldName14: 0, fieldName15: 0, fieldName16: 0, fieldName17: 0, fieldName18: 0 };
         globalThis.Object.defineProperty(message, MESSAGE_TYPE, { enumerable: false, value: this });
         if (value !== undefined)
             reflectionMergePartial<TestAllTypesProto3>(this, message, value);
@@ -1508,6 +1544,12 @@ class TestAllTypesProto3$Type extends MessageType<TestAllTypesProto3> {
                         oneofEnum: reader.int32()
                     };
                     break;
+                case /* google.protobuf.NullValue oneof_null_value */ 120:
+                    message.oneofField = {
+                        oneofKind: "oneofNullValue",
+                        oneofNullValue: reader.int32()
+                    };
+                    break;
                 case /* google.protobuf.BoolValue optional_bool_wrapper */ 201:
                     message.optionalBoolWrapper = BoolValue.internalBinaryRead(reader, reader.uint32(), options, message.optionalBoolWrapper);
                     break;
@@ -1579,6 +1621,9 @@ class TestAllTypesProto3$Type extends MessageType<TestAllTypesProto3> {
                     break;
                 case /* google.protobuf.Value optional_value */ 306:
                     message.optionalValue = Value.internalBinaryRead(reader, reader.uint32(), options, message.optionalValue);
+                    break;
+                case /* google.protobuf.NullValue optional_null_value */ 307:
+                    message.optionalNullValue = reader.int32();
                     break;
                 case /* repeated google.protobuf.Duration repeated_duration */ 311:
                     message.repeatedDuration.push(Duration.internalBinaryRead(reader, reader.uint32(), options));
@@ -2395,6 +2440,9 @@ class TestAllTypesProto3$Type extends MessageType<TestAllTypesProto3> {
         /* protobuf_test_messages.proto3.TestAllTypesProto3.NestedEnum oneof_enum = 119; */
         if (message.oneofField.oneofKind === "oneofEnum")
             writer.tag(119, WireType.Varint).int32(message.oneofField.oneofEnum);
+        /* google.protobuf.NullValue oneof_null_value = 120; */
+        if (message.oneofField.oneofKind === "oneofNullValue")
+            writer.tag(120, WireType.Varint).int32(message.oneofField.oneofNullValue);
         /* google.protobuf.BoolValue optional_bool_wrapper = 201; */
         if (message.optionalBoolWrapper)
             BoolValue.internalBinaryWrite(message.optionalBoolWrapper, writer.tag(201, WireType.LengthDelimited).fork(), options).join();
@@ -2467,6 +2515,9 @@ class TestAllTypesProto3$Type extends MessageType<TestAllTypesProto3> {
         /* google.protobuf.Value optional_value = 306; */
         if (message.optionalValue)
             Value.internalBinaryWrite(message.optionalValue, writer.tag(306, WireType.LengthDelimited).fork(), options).join();
+        /* google.protobuf.NullValue optional_null_value = 307; */
+        if (message.optionalNullValue !== 0)
+            writer.tag(307, WireType.Varint).int32(message.optionalNullValue);
         /* repeated google.protobuf.Duration repeated_duration = 311; */
         for (let i = 0; i < message.repeatedDuration.length; i++)
             Duration.internalBinaryWrite(message.repeatedDuration[i], writer.tag(311, WireType.LengthDelimited).fork(), options).join();
@@ -2653,3 +2704,55 @@ class ForeignMessage$Type extends MessageType<ForeignMessage> {
  * @generated MessageType for protobuf message protobuf_test_messages.proto3.ForeignMessage
  */
 export const ForeignMessage = new ForeignMessage$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class NullHypothesisProto3$Type extends MessageType<NullHypothesisProto3> {
+    constructor() {
+        super("protobuf_test_messages.proto3.NullHypothesisProto3", []);
+    }
+    create(value?: PartialMessage<NullHypothesisProto3>): NullHypothesisProto3 {
+        const message = {};
+        globalThis.Object.defineProperty(message, MESSAGE_TYPE, { enumerable: false, value: this });
+        if (value !== undefined)
+            reflectionMergePartial<NullHypothesisProto3>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: NullHypothesisProto3): NullHypothesisProto3 {
+        return target ?? this.create();
+    }
+    internalBinaryWrite(message: NullHypothesisProto3, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message protobuf_test_messages.proto3.NullHypothesisProto3
+ */
+export const NullHypothesisProto3 = new NullHypothesisProto3$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class EnumOnlyProto3$Type extends MessageType<EnumOnlyProto3> {
+    constructor() {
+        super("protobuf_test_messages.proto3.EnumOnlyProto3", []);
+    }
+    create(value?: PartialMessage<EnumOnlyProto3>): EnumOnlyProto3 {
+        const message = {};
+        globalThis.Object.defineProperty(message, MESSAGE_TYPE, { enumerable: false, value: this });
+        if (value !== undefined)
+            reflectionMergePartial<EnumOnlyProto3>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: EnumOnlyProto3): EnumOnlyProto3 {
+        return target ?? this.create();
+    }
+    internalBinaryWrite(message: EnumOnlyProto3, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message protobuf_test_messages.proto3.EnumOnlyProto3
+ */
+export const EnumOnlyProto3 = new EnumOnlyProto3$Type();

--- a/packages/test-conformance/src/gen/optimize_speed-long_type_bigint/conformance/conformance.ts
+++ b/packages/test-conformance/src/gen/optimize_speed-long_type_bigint/conformance/conformance.ts
@@ -83,7 +83,7 @@ export interface ConformanceRequest {
     } | {
         oneofKind: "jspbPayload";
         /**
-         * Google internal only.  Opensource testees just skip it.
+         * Only used inside Google.  Opensource testees just skip it.
          *
          * @generated from protobuf field: string jspb_payload = 7;
          */
@@ -106,15 +106,15 @@ export interface ConformanceRequest {
     /**
      * The full name for the test message to use; for the moment, either:
      * protobuf_test_messages.proto3.TestAllTypesProto3 or
-     * protobuf_test_messages.proto2.TestAllTypesProto2.
+     * protobuf_test_messages.google.protobuf.TestAllTypesProto2.
      *
      * @generated from protobuf field: string message_type = 4;
      */
     messageType: string;
     /**
      * Each test is given a specific test category. Some category may need
-     * specific support in testee programs. Refer to the definition of TestCategory
-     * for more information.
+     * specific support in testee programs. Refer to the definition of
+     * TestCategory for more information.
      *
      * @generated from protobuf field: conformance.TestCategory test_category = 5;
      */
@@ -165,6 +165,16 @@ export interface ConformanceResponse {
          */
         serializeError: string;
     } | {
+        oneofKind: "timeoutError";
+        /**
+         * This should be set if the test program timed out.  The string should
+         * provide more information about what the child process was doing when it
+         * was killed.
+         *
+         * @generated from protobuf field: string timeout_error = 9;
+         */
+        timeoutError: string;
+    } | {
         oneofKind: "runtimeError";
         /**
          * This should be set if some other error occurred.  This will always
@@ -205,8 +215,8 @@ export interface ConformanceResponse {
         oneofKind: "jspbPayload";
         /**
          * If the input was successfully parsed and the requested output was JSPB,
-         * serialize to JSPB and set it in this field. JSPB is google internal only
-         * format. Opensource testees can just skip it.
+         * serialize to JSPB and set it in this field. JSPB is only used inside
+         * Google. Opensource testees can just skip it.
          *
          * @generated from protobuf field: string jspb_payload = 7;
          */
@@ -273,7 +283,7 @@ export enum WireFormat {
      */
     JSON = 2,
     /**
-     * Google internal only. Opensource testees just skip it.
+     * Only used inside Google. Opensource testees just skip it.
      *
      * @generated from protobuf enum value: JSPB = 3;
      */
@@ -314,7 +324,8 @@ export enum TestCategory {
      */
     JSON_IGNORE_UNKNOWN_PARSING_TEST = 3,
     /**
-     * Test jspb wire format. Google internal only. Opensource testees just skip it.
+     * Test jspb wire format. Only used inside Google. Opensource testees just
+     * skip it.
      *
      * @generated from protobuf enum value: JSPB_TEST = 4;
      */
@@ -495,6 +506,7 @@ class ConformanceResponse$Type extends MessageType<ConformanceResponse> {
         super("conformance.ConformanceResponse", [
             { no: 1, name: "parse_error", kind: "scalar", oneof: "result", T: 9 /*ScalarType.STRING*/ },
             { no: 6, name: "serialize_error", kind: "scalar", oneof: "result", T: 9 /*ScalarType.STRING*/ },
+            { no: 9, name: "timeout_error", kind: "scalar", oneof: "result", T: 9 /*ScalarType.STRING*/ },
             { no: 2, name: "runtime_error", kind: "scalar", oneof: "result", T: 9 /*ScalarType.STRING*/ },
             { no: 3, name: "protobuf_payload", kind: "scalar", oneof: "result", T: 12 /*ScalarType.BYTES*/ },
             { no: 4, name: "json_payload", kind: "scalar", oneof: "result", T: 9 /*ScalarType.STRING*/ },
@@ -525,6 +537,12 @@ class ConformanceResponse$Type extends MessageType<ConformanceResponse> {
                     message.result = {
                         oneofKind: "serializeError",
                         serializeError: reader.string()
+                    };
+                    break;
+                case /* string timeout_error */ 9:
+                    message.result = {
+                        oneofKind: "timeoutError",
+                        timeoutError: reader.string()
                     };
                     break;
                 case /* string runtime_error */ 2:
@@ -581,6 +599,9 @@ class ConformanceResponse$Type extends MessageType<ConformanceResponse> {
         /* string serialize_error = 6; */
         if (message.result.oneofKind === "serializeError")
             writer.tag(6, WireType.LengthDelimited).string(message.result.serializeError);
+        /* string timeout_error = 9; */
+        if (message.result.oneofKind === "timeoutError")
+            writer.tag(9, WireType.LengthDelimited).string(message.result.timeoutError);
         /* string runtime_error = 2; */
         if (message.result.oneofKind === "runtimeError")
             writer.tag(2, WireType.LengthDelimited).string(message.result.runtimeError);

--- a/packages/test-conformance/src/gen/optimize_speed-long_type_bigint/google/protobuf/duration.ts
+++ b/packages/test-conformance/src/gen/optimize_speed-long_type_bigint/google/protobuf/duration.ts
@@ -147,6 +147,8 @@ class Duration$Type extends MessageType<Duration> {
         if (s > 315576000000 || s < -315576000000)
             throw new Error("Duration value out of range.");
         let text = message.seconds.toString();
+        if (s === 0 && message.nanos < 0)
+            text = "-" + text;
         if (message.nanos !== 0) {
             let nanosStr = Math.abs(message.nanos).toString();
             nanosStr = "0".repeat(9 - nanosStr.length) + nanosStr;
@@ -164,21 +166,19 @@ class Duration$Type extends MessageType<Duration> {
     internalJsonRead(json: JsonValue, options: JsonReadOptions, target?: Duration): Duration {
         if (typeof json !== "string")
             throw new Error("Unable to parse Duration from JSON " + typeofJsonValue(json) + ". Expected string.");
-        let match = json.match(/^(-?[0-9]+)(?:\.([0-9]+))?s/);
+        let match = json.match(/^(-?)([0-9]+)(?:\.([0-9]+))?s/);
         if (match === null)
             throw new Error("Unable to parse Duration from JSON string. Invalid format.");
         if (!target)
             target = this.create();
-        let longSeconds = PbLong.from(match[1]);
+        let [, sign, secs, nanos] = match;
+        let longSeconds = PbLong.from(sign + secs);
         if (longSeconds.toNumber() > 315576000000 || longSeconds.toNumber() < -315576000000)
             throw new Error("Unable to parse Duration from JSON string. Value out of range.");
         target.seconds = longSeconds.toBigInt();
-        if (typeof match[2] == "string") {
-            let nanosStr = match[2] + "0".repeat(9 - match[2].length);
+        if (typeof nanos == "string") {
+            let nanosStr = sign + nanos + "0".repeat(9 - nanos.length);
             target.nanos = parseInt(nanosStr);
-            if (longSeconds.isNegative()) {
-                target.nanos = -target.nanos;
-            }
         }
         return target;
     }

--- a/packages/test-conformance/src/gen/optimize_speed-long_type_bigint/google/protobuf/struct.ts
+++ b/packages/test-conformance/src/gen/optimize_speed-long_type_bigint/google/protobuf/struct.ts
@@ -279,7 +279,11 @@ class Value$Type extends MessageType<Value> {
             case undefined: throw new globalThis.Error();
             case "boolValue": return message.kind.boolValue;
             case "nullValue": return null;
-            case "numberValue": return message.kind.numberValue;
+            case "numberValue":
+                let numberValue = message.kind.numberValue;
+                if (typeof numberValue == "number" && !Number.isFinite(numberValue))
+                    throw new globalThis.Error();
+                return numberValue;
             case "stringValue": return message.kind.stringValue;
             case "listValue":
                 let listValueField = this.fields.find(f => f.no === 6);

--- a/packages/test-conformance/src/gen/optimize_speed-long_type_bigint/google/protobuf/test_messages_proto2.ts
+++ b/packages/test-conformance/src/gen/optimize_speed-long_type_bigint/google/protobuf/test_messages_proto2.ts
@@ -531,6 +531,68 @@ export interface TestAllTypesProto2 {
         oneofKind: undefined;
     };
     /**
+     * default values
+     *
+     * @generated from protobuf field: optional int32 default_int32 = 241;
+     */
+    defaultInt32?: number;
+    /**
+     * @generated from protobuf field: optional int64 default_int64 = 242;
+     */
+    defaultInt64?: bigint;
+    /**
+     * @generated from protobuf field: optional uint32 default_uint32 = 243;
+     */
+    defaultUint32?: number;
+    /**
+     * @generated from protobuf field: optional uint64 default_uint64 = 244;
+     */
+    defaultUint64?: bigint;
+    /**
+     * @generated from protobuf field: optional sint32 default_sint32 = 245;
+     */
+    defaultSint32?: number;
+    /**
+     * @generated from protobuf field: optional sint64 default_sint64 = 246;
+     */
+    defaultSint64?: bigint;
+    /**
+     * @generated from protobuf field: optional fixed32 default_fixed32 = 247;
+     */
+    defaultFixed32?: number;
+    /**
+     * @generated from protobuf field: optional fixed64 default_fixed64 = 248;
+     */
+    defaultFixed64?: bigint;
+    /**
+     * @generated from protobuf field: optional sfixed32 default_sfixed32 = 249;
+     */
+    defaultSfixed32?: number;
+    /**
+     * @generated from protobuf field: optional sfixed64 default_sfixed64 = 250;
+     */
+    defaultSfixed64?: bigint;
+    /**
+     * @generated from protobuf field: optional float default_float = 251;
+     */
+    defaultFloat?: number;
+    /**
+     * @generated from protobuf field: optional double default_double = 252;
+     */
+    defaultDouble?: number;
+    /**
+     * @generated from protobuf field: optional bool default_bool = 253;
+     */
+    defaultBool?: boolean;
+    /**
+     * @generated from protobuf field: optional string default_string = 254;
+     */
+    defaultString?: string;
+    /**
+     * @generated from protobuf field: optional bytes default_bytes = 255;
+     */
+    defaultBytes?: Uint8Array;
+    /**
      * Test field-name-to-JSON-name convention.
      * (protobuf says names can be any valid C/C++ identifier.)
      *
@@ -726,6 +788,55 @@ export interface UnknownToTestAllTypes_OptionalGroup {
     a?: number;
 }
 /**
+ * @generated from protobuf message protobuf_test_messages.proto2.NullHypothesisProto2
+ */
+export interface NullHypothesisProto2 {
+}
+/**
+ * @generated from protobuf message protobuf_test_messages.proto2.EnumOnlyProto2
+ */
+export interface EnumOnlyProto2 {
+}
+/**
+ * @generated from protobuf enum protobuf_test_messages.proto2.EnumOnlyProto2.Bool
+ */
+export enum EnumOnlyProto2_Bool {
+    /**
+     * @generated from protobuf enum value: kFalse = 0;
+     */
+    kFalse = 0,
+    /**
+     * @generated from protobuf enum value: kTrue = 1;
+     */
+    kTrue = 1
+}
+/**
+ * @generated from protobuf message protobuf_test_messages.proto2.OneStringProto2
+ */
+export interface OneStringProto2 {
+    /**
+     * @generated from protobuf field: optional string data = 1;
+     */
+    data?: string;
+}
+/**
+ * @generated from protobuf message protobuf_test_messages.proto2.ProtoWithKeywords
+ */
+export interface ProtoWithKeywords {
+    /**
+     * @generated from protobuf field: optional int32 inline = 1;
+     */
+    inline?: number;
+    /**
+     * @generated from protobuf field: optional string concept = 2;
+     */
+    concept?: string;
+    /**
+     * @generated from protobuf field: repeated string requires = 3;
+     */
+    requires: string[];
+}
+/**
  * @generated from protobuf enum protobuf_test_messages.proto2.ForeignEnumProto2
  */
 export enum ForeignEnumProto2 {
@@ -845,6 +956,21 @@ class TestAllTypesProto2$Type extends MessageType<TestAllTypesProto2> {
             { no: 117, name: "oneof_float", kind: "scalar", oneof: "oneofField", T: 2 /*ScalarType.FLOAT*/ },
             { no: 118, name: "oneof_double", kind: "scalar", oneof: "oneofField", T: 1 /*ScalarType.DOUBLE*/ },
             { no: 119, name: "oneof_enum", kind: "enum", oneof: "oneofField", T: () => ["protobuf_test_messages.proto2.TestAllTypesProto2.NestedEnum", TestAllTypesProto2_NestedEnum] },
+            { no: 241, name: "default_int32", kind: "scalar", opt: true, T: 5 /*ScalarType.INT32*/ },
+            { no: 242, name: "default_int64", kind: "scalar", opt: true, T: 3 /*ScalarType.INT64*/, L: 0 /*LongType.BIGINT*/ },
+            { no: 243, name: "default_uint32", kind: "scalar", opt: true, T: 13 /*ScalarType.UINT32*/ },
+            { no: 244, name: "default_uint64", kind: "scalar", opt: true, T: 4 /*ScalarType.UINT64*/, L: 0 /*LongType.BIGINT*/ },
+            { no: 245, name: "default_sint32", kind: "scalar", opt: true, T: 17 /*ScalarType.SINT32*/ },
+            { no: 246, name: "default_sint64", kind: "scalar", opt: true, T: 18 /*ScalarType.SINT64*/, L: 0 /*LongType.BIGINT*/ },
+            { no: 247, name: "default_fixed32", kind: "scalar", opt: true, T: 7 /*ScalarType.FIXED32*/ },
+            { no: 248, name: "default_fixed64", kind: "scalar", opt: true, T: 6 /*ScalarType.FIXED64*/, L: 0 /*LongType.BIGINT*/ },
+            { no: 249, name: "default_sfixed32", kind: "scalar", opt: true, T: 15 /*ScalarType.SFIXED32*/ },
+            { no: 250, name: "default_sfixed64", kind: "scalar", opt: true, T: 16 /*ScalarType.SFIXED64*/, L: 0 /*LongType.BIGINT*/ },
+            { no: 251, name: "default_float", kind: "scalar", opt: true, T: 2 /*ScalarType.FLOAT*/ },
+            { no: 252, name: "default_double", kind: "scalar", opt: true, T: 1 /*ScalarType.DOUBLE*/ },
+            { no: 253, name: "default_bool", kind: "scalar", opt: true, T: 8 /*ScalarType.BOOL*/ },
+            { no: 254, name: "default_string", kind: "scalar", opt: true, T: 9 /*ScalarType.STRING*/ },
+            { no: 255, name: "default_bytes", kind: "scalar", opt: true, T: 12 /*ScalarType.BYTES*/ },
             { no: 401, name: "fieldname1", kind: "scalar", opt: true, T: 5 /*ScalarType.INT32*/ },
             { no: 402, name: "field_name2", kind: "scalar", opt: true, T: 5 /*ScalarType.INT32*/ },
             { no: 403, name: "_field_name3", kind: "scalar", opt: true, T: 5 /*ScalarType.INT32*/ },
@@ -1372,6 +1498,51 @@ class TestAllTypesProto2$Type extends MessageType<TestAllTypesProto2> {
                         oneofKind: "oneofEnum",
                         oneofEnum: reader.int32()
                     };
+                    break;
+                case /* optional int32 default_int32 */ 241:
+                    message.defaultInt32 = reader.int32();
+                    break;
+                case /* optional int64 default_int64 */ 242:
+                    message.defaultInt64 = reader.int64().toBigInt();
+                    break;
+                case /* optional uint32 default_uint32 */ 243:
+                    message.defaultUint32 = reader.uint32();
+                    break;
+                case /* optional uint64 default_uint64 */ 244:
+                    message.defaultUint64 = reader.uint64().toBigInt();
+                    break;
+                case /* optional sint32 default_sint32 */ 245:
+                    message.defaultSint32 = reader.sint32();
+                    break;
+                case /* optional sint64 default_sint64 */ 246:
+                    message.defaultSint64 = reader.sint64().toBigInt();
+                    break;
+                case /* optional fixed32 default_fixed32 */ 247:
+                    message.defaultFixed32 = reader.fixed32();
+                    break;
+                case /* optional fixed64 default_fixed64 */ 248:
+                    message.defaultFixed64 = reader.fixed64().toBigInt();
+                    break;
+                case /* optional sfixed32 default_sfixed32 */ 249:
+                    message.defaultSfixed32 = reader.sfixed32();
+                    break;
+                case /* optional sfixed64 default_sfixed64 */ 250:
+                    message.defaultSfixed64 = reader.sfixed64().toBigInt();
+                    break;
+                case /* optional float default_float */ 251:
+                    message.defaultFloat = reader.float();
+                    break;
+                case /* optional double default_double */ 252:
+                    message.defaultDouble = reader.double();
+                    break;
+                case /* optional bool default_bool */ 253:
+                    message.defaultBool = reader.bool();
+                    break;
+                case /* optional string default_string */ 254:
+                    message.defaultString = reader.string();
+                    break;
+                case /* optional bytes default_bytes */ 255:
+                    message.defaultBytes = reader.bytes();
                     break;
                 case /* optional int32 fieldname1 */ 401:
                     message.fieldname1 = reader.int32();
@@ -2104,6 +2275,51 @@ class TestAllTypesProto2$Type extends MessageType<TestAllTypesProto2> {
         /* protobuf_test_messages.proto2.TestAllTypesProto2.NestedEnum oneof_enum = 119; */
         if (message.oneofField.oneofKind === "oneofEnum")
             writer.tag(119, WireType.Varint).int32(message.oneofField.oneofEnum);
+        /* optional int32 default_int32 = 241; */
+        if (message.defaultInt32 !== undefined)
+            writer.tag(241, WireType.Varint).int32(message.defaultInt32);
+        /* optional int64 default_int64 = 242; */
+        if (message.defaultInt64 !== undefined)
+            writer.tag(242, WireType.Varint).int64(message.defaultInt64);
+        /* optional uint32 default_uint32 = 243; */
+        if (message.defaultUint32 !== undefined)
+            writer.tag(243, WireType.Varint).uint32(message.defaultUint32);
+        /* optional uint64 default_uint64 = 244; */
+        if (message.defaultUint64 !== undefined)
+            writer.tag(244, WireType.Varint).uint64(message.defaultUint64);
+        /* optional sint32 default_sint32 = 245; */
+        if (message.defaultSint32 !== undefined)
+            writer.tag(245, WireType.Varint).sint32(message.defaultSint32);
+        /* optional sint64 default_sint64 = 246; */
+        if (message.defaultSint64 !== undefined)
+            writer.tag(246, WireType.Varint).sint64(message.defaultSint64);
+        /* optional fixed32 default_fixed32 = 247; */
+        if (message.defaultFixed32 !== undefined)
+            writer.tag(247, WireType.Bit32).fixed32(message.defaultFixed32);
+        /* optional fixed64 default_fixed64 = 248; */
+        if (message.defaultFixed64 !== undefined)
+            writer.tag(248, WireType.Bit64).fixed64(message.defaultFixed64);
+        /* optional sfixed32 default_sfixed32 = 249; */
+        if (message.defaultSfixed32 !== undefined)
+            writer.tag(249, WireType.Bit32).sfixed32(message.defaultSfixed32);
+        /* optional sfixed64 default_sfixed64 = 250; */
+        if (message.defaultSfixed64 !== undefined)
+            writer.tag(250, WireType.Bit64).sfixed64(message.defaultSfixed64);
+        /* optional float default_float = 251; */
+        if (message.defaultFloat !== undefined)
+            writer.tag(251, WireType.Bit32).float(message.defaultFloat);
+        /* optional double default_double = 252; */
+        if (message.defaultDouble !== undefined)
+            writer.tag(252, WireType.Bit64).double(message.defaultDouble);
+        /* optional bool default_bool = 253; */
+        if (message.defaultBool !== undefined)
+            writer.tag(253, WireType.Varint).bool(message.defaultBool);
+        /* optional string default_string = 254; */
+        if (message.defaultString !== undefined)
+            writer.tag(254, WireType.LengthDelimited).string(message.defaultString);
+        /* optional bytes default_bytes = 255; */
+        if (message.defaultBytes !== undefined)
+            writer.tag(255, WireType.LengthDelimited).bytes(message.defaultBytes);
         /* optional int32 fieldname1 = 401; */
         if (message.fieldname1 !== undefined)
             writer.tag(401, WireType.Varint).int32(message.fieldname1);
@@ -2569,3 +2785,163 @@ class UnknownToTestAllTypes_OptionalGroup$Type extends MessageType<UnknownToTest
  * @generated MessageType for protobuf message protobuf_test_messages.proto2.UnknownToTestAllTypes.OptionalGroup
  */
 export const UnknownToTestAllTypes_OptionalGroup = new UnknownToTestAllTypes_OptionalGroup$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class NullHypothesisProto2$Type extends MessageType<NullHypothesisProto2> {
+    constructor() {
+        super("protobuf_test_messages.proto2.NullHypothesisProto2", []);
+    }
+    create(value?: PartialMessage<NullHypothesisProto2>): NullHypothesisProto2 {
+        const message = {};
+        globalThis.Object.defineProperty(message, MESSAGE_TYPE, { enumerable: false, value: this });
+        if (value !== undefined)
+            reflectionMergePartial<NullHypothesisProto2>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: NullHypothesisProto2): NullHypothesisProto2 {
+        return target ?? this.create();
+    }
+    internalBinaryWrite(message: NullHypothesisProto2, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message protobuf_test_messages.proto2.NullHypothesisProto2
+ */
+export const NullHypothesisProto2 = new NullHypothesisProto2$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class EnumOnlyProto2$Type extends MessageType<EnumOnlyProto2> {
+    constructor() {
+        super("protobuf_test_messages.proto2.EnumOnlyProto2", []);
+    }
+    create(value?: PartialMessage<EnumOnlyProto2>): EnumOnlyProto2 {
+        const message = {};
+        globalThis.Object.defineProperty(message, MESSAGE_TYPE, { enumerable: false, value: this });
+        if (value !== undefined)
+            reflectionMergePartial<EnumOnlyProto2>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: EnumOnlyProto2): EnumOnlyProto2 {
+        return target ?? this.create();
+    }
+    internalBinaryWrite(message: EnumOnlyProto2, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message protobuf_test_messages.proto2.EnumOnlyProto2
+ */
+export const EnumOnlyProto2 = new EnumOnlyProto2$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class OneStringProto2$Type extends MessageType<OneStringProto2> {
+    constructor() {
+        super("protobuf_test_messages.proto2.OneStringProto2", [
+            { no: 1, name: "data", kind: "scalar", opt: true, T: 9 /*ScalarType.STRING*/ }
+        ]);
+    }
+    create(value?: PartialMessage<OneStringProto2>): OneStringProto2 {
+        const message = {};
+        globalThis.Object.defineProperty(message, MESSAGE_TYPE, { enumerable: false, value: this });
+        if (value !== undefined)
+            reflectionMergePartial<OneStringProto2>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: OneStringProto2): OneStringProto2 {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                case /* optional string data */ 1:
+                    message.data = reader.string();
+                    break;
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: OneStringProto2, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* optional string data = 1; */
+        if (message.data !== undefined)
+            writer.tag(1, WireType.LengthDelimited).string(message.data);
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message protobuf_test_messages.proto2.OneStringProto2
+ */
+export const OneStringProto2 = new OneStringProto2$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class ProtoWithKeywords$Type extends MessageType<ProtoWithKeywords> {
+    constructor() {
+        super("protobuf_test_messages.proto2.ProtoWithKeywords", [
+            { no: 1, name: "inline", kind: "scalar", opt: true, T: 5 /*ScalarType.INT32*/ },
+            { no: 2, name: "concept", kind: "scalar", opt: true, T: 9 /*ScalarType.STRING*/ },
+            { no: 3, name: "requires", kind: "scalar", repeat: 2 /*RepeatType.UNPACKED*/, T: 9 /*ScalarType.STRING*/ }
+        ]);
+    }
+    create(value?: PartialMessage<ProtoWithKeywords>): ProtoWithKeywords {
+        const message = { requires: [] };
+        globalThis.Object.defineProperty(message, MESSAGE_TYPE, { enumerable: false, value: this });
+        if (value !== undefined)
+            reflectionMergePartial<ProtoWithKeywords>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: ProtoWithKeywords): ProtoWithKeywords {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                case /* optional int32 inline */ 1:
+                    message.inline = reader.int32();
+                    break;
+                case /* optional string concept */ 2:
+                    message.concept = reader.string();
+                    break;
+                case /* repeated string requires */ 3:
+                    message.requires.push(reader.string());
+                    break;
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: ProtoWithKeywords, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* optional int32 inline = 1; */
+        if (message.inline !== undefined)
+            writer.tag(1, WireType.Varint).int32(message.inline);
+        /* optional string concept = 2; */
+        if (message.concept !== undefined)
+            writer.tag(2, WireType.LengthDelimited).string(message.concept);
+        /* repeated string requires = 3; */
+        for (let i = 0; i < message.requires.length; i++)
+            writer.tag(3, WireType.LengthDelimited).string(message.requires[i]);
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message protobuf_test_messages.proto2.ProtoWithKeywords
+ */
+export const ProtoWithKeywords = new ProtoWithKeywords$Type();

--- a/packages/test-conformance/src/gen/optimize_speed-long_type_bigint/google/protobuf/test_messages_proto3.ts
+++ b/packages/test-conformance/src/gen/optimize_speed-long_type_bigint/google/protobuf/test_messages_proto3.ts
@@ -65,6 +65,7 @@ import { UInt32Value } from "./wrappers";
 import { Int64Value } from "./wrappers";
 import { Int32Value } from "./wrappers";
 import { BoolValue } from "./wrappers";
+import { NullValue } from "./struct";
 /**
  * This proto includes every type of field in both singular and repeated
  * forms.
@@ -547,6 +548,12 @@ export interface TestAllTypesProto3 {
          */
         oneofEnum: TestAllTypesProto3_NestedEnum;
     } | {
+        oneofKind: "oneofNullValue";
+        /**
+         * @generated from protobuf field: google.protobuf.NullValue oneof_null_value = 120;
+         */
+        oneofNullValue: NullValue;
+    } | {
         oneofKind: undefined;
     };
     /**
@@ -647,6 +654,10 @@ export interface TestAllTypesProto3 {
      * @generated from protobuf field: google.protobuf.Value optional_value = 306;
      */
     optionalValue?: Value;
+    /**
+     * @generated from protobuf field: google.protobuf.NullValue optional_null_value = 307;
+     */
+    optionalNullValue: NullValue;
     /**
      * @generated from protobuf field: repeated google.protobuf.Duration repeated_duration = 311;
      */
@@ -806,11 +817,11 @@ export enum TestAllTypesProto3_AliasedEnum {
     /**
      * @generated from protobuf enum value: ALIAS_BAZ = 2;
      */
-    QUX = 2,
+    MOO = 2,
     /**
      * @generated from protobuf enum value: ALIAS_BAZ = 2;
      */
-    qux = 2,
+    moo = 2,
     /**
      * @generated from protobuf enum value: ALIAS_BAZ = 2;
      */
@@ -824,6 +835,29 @@ export interface ForeignMessage {
      * @generated from protobuf field: int32 c = 1;
      */
     c: number;
+}
+/**
+ * @generated from protobuf message protobuf_test_messages.proto3.NullHypothesisProto3
+ */
+export interface NullHypothesisProto3 {
+}
+/**
+ * @generated from protobuf message protobuf_test_messages.proto3.EnumOnlyProto3
+ */
+export interface EnumOnlyProto3 {
+}
+/**
+ * @generated from protobuf enum protobuf_test_messages.proto3.EnumOnlyProto3.Bool
+ */
+export enum EnumOnlyProto3_Bool {
+    /**
+     * @generated from protobuf enum value: kFalse = 0;
+     */
+    kFalse = 0,
+    /**
+     * @generated from protobuf enum value: kTrue = 1;
+     */
+    kTrue = 1
 }
 /**
  * @generated from protobuf enum protobuf_test_messages.proto3.ForeignEnum
@@ -946,6 +980,7 @@ class TestAllTypesProto3$Type extends MessageType<TestAllTypesProto3> {
             { no: 117, name: "oneof_float", kind: "scalar", oneof: "oneofField", T: 2 /*ScalarType.FLOAT*/ },
             { no: 118, name: "oneof_double", kind: "scalar", oneof: "oneofField", T: 1 /*ScalarType.DOUBLE*/ },
             { no: 119, name: "oneof_enum", kind: "enum", oneof: "oneofField", T: () => ["protobuf_test_messages.proto3.TestAllTypesProto3.NestedEnum", TestAllTypesProto3_NestedEnum] },
+            { no: 120, name: "oneof_null_value", kind: "enum", oneof: "oneofField", T: () => ["google.protobuf.NullValue", NullValue] },
             { no: 201, name: "optional_bool_wrapper", kind: "message", T: () => BoolValue },
             { no: 202, name: "optional_int32_wrapper", kind: "message", T: () => Int32Value },
             { no: 203, name: "optional_int64_wrapper", kind: "message", T: () => Int64Value },
@@ -970,6 +1005,7 @@ class TestAllTypesProto3$Type extends MessageType<TestAllTypesProto3> {
             { no: 304, name: "optional_struct", kind: "message", T: () => Struct },
             { no: 305, name: "optional_any", kind: "message", T: () => Any },
             { no: 306, name: "optional_value", kind: "message", T: () => Value },
+            { no: 307, name: "optional_null_value", kind: "enum", T: () => ["google.protobuf.NullValue", NullValue] },
             { no: 311, name: "repeated_duration", kind: "message", repeat: 1 /*RepeatType.PACKED*/, T: () => Duration },
             { no: 312, name: "repeated_timestamp", kind: "message", repeat: 1 /*RepeatType.PACKED*/, T: () => Timestamp },
             { no: 313, name: "repeated_fieldmask", kind: "message", repeat: 1 /*RepeatType.PACKED*/, T: () => FieldMask },
@@ -998,7 +1034,7 @@ class TestAllTypesProto3$Type extends MessageType<TestAllTypesProto3> {
         ]);
     }
     create(value?: PartialMessage<TestAllTypesProto3>): TestAllTypesProto3 {
-        const message = { optionalInt32: 0, optionalInt64: 0n, optionalUint32: 0, optionalUint64: 0n, optionalSint32: 0, optionalSint64: 0n, optionalFixed32: 0, optionalFixed64: 0n, optionalSfixed32: 0, optionalSfixed64: 0n, optionalFloat: 0, optionalDouble: 0, optionalBool: false, optionalString: "", optionalBytes: new Uint8Array(0), optionalNestedEnum: 0, optionalForeignEnum: 0, optionalAliasedEnum: 0, optionalStringPiece: "", optionalCord: "", repeatedInt32: [], repeatedInt64: [], repeatedUint32: [], repeatedUint64: [], repeatedSint32: [], repeatedSint64: [], repeatedFixed32: [], repeatedFixed64: [], repeatedSfixed32: [], repeatedSfixed64: [], repeatedFloat: [], repeatedDouble: [], repeatedBool: [], repeatedString: [], repeatedBytes: [], repeatedNestedMessage: [], repeatedForeignMessage: [], repeatedNestedEnum: [], repeatedForeignEnum: [], repeatedStringPiece: [], repeatedCord: [], packedInt32: [], packedInt64: [], packedUint32: [], packedUint64: [], packedSint32: [], packedSint64: [], packedFixed32: [], packedFixed64: [], packedSfixed32: [], packedSfixed64: [], packedFloat: [], packedDouble: [], packedBool: [], packedNestedEnum: [], unpackedInt32: [], unpackedInt64: [], unpackedUint32: [], unpackedUint64: [], unpackedSint32: [], unpackedSint64: [], unpackedFixed32: [], unpackedFixed64: [], unpackedSfixed32: [], unpackedSfixed64: [], unpackedFloat: [], unpackedDouble: [], unpackedBool: [], unpackedNestedEnum: [], mapInt32Int32: {}, mapInt64Int64: {}, mapUint32Uint32: {}, mapUint64Uint64: {}, mapSint32Sint32: {}, mapSint64Sint64: {}, mapFixed32Fixed32: {}, mapFixed64Fixed64: {}, mapSfixed32Sfixed32: {}, mapSfixed64Sfixed64: {}, mapInt32Float: {}, mapInt32Double: {}, mapBoolBool: {}, mapStringString: {}, mapStringBytes: {}, mapStringNestedMessage: {}, mapStringForeignMessage: {}, mapStringNestedEnum: {}, mapStringForeignEnum: {}, oneofField: { oneofKind: undefined }, repeatedBoolWrapper: [], repeatedInt32Wrapper: [], repeatedInt64Wrapper: [], repeatedUint32Wrapper: [], repeatedUint64Wrapper: [], repeatedFloatWrapper: [], repeatedDoubleWrapper: [], repeatedStringWrapper: [], repeatedBytesWrapper: [], repeatedDuration: [], repeatedTimestamp: [], repeatedFieldmask: [], repeatedStruct: [], repeatedAny: [], repeatedValue: [], repeatedListValue: [], fieldname1: 0, fieldName2: 0, FieldName3: 0, fieldName4: 0, field0Name5: 0, field0Name6: 0, fieldName7: 0, fieldName8: 0, fieldName9: 0, fieldName10: 0, fIELDNAME11: 0, fIELDName12: 0, FieldName13: 0, FieldName14: 0, fieldName15: 0, fieldName16: 0, fieldName17: 0, fieldName18: 0 };
+        const message = { optionalInt32: 0, optionalInt64: 0n, optionalUint32: 0, optionalUint64: 0n, optionalSint32: 0, optionalSint64: 0n, optionalFixed32: 0, optionalFixed64: 0n, optionalSfixed32: 0, optionalSfixed64: 0n, optionalFloat: 0, optionalDouble: 0, optionalBool: false, optionalString: "", optionalBytes: new Uint8Array(0), optionalNestedEnum: 0, optionalForeignEnum: 0, optionalAliasedEnum: 0, optionalStringPiece: "", optionalCord: "", repeatedInt32: [], repeatedInt64: [], repeatedUint32: [], repeatedUint64: [], repeatedSint32: [], repeatedSint64: [], repeatedFixed32: [], repeatedFixed64: [], repeatedSfixed32: [], repeatedSfixed64: [], repeatedFloat: [], repeatedDouble: [], repeatedBool: [], repeatedString: [], repeatedBytes: [], repeatedNestedMessage: [], repeatedForeignMessage: [], repeatedNestedEnum: [], repeatedForeignEnum: [], repeatedStringPiece: [], repeatedCord: [], packedInt32: [], packedInt64: [], packedUint32: [], packedUint64: [], packedSint32: [], packedSint64: [], packedFixed32: [], packedFixed64: [], packedSfixed32: [], packedSfixed64: [], packedFloat: [], packedDouble: [], packedBool: [], packedNestedEnum: [], unpackedInt32: [], unpackedInt64: [], unpackedUint32: [], unpackedUint64: [], unpackedSint32: [], unpackedSint64: [], unpackedFixed32: [], unpackedFixed64: [], unpackedSfixed32: [], unpackedSfixed64: [], unpackedFloat: [], unpackedDouble: [], unpackedBool: [], unpackedNestedEnum: [], mapInt32Int32: {}, mapInt64Int64: {}, mapUint32Uint32: {}, mapUint64Uint64: {}, mapSint32Sint32: {}, mapSint64Sint64: {}, mapFixed32Fixed32: {}, mapFixed64Fixed64: {}, mapSfixed32Sfixed32: {}, mapSfixed64Sfixed64: {}, mapInt32Float: {}, mapInt32Double: {}, mapBoolBool: {}, mapStringString: {}, mapStringBytes: {}, mapStringNestedMessage: {}, mapStringForeignMessage: {}, mapStringNestedEnum: {}, mapStringForeignEnum: {}, oneofField: { oneofKind: undefined }, repeatedBoolWrapper: [], repeatedInt32Wrapper: [], repeatedInt64Wrapper: [], repeatedUint32Wrapper: [], repeatedUint64Wrapper: [], repeatedFloatWrapper: [], repeatedDoubleWrapper: [], repeatedStringWrapper: [], repeatedBytesWrapper: [], optionalNullValue: 0, repeatedDuration: [], repeatedTimestamp: [], repeatedFieldmask: [], repeatedStruct: [], repeatedAny: [], repeatedValue: [], repeatedListValue: [], fieldname1: 0, fieldName2: 0, FieldName3: 0, fieldName4: 0, field0Name5: 0, field0Name6: 0, fieldName7: 0, fieldName8: 0, fieldName9: 0, fieldName10: 0, fIELDNAME11: 0, fIELDName12: 0, FieldName13: 0, FieldName14: 0, fieldName15: 0, fieldName16: 0, fieldName17: 0, fieldName18: 0 };
         globalThis.Object.defineProperty(message, MESSAGE_TYPE, { enumerable: false, value: this });
         if (value !== undefined)
             reflectionMergePartial<TestAllTypesProto3>(this, message, value);
@@ -1508,6 +1544,12 @@ class TestAllTypesProto3$Type extends MessageType<TestAllTypesProto3> {
                         oneofEnum: reader.int32()
                     };
                     break;
+                case /* google.protobuf.NullValue oneof_null_value */ 120:
+                    message.oneofField = {
+                        oneofKind: "oneofNullValue",
+                        oneofNullValue: reader.int32()
+                    };
+                    break;
                 case /* google.protobuf.BoolValue optional_bool_wrapper */ 201:
                     message.optionalBoolWrapper = BoolValue.internalBinaryRead(reader, reader.uint32(), options, message.optionalBoolWrapper);
                     break;
@@ -1579,6 +1621,9 @@ class TestAllTypesProto3$Type extends MessageType<TestAllTypesProto3> {
                     break;
                 case /* google.protobuf.Value optional_value */ 306:
                     message.optionalValue = Value.internalBinaryRead(reader, reader.uint32(), options, message.optionalValue);
+                    break;
+                case /* google.protobuf.NullValue optional_null_value */ 307:
+                    message.optionalNullValue = reader.int32();
                     break;
                 case /* repeated google.protobuf.Duration repeated_duration */ 311:
                     message.repeatedDuration.push(Duration.internalBinaryRead(reader, reader.uint32(), options));
@@ -2395,6 +2440,9 @@ class TestAllTypesProto3$Type extends MessageType<TestAllTypesProto3> {
         /* protobuf_test_messages.proto3.TestAllTypesProto3.NestedEnum oneof_enum = 119; */
         if (message.oneofField.oneofKind === "oneofEnum")
             writer.tag(119, WireType.Varint).int32(message.oneofField.oneofEnum);
+        /* google.protobuf.NullValue oneof_null_value = 120; */
+        if (message.oneofField.oneofKind === "oneofNullValue")
+            writer.tag(120, WireType.Varint).int32(message.oneofField.oneofNullValue);
         /* google.protobuf.BoolValue optional_bool_wrapper = 201; */
         if (message.optionalBoolWrapper)
             BoolValue.internalBinaryWrite(message.optionalBoolWrapper, writer.tag(201, WireType.LengthDelimited).fork(), options).join();
@@ -2467,6 +2515,9 @@ class TestAllTypesProto3$Type extends MessageType<TestAllTypesProto3> {
         /* google.protobuf.Value optional_value = 306; */
         if (message.optionalValue)
             Value.internalBinaryWrite(message.optionalValue, writer.tag(306, WireType.LengthDelimited).fork(), options).join();
+        /* google.protobuf.NullValue optional_null_value = 307; */
+        if (message.optionalNullValue !== 0)
+            writer.tag(307, WireType.Varint).int32(message.optionalNullValue);
         /* repeated google.protobuf.Duration repeated_duration = 311; */
         for (let i = 0; i < message.repeatedDuration.length; i++)
             Duration.internalBinaryWrite(message.repeatedDuration[i], writer.tag(311, WireType.LengthDelimited).fork(), options).join();
@@ -2653,3 +2704,55 @@ class ForeignMessage$Type extends MessageType<ForeignMessage> {
  * @generated MessageType for protobuf message protobuf_test_messages.proto3.ForeignMessage
  */
 export const ForeignMessage = new ForeignMessage$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class NullHypothesisProto3$Type extends MessageType<NullHypothesisProto3> {
+    constructor() {
+        super("protobuf_test_messages.proto3.NullHypothesisProto3", []);
+    }
+    create(value?: PartialMessage<NullHypothesisProto3>): NullHypothesisProto3 {
+        const message = {};
+        globalThis.Object.defineProperty(message, MESSAGE_TYPE, { enumerable: false, value: this });
+        if (value !== undefined)
+            reflectionMergePartial<NullHypothesisProto3>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: NullHypothesisProto3): NullHypothesisProto3 {
+        return target ?? this.create();
+    }
+    internalBinaryWrite(message: NullHypothesisProto3, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message protobuf_test_messages.proto3.NullHypothesisProto3
+ */
+export const NullHypothesisProto3 = new NullHypothesisProto3$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class EnumOnlyProto3$Type extends MessageType<EnumOnlyProto3> {
+    constructor() {
+        super("protobuf_test_messages.proto3.EnumOnlyProto3", []);
+    }
+    create(value?: PartialMessage<EnumOnlyProto3>): EnumOnlyProto3 {
+        const message = {};
+        globalThis.Object.defineProperty(message, MESSAGE_TYPE, { enumerable: false, value: this });
+        if (value !== undefined)
+            reflectionMergePartial<EnumOnlyProto3>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: EnumOnlyProto3): EnumOnlyProto3 {
+        return target ?? this.create();
+    }
+    internalBinaryWrite(message: EnumOnlyProto3, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message protobuf_test_messages.proto3.EnumOnlyProto3
+ */
+export const EnumOnlyProto3 = new EnumOnlyProto3$Type();

--- a/packages/test-conformance/src/gen/optimize_speed-long_type_string/conformance/conformance.ts
+++ b/packages/test-conformance/src/gen/optimize_speed-long_type_string/conformance/conformance.ts
@@ -83,7 +83,7 @@ export interface ConformanceRequest {
     } | {
         oneofKind: "jspbPayload";
         /**
-         * Google internal only.  Opensource testees just skip it.
+         * Only used inside Google.  Opensource testees just skip it.
          *
          * @generated from protobuf field: string jspb_payload = 7;
          */
@@ -106,15 +106,15 @@ export interface ConformanceRequest {
     /**
      * The full name for the test message to use; for the moment, either:
      * protobuf_test_messages.proto3.TestAllTypesProto3 or
-     * protobuf_test_messages.proto2.TestAllTypesProto2.
+     * protobuf_test_messages.google.protobuf.TestAllTypesProto2.
      *
      * @generated from protobuf field: string message_type = 4;
      */
     messageType: string;
     /**
      * Each test is given a specific test category. Some category may need
-     * specific support in testee programs. Refer to the definition of TestCategory
-     * for more information.
+     * specific support in testee programs. Refer to the definition of
+     * TestCategory for more information.
      *
      * @generated from protobuf field: conformance.TestCategory test_category = 5;
      */
@@ -165,6 +165,16 @@ export interface ConformanceResponse {
          */
         serializeError: string;
     } | {
+        oneofKind: "timeoutError";
+        /**
+         * This should be set if the test program timed out.  The string should
+         * provide more information about what the child process was doing when it
+         * was killed.
+         *
+         * @generated from protobuf field: string timeout_error = 9;
+         */
+        timeoutError: string;
+    } | {
         oneofKind: "runtimeError";
         /**
          * This should be set if some other error occurred.  This will always
@@ -205,8 +215,8 @@ export interface ConformanceResponse {
         oneofKind: "jspbPayload";
         /**
          * If the input was successfully parsed and the requested output was JSPB,
-         * serialize to JSPB and set it in this field. JSPB is google internal only
-         * format. Opensource testees can just skip it.
+         * serialize to JSPB and set it in this field. JSPB is only used inside
+         * Google. Opensource testees can just skip it.
          *
          * @generated from protobuf field: string jspb_payload = 7;
          */
@@ -273,7 +283,7 @@ export enum WireFormat {
      */
     JSON = 2,
     /**
-     * Google internal only. Opensource testees just skip it.
+     * Only used inside Google. Opensource testees just skip it.
      *
      * @generated from protobuf enum value: JSPB = 3;
      */
@@ -314,7 +324,8 @@ export enum TestCategory {
      */
     JSON_IGNORE_UNKNOWN_PARSING_TEST = 3,
     /**
-     * Test jspb wire format. Google internal only. Opensource testees just skip it.
+     * Test jspb wire format. Only used inside Google. Opensource testees just
+     * skip it.
      *
      * @generated from protobuf enum value: JSPB_TEST = 4;
      */
@@ -495,6 +506,7 @@ class ConformanceResponse$Type extends MessageType<ConformanceResponse> {
         super("conformance.ConformanceResponse", [
             { no: 1, name: "parse_error", kind: "scalar", oneof: "result", T: 9 /*ScalarType.STRING*/ },
             { no: 6, name: "serialize_error", kind: "scalar", oneof: "result", T: 9 /*ScalarType.STRING*/ },
+            { no: 9, name: "timeout_error", kind: "scalar", oneof: "result", T: 9 /*ScalarType.STRING*/ },
             { no: 2, name: "runtime_error", kind: "scalar", oneof: "result", T: 9 /*ScalarType.STRING*/ },
             { no: 3, name: "protobuf_payload", kind: "scalar", oneof: "result", T: 12 /*ScalarType.BYTES*/ },
             { no: 4, name: "json_payload", kind: "scalar", oneof: "result", T: 9 /*ScalarType.STRING*/ },
@@ -525,6 +537,12 @@ class ConformanceResponse$Type extends MessageType<ConformanceResponse> {
                     message.result = {
                         oneofKind: "serializeError",
                         serializeError: reader.string()
+                    };
+                    break;
+                case /* string timeout_error */ 9:
+                    message.result = {
+                        oneofKind: "timeoutError",
+                        timeoutError: reader.string()
                     };
                     break;
                 case /* string runtime_error */ 2:
@@ -581,6 +599,9 @@ class ConformanceResponse$Type extends MessageType<ConformanceResponse> {
         /* string serialize_error = 6; */
         if (message.result.oneofKind === "serializeError")
             writer.tag(6, WireType.LengthDelimited).string(message.result.serializeError);
+        /* string timeout_error = 9; */
+        if (message.result.oneofKind === "timeoutError")
+            writer.tag(9, WireType.LengthDelimited).string(message.result.timeoutError);
         /* string runtime_error = 2; */
         if (message.result.oneofKind === "runtimeError")
             writer.tag(2, WireType.LengthDelimited).string(message.result.runtimeError);

--- a/packages/test-conformance/src/gen/optimize_speed-long_type_string/google/protobuf/duration.ts
+++ b/packages/test-conformance/src/gen/optimize_speed-long_type_string/google/protobuf/duration.ts
@@ -147,6 +147,8 @@ class Duration$Type extends MessageType<Duration> {
         if (s > 315576000000 || s < -315576000000)
             throw new Error("Duration value out of range.");
         let text = message.seconds.toString();
+        if (s === 0 && message.nanos < 0)
+            text = "-" + text;
         if (message.nanos !== 0) {
             let nanosStr = Math.abs(message.nanos).toString();
             nanosStr = "0".repeat(9 - nanosStr.length) + nanosStr;
@@ -164,21 +166,19 @@ class Duration$Type extends MessageType<Duration> {
     internalJsonRead(json: JsonValue, options: JsonReadOptions, target?: Duration): Duration {
         if (typeof json !== "string")
             throw new Error("Unable to parse Duration from JSON " + typeofJsonValue(json) + ". Expected string.");
-        let match = json.match(/^(-?[0-9]+)(?:\.([0-9]+))?s/);
+        let match = json.match(/^(-?)([0-9]+)(?:\.([0-9]+))?s/);
         if (match === null)
             throw new Error("Unable to parse Duration from JSON string. Invalid format.");
         if (!target)
             target = this.create();
-        let longSeconds = PbLong.from(match[1]);
+        let [, sign, secs, nanos] = match;
+        let longSeconds = PbLong.from(sign + secs);
         if (longSeconds.toNumber() > 315576000000 || longSeconds.toNumber() < -315576000000)
             throw new Error("Unable to parse Duration from JSON string. Value out of range.");
         target.seconds = longSeconds.toString();
-        if (typeof match[2] == "string") {
-            let nanosStr = match[2] + "0".repeat(9 - match[2].length);
+        if (typeof nanos == "string") {
+            let nanosStr = sign + nanos + "0".repeat(9 - nanos.length);
             target.nanos = parseInt(nanosStr);
-            if (longSeconds.isNegative()) {
-                target.nanos = -target.nanos;
-            }
         }
         return target;
     }

--- a/packages/test-conformance/src/gen/optimize_speed-long_type_string/google/protobuf/struct.ts
+++ b/packages/test-conformance/src/gen/optimize_speed-long_type_string/google/protobuf/struct.ts
@@ -279,7 +279,11 @@ class Value$Type extends MessageType<Value> {
             case undefined: throw new globalThis.Error();
             case "boolValue": return message.kind.boolValue;
             case "nullValue": return null;
-            case "numberValue": return message.kind.numberValue;
+            case "numberValue":
+                let numberValue = message.kind.numberValue;
+                if (typeof numberValue == "number" && !Number.isFinite(numberValue))
+                    throw new globalThis.Error();
+                return numberValue;
             case "stringValue": return message.kind.stringValue;
             case "listValue":
                 let listValueField = this.fields.find(f => f.no === 6);

--- a/packages/test-conformance/src/gen/optimize_speed-long_type_string/google/protobuf/test_messages_proto2.ts
+++ b/packages/test-conformance/src/gen/optimize_speed-long_type_string/google/protobuf/test_messages_proto2.ts
@@ -531,6 +531,68 @@ export interface TestAllTypesProto2 {
         oneofKind: undefined;
     };
     /**
+     * default values
+     *
+     * @generated from protobuf field: optional int32 default_int32 = 241;
+     */
+    defaultInt32?: number;
+    /**
+     * @generated from protobuf field: optional int64 default_int64 = 242;
+     */
+    defaultInt64?: string;
+    /**
+     * @generated from protobuf field: optional uint32 default_uint32 = 243;
+     */
+    defaultUint32?: number;
+    /**
+     * @generated from protobuf field: optional uint64 default_uint64 = 244;
+     */
+    defaultUint64?: string;
+    /**
+     * @generated from protobuf field: optional sint32 default_sint32 = 245;
+     */
+    defaultSint32?: number;
+    /**
+     * @generated from protobuf field: optional sint64 default_sint64 = 246;
+     */
+    defaultSint64?: string;
+    /**
+     * @generated from protobuf field: optional fixed32 default_fixed32 = 247;
+     */
+    defaultFixed32?: number;
+    /**
+     * @generated from protobuf field: optional fixed64 default_fixed64 = 248;
+     */
+    defaultFixed64?: string;
+    /**
+     * @generated from protobuf field: optional sfixed32 default_sfixed32 = 249;
+     */
+    defaultSfixed32?: number;
+    /**
+     * @generated from protobuf field: optional sfixed64 default_sfixed64 = 250;
+     */
+    defaultSfixed64?: string;
+    /**
+     * @generated from protobuf field: optional float default_float = 251;
+     */
+    defaultFloat?: number;
+    /**
+     * @generated from protobuf field: optional double default_double = 252;
+     */
+    defaultDouble?: number;
+    /**
+     * @generated from protobuf field: optional bool default_bool = 253;
+     */
+    defaultBool?: boolean;
+    /**
+     * @generated from protobuf field: optional string default_string = 254;
+     */
+    defaultString?: string;
+    /**
+     * @generated from protobuf field: optional bytes default_bytes = 255;
+     */
+    defaultBytes?: Uint8Array;
+    /**
      * Test field-name-to-JSON-name convention.
      * (protobuf says names can be any valid C/C++ identifier.)
      *
@@ -726,6 +788,55 @@ export interface UnknownToTestAllTypes_OptionalGroup {
     a?: number;
 }
 /**
+ * @generated from protobuf message protobuf_test_messages.proto2.NullHypothesisProto2
+ */
+export interface NullHypothesisProto2 {
+}
+/**
+ * @generated from protobuf message protobuf_test_messages.proto2.EnumOnlyProto2
+ */
+export interface EnumOnlyProto2 {
+}
+/**
+ * @generated from protobuf enum protobuf_test_messages.proto2.EnumOnlyProto2.Bool
+ */
+export enum EnumOnlyProto2_Bool {
+    /**
+     * @generated from protobuf enum value: kFalse = 0;
+     */
+    kFalse = 0,
+    /**
+     * @generated from protobuf enum value: kTrue = 1;
+     */
+    kTrue = 1
+}
+/**
+ * @generated from protobuf message protobuf_test_messages.proto2.OneStringProto2
+ */
+export interface OneStringProto2 {
+    /**
+     * @generated from protobuf field: optional string data = 1;
+     */
+    data?: string;
+}
+/**
+ * @generated from protobuf message protobuf_test_messages.proto2.ProtoWithKeywords
+ */
+export interface ProtoWithKeywords {
+    /**
+     * @generated from protobuf field: optional int32 inline = 1;
+     */
+    inline?: number;
+    /**
+     * @generated from protobuf field: optional string concept = 2;
+     */
+    concept?: string;
+    /**
+     * @generated from protobuf field: repeated string requires = 3;
+     */
+    requires: string[];
+}
+/**
  * @generated from protobuf enum protobuf_test_messages.proto2.ForeignEnumProto2
  */
 export enum ForeignEnumProto2 {
@@ -845,6 +956,21 @@ class TestAllTypesProto2$Type extends MessageType<TestAllTypesProto2> {
             { no: 117, name: "oneof_float", kind: "scalar", oneof: "oneofField", T: 2 /*ScalarType.FLOAT*/ },
             { no: 118, name: "oneof_double", kind: "scalar", oneof: "oneofField", T: 1 /*ScalarType.DOUBLE*/ },
             { no: 119, name: "oneof_enum", kind: "enum", oneof: "oneofField", T: () => ["protobuf_test_messages.proto2.TestAllTypesProto2.NestedEnum", TestAllTypesProto2_NestedEnum] },
+            { no: 241, name: "default_int32", kind: "scalar", opt: true, T: 5 /*ScalarType.INT32*/ },
+            { no: 242, name: "default_int64", kind: "scalar", opt: true, T: 3 /*ScalarType.INT64*/ },
+            { no: 243, name: "default_uint32", kind: "scalar", opt: true, T: 13 /*ScalarType.UINT32*/ },
+            { no: 244, name: "default_uint64", kind: "scalar", opt: true, T: 4 /*ScalarType.UINT64*/ },
+            { no: 245, name: "default_sint32", kind: "scalar", opt: true, T: 17 /*ScalarType.SINT32*/ },
+            { no: 246, name: "default_sint64", kind: "scalar", opt: true, T: 18 /*ScalarType.SINT64*/ },
+            { no: 247, name: "default_fixed32", kind: "scalar", opt: true, T: 7 /*ScalarType.FIXED32*/ },
+            { no: 248, name: "default_fixed64", kind: "scalar", opt: true, T: 6 /*ScalarType.FIXED64*/ },
+            { no: 249, name: "default_sfixed32", kind: "scalar", opt: true, T: 15 /*ScalarType.SFIXED32*/ },
+            { no: 250, name: "default_sfixed64", kind: "scalar", opt: true, T: 16 /*ScalarType.SFIXED64*/ },
+            { no: 251, name: "default_float", kind: "scalar", opt: true, T: 2 /*ScalarType.FLOAT*/ },
+            { no: 252, name: "default_double", kind: "scalar", opt: true, T: 1 /*ScalarType.DOUBLE*/ },
+            { no: 253, name: "default_bool", kind: "scalar", opt: true, T: 8 /*ScalarType.BOOL*/ },
+            { no: 254, name: "default_string", kind: "scalar", opt: true, T: 9 /*ScalarType.STRING*/ },
+            { no: 255, name: "default_bytes", kind: "scalar", opt: true, T: 12 /*ScalarType.BYTES*/ },
             { no: 401, name: "fieldname1", kind: "scalar", opt: true, T: 5 /*ScalarType.INT32*/ },
             { no: 402, name: "field_name2", kind: "scalar", opt: true, T: 5 /*ScalarType.INT32*/ },
             { no: 403, name: "_field_name3", kind: "scalar", opt: true, T: 5 /*ScalarType.INT32*/ },
@@ -1372,6 +1498,51 @@ class TestAllTypesProto2$Type extends MessageType<TestAllTypesProto2> {
                         oneofKind: "oneofEnum",
                         oneofEnum: reader.int32()
                     };
+                    break;
+                case /* optional int32 default_int32 */ 241:
+                    message.defaultInt32 = reader.int32();
+                    break;
+                case /* optional int64 default_int64 */ 242:
+                    message.defaultInt64 = reader.int64().toString();
+                    break;
+                case /* optional uint32 default_uint32 */ 243:
+                    message.defaultUint32 = reader.uint32();
+                    break;
+                case /* optional uint64 default_uint64 */ 244:
+                    message.defaultUint64 = reader.uint64().toString();
+                    break;
+                case /* optional sint32 default_sint32 */ 245:
+                    message.defaultSint32 = reader.sint32();
+                    break;
+                case /* optional sint64 default_sint64 */ 246:
+                    message.defaultSint64 = reader.sint64().toString();
+                    break;
+                case /* optional fixed32 default_fixed32 */ 247:
+                    message.defaultFixed32 = reader.fixed32();
+                    break;
+                case /* optional fixed64 default_fixed64 */ 248:
+                    message.defaultFixed64 = reader.fixed64().toString();
+                    break;
+                case /* optional sfixed32 default_sfixed32 */ 249:
+                    message.defaultSfixed32 = reader.sfixed32();
+                    break;
+                case /* optional sfixed64 default_sfixed64 */ 250:
+                    message.defaultSfixed64 = reader.sfixed64().toString();
+                    break;
+                case /* optional float default_float */ 251:
+                    message.defaultFloat = reader.float();
+                    break;
+                case /* optional double default_double */ 252:
+                    message.defaultDouble = reader.double();
+                    break;
+                case /* optional bool default_bool */ 253:
+                    message.defaultBool = reader.bool();
+                    break;
+                case /* optional string default_string */ 254:
+                    message.defaultString = reader.string();
+                    break;
+                case /* optional bytes default_bytes */ 255:
+                    message.defaultBytes = reader.bytes();
                     break;
                 case /* optional int32 fieldname1 */ 401:
                     message.fieldname1 = reader.int32();
@@ -2104,6 +2275,51 @@ class TestAllTypesProto2$Type extends MessageType<TestAllTypesProto2> {
         /* protobuf_test_messages.proto2.TestAllTypesProto2.NestedEnum oneof_enum = 119; */
         if (message.oneofField.oneofKind === "oneofEnum")
             writer.tag(119, WireType.Varint).int32(message.oneofField.oneofEnum);
+        /* optional int32 default_int32 = 241; */
+        if (message.defaultInt32 !== undefined)
+            writer.tag(241, WireType.Varint).int32(message.defaultInt32);
+        /* optional int64 default_int64 = 242; */
+        if (message.defaultInt64 !== undefined)
+            writer.tag(242, WireType.Varint).int64(message.defaultInt64);
+        /* optional uint32 default_uint32 = 243; */
+        if (message.defaultUint32 !== undefined)
+            writer.tag(243, WireType.Varint).uint32(message.defaultUint32);
+        /* optional uint64 default_uint64 = 244; */
+        if (message.defaultUint64 !== undefined)
+            writer.tag(244, WireType.Varint).uint64(message.defaultUint64);
+        /* optional sint32 default_sint32 = 245; */
+        if (message.defaultSint32 !== undefined)
+            writer.tag(245, WireType.Varint).sint32(message.defaultSint32);
+        /* optional sint64 default_sint64 = 246; */
+        if (message.defaultSint64 !== undefined)
+            writer.tag(246, WireType.Varint).sint64(message.defaultSint64);
+        /* optional fixed32 default_fixed32 = 247; */
+        if (message.defaultFixed32 !== undefined)
+            writer.tag(247, WireType.Bit32).fixed32(message.defaultFixed32);
+        /* optional fixed64 default_fixed64 = 248; */
+        if (message.defaultFixed64 !== undefined)
+            writer.tag(248, WireType.Bit64).fixed64(message.defaultFixed64);
+        /* optional sfixed32 default_sfixed32 = 249; */
+        if (message.defaultSfixed32 !== undefined)
+            writer.tag(249, WireType.Bit32).sfixed32(message.defaultSfixed32);
+        /* optional sfixed64 default_sfixed64 = 250; */
+        if (message.defaultSfixed64 !== undefined)
+            writer.tag(250, WireType.Bit64).sfixed64(message.defaultSfixed64);
+        /* optional float default_float = 251; */
+        if (message.defaultFloat !== undefined)
+            writer.tag(251, WireType.Bit32).float(message.defaultFloat);
+        /* optional double default_double = 252; */
+        if (message.defaultDouble !== undefined)
+            writer.tag(252, WireType.Bit64).double(message.defaultDouble);
+        /* optional bool default_bool = 253; */
+        if (message.defaultBool !== undefined)
+            writer.tag(253, WireType.Varint).bool(message.defaultBool);
+        /* optional string default_string = 254; */
+        if (message.defaultString !== undefined)
+            writer.tag(254, WireType.LengthDelimited).string(message.defaultString);
+        /* optional bytes default_bytes = 255; */
+        if (message.defaultBytes !== undefined)
+            writer.tag(255, WireType.LengthDelimited).bytes(message.defaultBytes);
         /* optional int32 fieldname1 = 401; */
         if (message.fieldname1 !== undefined)
             writer.tag(401, WireType.Varint).int32(message.fieldname1);
@@ -2569,3 +2785,163 @@ class UnknownToTestAllTypes_OptionalGroup$Type extends MessageType<UnknownToTest
  * @generated MessageType for protobuf message protobuf_test_messages.proto2.UnknownToTestAllTypes.OptionalGroup
  */
 export const UnknownToTestAllTypes_OptionalGroup = new UnknownToTestAllTypes_OptionalGroup$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class NullHypothesisProto2$Type extends MessageType<NullHypothesisProto2> {
+    constructor() {
+        super("protobuf_test_messages.proto2.NullHypothesisProto2", []);
+    }
+    create(value?: PartialMessage<NullHypothesisProto2>): NullHypothesisProto2 {
+        const message = {};
+        globalThis.Object.defineProperty(message, MESSAGE_TYPE, { enumerable: false, value: this });
+        if (value !== undefined)
+            reflectionMergePartial<NullHypothesisProto2>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: NullHypothesisProto2): NullHypothesisProto2 {
+        return target ?? this.create();
+    }
+    internalBinaryWrite(message: NullHypothesisProto2, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message protobuf_test_messages.proto2.NullHypothesisProto2
+ */
+export const NullHypothesisProto2 = new NullHypothesisProto2$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class EnumOnlyProto2$Type extends MessageType<EnumOnlyProto2> {
+    constructor() {
+        super("protobuf_test_messages.proto2.EnumOnlyProto2", []);
+    }
+    create(value?: PartialMessage<EnumOnlyProto2>): EnumOnlyProto2 {
+        const message = {};
+        globalThis.Object.defineProperty(message, MESSAGE_TYPE, { enumerable: false, value: this });
+        if (value !== undefined)
+            reflectionMergePartial<EnumOnlyProto2>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: EnumOnlyProto2): EnumOnlyProto2 {
+        return target ?? this.create();
+    }
+    internalBinaryWrite(message: EnumOnlyProto2, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message protobuf_test_messages.proto2.EnumOnlyProto2
+ */
+export const EnumOnlyProto2 = new EnumOnlyProto2$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class OneStringProto2$Type extends MessageType<OneStringProto2> {
+    constructor() {
+        super("protobuf_test_messages.proto2.OneStringProto2", [
+            { no: 1, name: "data", kind: "scalar", opt: true, T: 9 /*ScalarType.STRING*/ }
+        ]);
+    }
+    create(value?: PartialMessage<OneStringProto2>): OneStringProto2 {
+        const message = {};
+        globalThis.Object.defineProperty(message, MESSAGE_TYPE, { enumerable: false, value: this });
+        if (value !== undefined)
+            reflectionMergePartial<OneStringProto2>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: OneStringProto2): OneStringProto2 {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                case /* optional string data */ 1:
+                    message.data = reader.string();
+                    break;
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: OneStringProto2, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* optional string data = 1; */
+        if (message.data !== undefined)
+            writer.tag(1, WireType.LengthDelimited).string(message.data);
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message protobuf_test_messages.proto2.OneStringProto2
+ */
+export const OneStringProto2 = new OneStringProto2$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class ProtoWithKeywords$Type extends MessageType<ProtoWithKeywords> {
+    constructor() {
+        super("protobuf_test_messages.proto2.ProtoWithKeywords", [
+            { no: 1, name: "inline", kind: "scalar", opt: true, T: 5 /*ScalarType.INT32*/ },
+            { no: 2, name: "concept", kind: "scalar", opt: true, T: 9 /*ScalarType.STRING*/ },
+            { no: 3, name: "requires", kind: "scalar", repeat: 2 /*RepeatType.UNPACKED*/, T: 9 /*ScalarType.STRING*/ }
+        ]);
+    }
+    create(value?: PartialMessage<ProtoWithKeywords>): ProtoWithKeywords {
+        const message = { requires: [] };
+        globalThis.Object.defineProperty(message, MESSAGE_TYPE, { enumerable: false, value: this });
+        if (value !== undefined)
+            reflectionMergePartial<ProtoWithKeywords>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: ProtoWithKeywords): ProtoWithKeywords {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                case /* optional int32 inline */ 1:
+                    message.inline = reader.int32();
+                    break;
+                case /* optional string concept */ 2:
+                    message.concept = reader.string();
+                    break;
+                case /* repeated string requires */ 3:
+                    message.requires.push(reader.string());
+                    break;
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: ProtoWithKeywords, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* optional int32 inline = 1; */
+        if (message.inline !== undefined)
+            writer.tag(1, WireType.Varint).int32(message.inline);
+        /* optional string concept = 2; */
+        if (message.concept !== undefined)
+            writer.tag(2, WireType.LengthDelimited).string(message.concept);
+        /* repeated string requires = 3; */
+        for (let i = 0; i < message.requires.length; i++)
+            writer.tag(3, WireType.LengthDelimited).string(message.requires[i]);
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message protobuf_test_messages.proto2.ProtoWithKeywords
+ */
+export const ProtoWithKeywords = new ProtoWithKeywords$Type();

--- a/packages/test-conformance/src/gen/optimize_speed-long_type_string/google/protobuf/test_messages_proto3.ts
+++ b/packages/test-conformance/src/gen/optimize_speed-long_type_string/google/protobuf/test_messages_proto3.ts
@@ -65,6 +65,7 @@ import { UInt32Value } from "./wrappers";
 import { Int64Value } from "./wrappers";
 import { Int32Value } from "./wrappers";
 import { BoolValue } from "./wrappers";
+import { NullValue } from "./struct";
 /**
  * This proto includes every type of field in both singular and repeated
  * forms.
@@ -547,6 +548,12 @@ export interface TestAllTypesProto3 {
          */
         oneofEnum: TestAllTypesProto3_NestedEnum;
     } | {
+        oneofKind: "oneofNullValue";
+        /**
+         * @generated from protobuf field: google.protobuf.NullValue oneof_null_value = 120;
+         */
+        oneofNullValue: NullValue;
+    } | {
         oneofKind: undefined;
     };
     /**
@@ -647,6 +654,10 @@ export interface TestAllTypesProto3 {
      * @generated from protobuf field: google.protobuf.Value optional_value = 306;
      */
     optionalValue?: Value;
+    /**
+     * @generated from protobuf field: google.protobuf.NullValue optional_null_value = 307;
+     */
+    optionalNullValue: NullValue;
     /**
      * @generated from protobuf field: repeated google.protobuf.Duration repeated_duration = 311;
      */
@@ -806,11 +817,11 @@ export enum TestAllTypesProto3_AliasedEnum {
     /**
      * @generated from protobuf enum value: ALIAS_BAZ = 2;
      */
-    QUX = 2,
+    MOO = 2,
     /**
      * @generated from protobuf enum value: ALIAS_BAZ = 2;
      */
-    qux = 2,
+    moo = 2,
     /**
      * @generated from protobuf enum value: ALIAS_BAZ = 2;
      */
@@ -824,6 +835,29 @@ export interface ForeignMessage {
      * @generated from protobuf field: int32 c = 1;
      */
     c: number;
+}
+/**
+ * @generated from protobuf message protobuf_test_messages.proto3.NullHypothesisProto3
+ */
+export interface NullHypothesisProto3 {
+}
+/**
+ * @generated from protobuf message protobuf_test_messages.proto3.EnumOnlyProto3
+ */
+export interface EnumOnlyProto3 {
+}
+/**
+ * @generated from protobuf enum protobuf_test_messages.proto3.EnumOnlyProto3.Bool
+ */
+export enum EnumOnlyProto3_Bool {
+    /**
+     * @generated from protobuf enum value: kFalse = 0;
+     */
+    kFalse = 0,
+    /**
+     * @generated from protobuf enum value: kTrue = 1;
+     */
+    kTrue = 1
 }
 /**
  * @generated from protobuf enum protobuf_test_messages.proto3.ForeignEnum
@@ -946,6 +980,7 @@ class TestAllTypesProto3$Type extends MessageType<TestAllTypesProto3> {
             { no: 117, name: "oneof_float", kind: "scalar", oneof: "oneofField", T: 2 /*ScalarType.FLOAT*/ },
             { no: 118, name: "oneof_double", kind: "scalar", oneof: "oneofField", T: 1 /*ScalarType.DOUBLE*/ },
             { no: 119, name: "oneof_enum", kind: "enum", oneof: "oneofField", T: () => ["protobuf_test_messages.proto3.TestAllTypesProto3.NestedEnum", TestAllTypesProto3_NestedEnum] },
+            { no: 120, name: "oneof_null_value", kind: "enum", oneof: "oneofField", T: () => ["google.protobuf.NullValue", NullValue] },
             { no: 201, name: "optional_bool_wrapper", kind: "message", T: () => BoolValue },
             { no: 202, name: "optional_int32_wrapper", kind: "message", T: () => Int32Value },
             { no: 203, name: "optional_int64_wrapper", kind: "message", T: () => Int64Value },
@@ -970,6 +1005,7 @@ class TestAllTypesProto3$Type extends MessageType<TestAllTypesProto3> {
             { no: 304, name: "optional_struct", kind: "message", T: () => Struct },
             { no: 305, name: "optional_any", kind: "message", T: () => Any },
             { no: 306, name: "optional_value", kind: "message", T: () => Value },
+            { no: 307, name: "optional_null_value", kind: "enum", T: () => ["google.protobuf.NullValue", NullValue] },
             { no: 311, name: "repeated_duration", kind: "message", repeat: 1 /*RepeatType.PACKED*/, T: () => Duration },
             { no: 312, name: "repeated_timestamp", kind: "message", repeat: 1 /*RepeatType.PACKED*/, T: () => Timestamp },
             { no: 313, name: "repeated_fieldmask", kind: "message", repeat: 1 /*RepeatType.PACKED*/, T: () => FieldMask },
@@ -998,7 +1034,7 @@ class TestAllTypesProto3$Type extends MessageType<TestAllTypesProto3> {
         ]);
     }
     create(value?: PartialMessage<TestAllTypesProto3>): TestAllTypesProto3 {
-        const message = { optionalInt32: 0, optionalInt64: "0", optionalUint32: 0, optionalUint64: "0", optionalSint32: 0, optionalSint64: "0", optionalFixed32: 0, optionalFixed64: "0", optionalSfixed32: 0, optionalSfixed64: "0", optionalFloat: 0, optionalDouble: 0, optionalBool: false, optionalString: "", optionalBytes: new Uint8Array(0), optionalNestedEnum: 0, optionalForeignEnum: 0, optionalAliasedEnum: 0, optionalStringPiece: "", optionalCord: "", repeatedInt32: [], repeatedInt64: [], repeatedUint32: [], repeatedUint64: [], repeatedSint32: [], repeatedSint64: [], repeatedFixed32: [], repeatedFixed64: [], repeatedSfixed32: [], repeatedSfixed64: [], repeatedFloat: [], repeatedDouble: [], repeatedBool: [], repeatedString: [], repeatedBytes: [], repeatedNestedMessage: [], repeatedForeignMessage: [], repeatedNestedEnum: [], repeatedForeignEnum: [], repeatedStringPiece: [], repeatedCord: [], packedInt32: [], packedInt64: [], packedUint32: [], packedUint64: [], packedSint32: [], packedSint64: [], packedFixed32: [], packedFixed64: [], packedSfixed32: [], packedSfixed64: [], packedFloat: [], packedDouble: [], packedBool: [], packedNestedEnum: [], unpackedInt32: [], unpackedInt64: [], unpackedUint32: [], unpackedUint64: [], unpackedSint32: [], unpackedSint64: [], unpackedFixed32: [], unpackedFixed64: [], unpackedSfixed32: [], unpackedSfixed64: [], unpackedFloat: [], unpackedDouble: [], unpackedBool: [], unpackedNestedEnum: [], mapInt32Int32: {}, mapInt64Int64: {}, mapUint32Uint32: {}, mapUint64Uint64: {}, mapSint32Sint32: {}, mapSint64Sint64: {}, mapFixed32Fixed32: {}, mapFixed64Fixed64: {}, mapSfixed32Sfixed32: {}, mapSfixed64Sfixed64: {}, mapInt32Float: {}, mapInt32Double: {}, mapBoolBool: {}, mapStringString: {}, mapStringBytes: {}, mapStringNestedMessage: {}, mapStringForeignMessage: {}, mapStringNestedEnum: {}, mapStringForeignEnum: {}, oneofField: { oneofKind: undefined }, repeatedBoolWrapper: [], repeatedInt32Wrapper: [], repeatedInt64Wrapper: [], repeatedUint32Wrapper: [], repeatedUint64Wrapper: [], repeatedFloatWrapper: [], repeatedDoubleWrapper: [], repeatedStringWrapper: [], repeatedBytesWrapper: [], repeatedDuration: [], repeatedTimestamp: [], repeatedFieldmask: [], repeatedStruct: [], repeatedAny: [], repeatedValue: [], repeatedListValue: [], fieldname1: 0, fieldName2: 0, FieldName3: 0, fieldName4: 0, field0Name5: 0, field0Name6: 0, fieldName7: 0, fieldName8: 0, fieldName9: 0, fieldName10: 0, fIELDNAME11: 0, fIELDName12: 0, FieldName13: 0, FieldName14: 0, fieldName15: 0, fieldName16: 0, fieldName17: 0, fieldName18: 0 };
+        const message = { optionalInt32: 0, optionalInt64: "0", optionalUint32: 0, optionalUint64: "0", optionalSint32: 0, optionalSint64: "0", optionalFixed32: 0, optionalFixed64: "0", optionalSfixed32: 0, optionalSfixed64: "0", optionalFloat: 0, optionalDouble: 0, optionalBool: false, optionalString: "", optionalBytes: new Uint8Array(0), optionalNestedEnum: 0, optionalForeignEnum: 0, optionalAliasedEnum: 0, optionalStringPiece: "", optionalCord: "", repeatedInt32: [], repeatedInt64: [], repeatedUint32: [], repeatedUint64: [], repeatedSint32: [], repeatedSint64: [], repeatedFixed32: [], repeatedFixed64: [], repeatedSfixed32: [], repeatedSfixed64: [], repeatedFloat: [], repeatedDouble: [], repeatedBool: [], repeatedString: [], repeatedBytes: [], repeatedNestedMessage: [], repeatedForeignMessage: [], repeatedNestedEnum: [], repeatedForeignEnum: [], repeatedStringPiece: [], repeatedCord: [], packedInt32: [], packedInt64: [], packedUint32: [], packedUint64: [], packedSint32: [], packedSint64: [], packedFixed32: [], packedFixed64: [], packedSfixed32: [], packedSfixed64: [], packedFloat: [], packedDouble: [], packedBool: [], packedNestedEnum: [], unpackedInt32: [], unpackedInt64: [], unpackedUint32: [], unpackedUint64: [], unpackedSint32: [], unpackedSint64: [], unpackedFixed32: [], unpackedFixed64: [], unpackedSfixed32: [], unpackedSfixed64: [], unpackedFloat: [], unpackedDouble: [], unpackedBool: [], unpackedNestedEnum: [], mapInt32Int32: {}, mapInt64Int64: {}, mapUint32Uint32: {}, mapUint64Uint64: {}, mapSint32Sint32: {}, mapSint64Sint64: {}, mapFixed32Fixed32: {}, mapFixed64Fixed64: {}, mapSfixed32Sfixed32: {}, mapSfixed64Sfixed64: {}, mapInt32Float: {}, mapInt32Double: {}, mapBoolBool: {}, mapStringString: {}, mapStringBytes: {}, mapStringNestedMessage: {}, mapStringForeignMessage: {}, mapStringNestedEnum: {}, mapStringForeignEnum: {}, oneofField: { oneofKind: undefined }, repeatedBoolWrapper: [], repeatedInt32Wrapper: [], repeatedInt64Wrapper: [], repeatedUint32Wrapper: [], repeatedUint64Wrapper: [], repeatedFloatWrapper: [], repeatedDoubleWrapper: [], repeatedStringWrapper: [], repeatedBytesWrapper: [], optionalNullValue: 0, repeatedDuration: [], repeatedTimestamp: [], repeatedFieldmask: [], repeatedStruct: [], repeatedAny: [], repeatedValue: [], repeatedListValue: [], fieldname1: 0, fieldName2: 0, FieldName3: 0, fieldName4: 0, field0Name5: 0, field0Name6: 0, fieldName7: 0, fieldName8: 0, fieldName9: 0, fieldName10: 0, fIELDNAME11: 0, fIELDName12: 0, FieldName13: 0, FieldName14: 0, fieldName15: 0, fieldName16: 0, fieldName17: 0, fieldName18: 0 };
         globalThis.Object.defineProperty(message, MESSAGE_TYPE, { enumerable: false, value: this });
         if (value !== undefined)
             reflectionMergePartial<TestAllTypesProto3>(this, message, value);
@@ -1508,6 +1544,12 @@ class TestAllTypesProto3$Type extends MessageType<TestAllTypesProto3> {
                         oneofEnum: reader.int32()
                     };
                     break;
+                case /* google.protobuf.NullValue oneof_null_value */ 120:
+                    message.oneofField = {
+                        oneofKind: "oneofNullValue",
+                        oneofNullValue: reader.int32()
+                    };
+                    break;
                 case /* google.protobuf.BoolValue optional_bool_wrapper */ 201:
                     message.optionalBoolWrapper = BoolValue.internalBinaryRead(reader, reader.uint32(), options, message.optionalBoolWrapper);
                     break;
@@ -1579,6 +1621,9 @@ class TestAllTypesProto3$Type extends MessageType<TestAllTypesProto3> {
                     break;
                 case /* google.protobuf.Value optional_value */ 306:
                     message.optionalValue = Value.internalBinaryRead(reader, reader.uint32(), options, message.optionalValue);
+                    break;
+                case /* google.protobuf.NullValue optional_null_value */ 307:
+                    message.optionalNullValue = reader.int32();
                     break;
                 case /* repeated google.protobuf.Duration repeated_duration */ 311:
                     message.repeatedDuration.push(Duration.internalBinaryRead(reader, reader.uint32(), options));
@@ -2395,6 +2440,9 @@ class TestAllTypesProto3$Type extends MessageType<TestAllTypesProto3> {
         /* protobuf_test_messages.proto3.TestAllTypesProto3.NestedEnum oneof_enum = 119; */
         if (message.oneofField.oneofKind === "oneofEnum")
             writer.tag(119, WireType.Varint).int32(message.oneofField.oneofEnum);
+        /* google.protobuf.NullValue oneof_null_value = 120; */
+        if (message.oneofField.oneofKind === "oneofNullValue")
+            writer.tag(120, WireType.Varint).int32(message.oneofField.oneofNullValue);
         /* google.protobuf.BoolValue optional_bool_wrapper = 201; */
         if (message.optionalBoolWrapper)
             BoolValue.internalBinaryWrite(message.optionalBoolWrapper, writer.tag(201, WireType.LengthDelimited).fork(), options).join();
@@ -2467,6 +2515,9 @@ class TestAllTypesProto3$Type extends MessageType<TestAllTypesProto3> {
         /* google.protobuf.Value optional_value = 306; */
         if (message.optionalValue)
             Value.internalBinaryWrite(message.optionalValue, writer.tag(306, WireType.LengthDelimited).fork(), options).join();
+        /* google.protobuf.NullValue optional_null_value = 307; */
+        if (message.optionalNullValue !== 0)
+            writer.tag(307, WireType.Varint).int32(message.optionalNullValue);
         /* repeated google.protobuf.Duration repeated_duration = 311; */
         for (let i = 0; i < message.repeatedDuration.length; i++)
             Duration.internalBinaryWrite(message.repeatedDuration[i], writer.tag(311, WireType.LengthDelimited).fork(), options).join();
@@ -2653,3 +2704,55 @@ class ForeignMessage$Type extends MessageType<ForeignMessage> {
  * @generated MessageType for protobuf message protobuf_test_messages.proto3.ForeignMessage
  */
 export const ForeignMessage = new ForeignMessage$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class NullHypothesisProto3$Type extends MessageType<NullHypothesisProto3> {
+    constructor() {
+        super("protobuf_test_messages.proto3.NullHypothesisProto3", []);
+    }
+    create(value?: PartialMessage<NullHypothesisProto3>): NullHypothesisProto3 {
+        const message = {};
+        globalThis.Object.defineProperty(message, MESSAGE_TYPE, { enumerable: false, value: this });
+        if (value !== undefined)
+            reflectionMergePartial<NullHypothesisProto3>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: NullHypothesisProto3): NullHypothesisProto3 {
+        return target ?? this.create();
+    }
+    internalBinaryWrite(message: NullHypothesisProto3, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message protobuf_test_messages.proto3.NullHypothesisProto3
+ */
+export const NullHypothesisProto3 = new NullHypothesisProto3$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class EnumOnlyProto3$Type extends MessageType<EnumOnlyProto3> {
+    constructor() {
+        super("protobuf_test_messages.proto3.EnumOnlyProto3", []);
+    }
+    create(value?: PartialMessage<EnumOnlyProto3>): EnumOnlyProto3 {
+        const message = {};
+        globalThis.Object.defineProperty(message, MESSAGE_TYPE, { enumerable: false, value: this });
+        if (value !== undefined)
+            reflectionMergePartial<EnumOnlyProto3>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: EnumOnlyProto3): EnumOnlyProto3 {
+        return target ?? this.create();
+    }
+    internalBinaryWrite(message: EnumOnlyProto3, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message protobuf_test_messages.proto3.EnumOnlyProto3
+ */
+export const EnumOnlyProto3 = new EnumOnlyProto3$Type();


### PR DESCRIPTION
This change fixes all remaining conformance tests except for `Recommended.Proto2.JsonInput.FieldNameExtension.Validator` (and obviously all the text format ones). This brings protobuf-ts up to the same level of conformance as protobuf-es.

The reason that the `Required.Proto3.JsonInput.EnumFieldWithAliasLowerCase` and `Required.Proto3.JsonInput.EnumFieldWithAliasUseAlias` conformance tests were failing was because the [test_messages_proto3.proto](https://github.com/timostamm/protobuf-ts/compare/main...jcready:protobuf-ts:make-conformant?expand=1#diff-b256b7523b5b8cd27cc00490a71ce1e743ed2b83ff8f40b412966ffc7b2df98a) file hadn't been updated to match the [version of the conformance runner](https://github.com/timostamm/protobuf-ts/blob/2f0ed591475e943df16653d49f1ca9f1ec678fe7/packages/test-conformance/download-conformance-runner.bash#L7). It has been updated (along with the [test_messages_proto2.proto](https://github.com/protocolbuffers/protobuf/blob/v22.3/src/google/protobuf/test_messages_proto2.proto) and [conformance.proto](https://github.com/protocolbuffers/protobuf/blob/v22.3/conformance/conformance.proto) files) to match what's in [v22.3](https://github.com/protocolbuffers/protobuf/blob/v22.3/src/google/protobuf/test_messages_proto3.proto).

Side note: would it make more sense to just add the `packages/test-conformance/src/gen` folder to the `.gitignore`? It'd make this PR a lot easier to grok.