### PR TITLE
Test pb-long without BI support and fix found issues

### DIFF
--- a/packages/runtime/spec/pb-long.spec.ts
+++ b/packages/runtime/spec/pb-long.spec.ts
@@ -1,8 +1,10 @@
 import {PbLong, PbULong} from "../src";
 import {int64toString} from "../src/goog-varint";
+import {detectBi} from '../src/pb-long';
 
+const BICtor = globalThis.BigInt;
 
-describe('PbULong', function () {
+function testPbULong() {
 
     it('can be constructed with bits', function () {
         let bi = new PbULong(0, 1);
@@ -19,7 +21,7 @@ describe('PbULong', function () {
 
     it('should from() max unsigned int64 native bigint', function () {
         if (globalThis.BigInt === undefined)
-            pending('No BigInt support on current platform');
+            return expect().nothing();
 
         // @ts-ignore
         let uLong = PbULong.from(18446744073709551615n);
@@ -39,18 +41,27 @@ describe('PbULong', function () {
         expect(uLong.toString()).toBe('18446744073709551615');
     });
 
-    it('should toBigInt()', function () {
-        if (globalThis.BigInt === undefined)
-            pending('No BigInt support on current platform');
+    it('should toNumber()', function () {
+        let bi = new PbLong(4294967295, 2097151);
+        expect(bi.toNumber()).toBe(Number.MAX_SAFE_INTEGER);
 
+        // signed max value
+        bi = new PbLong(4294967295, 2097152);
+        expect(() => bi.toNumber()).toThrowError("cannot convert to safe number");
+    });
+
+    it('should toBigInt()', function () {
         let uLong = new PbULong(-1, -1);
-        // @ts-ignore
-        expect(uLong.toBigInt()).toBe(18446744073709551615n);
+        if (globalThis.BigInt === undefined)
+            expect(() => uLong.toBigInt()).toThrowError();
+        else
+            // @ts-ignore
+            expect(uLong.toBigInt()).toBe(18446744073709551615n);
     });
 
     it('should fail from() max unsigned int64 native bigint', function () {
         if (globalThis.BigInt === undefined)
-            pending('No BigInt support on current platform');
+            return expect().nothing();
 
         // @ts-ignore
         expect(() => PbULong.from(18446744073709551615n + 10n)).toThrowError("ulong too large");
@@ -65,6 +76,7 @@ describe('PbULong', function () {
         expect(() => PbULong.from(-1)).toThrowError();
         expect(() => PbULong.from(Number.NaN)).toThrowError();
         expect(() => PbULong.from(Number.POSITIVE_INFINITY)).toThrowError();
+        expect(() => PbULong.from(true as unknown as number)).toThrowError();
     });
 
     it('0 has lo = 0, hi = 0', function () {
@@ -73,17 +85,24 @@ describe('PbULong', function () {
         expect(ulong.lo).toBe(0);
     });
 
-    it('int64toString should serialize the same was as BigInt.toString()', function () {
+    it('int64toString should serialize the same way as BigInt.toString()', function () {
         let ulong = PbULong.from(1661324400000);
         expect(ulong.hi).toBe(386);
         expect(ulong.lo).toBe(-827943552);
         expect(ulong.toString()).toBe('1661324400000')
         expect(int64toString(ulong.lo, ulong.hi)).toBe('1661324400000')
     });
-});
 
+    it('should return ZERO for "0", 0, or 0n', function () {
+        expect(PbULong.from("0").isZero()).toBe(true);
+        expect(PbULong.from(0).isZero()).toBe(true);
+        if (globalThis.BigInt !== undefined)
+            // @ts-ignore
+            expect(PbULong.from(0n).isZero()).toBe(true);
+    });
+}
 
-describe('PbLong', function () {
+function testPbLong () {
 
     it('can be constructed with bits', function () {
         let bi = new PbLong(0, 1);
@@ -93,36 +112,36 @@ describe('PbLong', function () {
 
     it('should from() max signed int64 string', function () {
         let str = '9223372036854775807';
-        let uLong = PbLong.from(str);
-        expect(uLong.lo).toBe(-1);
-        expect(uLong.hi).toBe(2147483647);
-        expect(uLong.toString()).toBe("9223372036854775807");
+        let long = PbLong.from(str);
+        expect(long.lo).toBe(-1);
+        expect(long.hi).toBe(2147483647);
+        expect(long.toString()).toBe("9223372036854775807");
     });
 
     it('should from() min signed int64 string', function () {
         let str = '-9223372036854775808';
-        let uLong = PbLong.from(str);
-        expect(uLong.lo).toBe(0);
-        expect(uLong.hi).toBe(-2147483648);
+        let long = PbLong.from(str);
+        expect(long.lo).toBe(0);
+        expect(long.hi).toBe(-2147483648);
     });
 
     it('should toString() min signed int64', function () {
-        let uLong = new PbLong(0, -2147483648);
-        expect(uLong.toString()).toBe('-9223372036854775808');
+        let long = new PbLong(0, -2147483648);
+        expect(long.toString()).toBe('-9223372036854775808');
     });
 
     it('should from() max safe integer number', function () {
-        let uLong = PbLong.from(Number.MAX_SAFE_INTEGER);
-        expect(uLong.lo).toBe(-1);
-        expect(uLong.hi).toBe(2097151);
-        expect(uLong.toNumber()).toBe(Number.MAX_SAFE_INTEGER);
+        let long = PbLong.from(Number.MAX_SAFE_INTEGER);
+        expect(long.lo).toBe(-1);
+        expect(long.hi).toBe(2097151);
+        expect(long.toNumber()).toBe(Number.MAX_SAFE_INTEGER);
     });
 
     it('should from() min safe integer number', function () {
-        let uLong = PbLong.from(Number.MIN_SAFE_INTEGER);
-        expect(uLong.lo).toBe(1);
-        expect(uLong.hi).toBe(-2097152);
-        expect(uLong.toNumber()).toBe(Number.MIN_SAFE_INTEGER);
+        let long = PbLong.from(Number.MIN_SAFE_INTEGER);
+        expect(long.lo).toBe(1);
+        expect(long.hi).toBe(-2097152);
+        expect(long.toNumber()).toBe(Number.MIN_SAFE_INTEGER);
     });
 
     it('should fail invalid from() value', function () {
@@ -130,17 +149,22 @@ describe('PbLong', function () {
         expect(() => PbLong.from("0.75")).toThrowError();
         expect(() => PbLong.from("1,000")).toThrowError();
         expect(() => PbLong.from("1-000")).toThrowError();
-        let maxSignedPlusOneStr = "9223372036854775808"
-        expect(() => PbLong.from(maxSignedPlusOneStr)).toThrowError();
+        let maxSignedPlusOneStr = "9223372036854775808";
+        expect(() => PbLong.from(maxSignedPlusOneStr)).toThrowError('signed long too large');
+        let minSignedMinusOneStr = "-9223372036854775809";
+        expect(() => PbLong.from(minSignedMinusOneStr)).toThrowError('signed long too small');
+        let minUnsignedStr = '-18446744073709551616';
+        expect(() => PbLong.from(minUnsignedStr)).toThrowError('signed long too small');
         expect(() => PbLong.from(Number.NaN)).toThrowError();
         expect(() => PbLong.from(Number.POSITIVE_INFINITY)).toThrowError();
+        expect(() => PbLong.from(true as unknown as number)).toThrowError();
     });
 
     it('should toBigInt()', function () {
-        if (globalThis.BigInt === undefined)
-            pending('No BigInt support on current platform');
-
         let bi = new PbLong(-620756991, 53471156);
+        if (globalThis.BigInt === undefined)
+            return expect(() => bi.toBigInt()).toThrowError();
+
         // @ts-ignore
         expect(bi.toBigInt()).toBe(229656869973524481n);
 
@@ -152,7 +176,15 @@ describe('PbLong', function () {
         bi = new PbLong(-1, 2147483647);
         // @ts-ignore
         expect(bi.toBigInt()).toBe(9223372036854775807n);
+    });
 
+    it('should toNumber()', function () {
+        let bi = new PbLong(4294967295, 2097151);
+        expect(bi.toNumber()).toBe(Number.MAX_SAFE_INTEGER);
+
+        // signed max value
+        bi = new PbLong(4294967295, 2097152);
+        expect(() => bi.toNumber()).toThrowError("cannot convert to safe number");
     });
 
 
@@ -173,7 +205,7 @@ describe('PbLong', function () {
 
     it('should isNegative() with negative native bigint', function () {
         if (globalThis.BigInt === undefined)
-            pending('No BigInt support on current platform');
+            return expect().nothing();
 
         // @ts-ignore
         let long = PbLong.from(-9223372036854775808n)
@@ -187,7 +219,7 @@ describe('PbLong', function () {
 
     it('from(bigint) set expected bits', function () {
         if (globalThis.BigInt === undefined)
-            pending('No BigInt support on current platform');
+            return expect().nothing();
 
         // @ts-ignore
         let bi = PbLong.from(9223372036854775807n);
@@ -205,14 +237,22 @@ describe('PbLong', function () {
         expect(ulong.lo).toBe(0);
     });
 
-});
+    
+    it('should return ZERO for "0", 0, or 0n', function () {
+        expect(PbLong.from("0").isZero()).toBe(true);
+        expect(PbLong.from(0).isZero()).toBe(true);
+        if (globalThis.BigInt !== undefined)
+            // @ts-ignore
+            expect(PbLong.from(0n).isZero()).toBe(true);
+    });
 
+}
 
-describe('testing native bigint', function () {
+function testNativeBigInt() {
 
     it('max uint64 value should survive string conversion', function () {
         if (globalThis.BigInt === undefined)
-            pending('No BigInt support on current platform');
+            return expect().nothing();
 
         // @ts-ignore
         let m = 18446744073709551615n;
@@ -223,7 +263,7 @@ describe('testing native bigint', function () {
 
     it('min int64 value should survive string conversion', function () {
         if (globalThis.BigInt === undefined)
-            pending('No BigInt support on current platform');
+            return expect().nothing();
 
         // @ts-ignore
         let m = -9223372036854775808n;
@@ -234,7 +274,7 @@ describe('testing native bigint', function () {
 
     it('max int64 value should survive string conversion', function () {
         if (globalThis.BigInt === undefined)
-            pending('No BigInt support on current platform');
+            return expect().nothing();
 
         // @ts-ignore
         let m = 9223372036854775807n;
@@ -246,7 +286,7 @@ describe('testing native bigint', function () {
 
     it('max uint64 value should survive DataView round trip', function () {
         if (globalThis.BigInt === undefined)
-            pending('No BigInt support on current platform');
+            return expect().nothing();
 
         // @ts-ignore
         let expected = 18446744073709551615n;
@@ -268,7 +308,7 @@ describe('testing native bigint', function () {
 
     it('max int64 value should survive DataView round trip', function () {
         if (globalThis.BigInt === undefined)
-            pending('No BigInt support on current platform');
+            return expect().nothing();
 
         // @ts-ignore
         let expected = 9223372036854775807n;
@@ -290,7 +330,7 @@ describe('testing native bigint', function () {
 
     it('min int64 value should survive DataView round trip', function () {
         if (globalThis.BigInt === undefined)
-            pending('No BigInt support on current platform');
+            return expect().nothing();
 
         // @ts-ignore
         let expected = -9223372036854775808n;
@@ -309,5 +349,38 @@ describe('testing native bigint', function () {
         expect(actual.toString()).toBe(expected.toString());
     });
 
-});
+}
+
+function supportBI() {
+    globalThis.BigInt = BICtor;
+    detectBi();
+}
+
+function unsupportBI() {
+    // @ts-ignore
+    globalThis.BigInt = undefined;
+    detectBi();
+}
+
+function withAndWithoutBISupport(testFn: () => void) {
+    return function () {
+        describe('(with BI support)', function () {
+            if (BICtor === undefined)
+                return it('cannot be tested', function () {
+                    pending('No BigInt support on current platform');
+                });
+            beforeEach(supportBI);
+            testFn();
+        });
+        describe('(without BI support)', function () {
+            beforeEach(unsupportBI);
+            testFn();
+        });
+    }
+}
+
+describe('PbULong', withAndWithoutBISupport(testPbULong));
+describe('PbLong', withAndWithoutBISupport(testPbLong));
+describe('native bigint', withAndWithoutBISupport(testNativeBigInt));
+afterAll(supportBI);
 

--- a/packages/runtime/src/goog-varint.ts
+++ b/packages/runtime/src/goog-varint.ts
@@ -154,7 +154,7 @@ export function int64fromString(dec: string): [boolean, number, number] {
         const digit1e6 = Number(dec.slice(begin, end));
         highBits *= base;
         lowBits = lowBits * base + digit1e6;
-        // Carry bits from lowBits to
+        // Carry bits from lowBits to highBits
         if (lowBits >= TWO_PWR_32_DBL) {
             highBits = highBits + ((lowBits / TWO_PWR_32_DBL) | 0);
             lowBits = lowBits % TWO_PWR_32_DBL;
@@ -177,7 +177,7 @@ export function int64fromString(dec: string): [boolean, number, number] {
 export function int64toString(bitsLow: number, bitsHigh: number): string {
     // Skip the expensive conversion if the number is small enough to use the
     // built-in conversions.
-    if (bitsHigh <= 0x1FFFFF) {
+    if ((bitsHigh >>> 0) <= 0x1FFFFF) {
         return '' + (TWO_PWR_32_DBL * bitsHigh + (bitsLow >>> 0));
     }
 


### PR DESCRIPTION
Initially my goal was simply to improve code coverage, but in doing so I discovered a number of issues related to pb-long when the test environment did not have BigInt support.

Issues discovered and fixed with pb-long w/o BI support:
1. `PbLong.from()` did not throw when the string value was too small `"-9223372036854775809"`, `"-18446744073709551616"`
2. https://github.com/timostamm/protobuf-ts/blob/2f0ed591475e943df16653d49f1ca9f1ec678fe7/packages/runtime/spec/pb-long.spec.ts#L133-L134 `Expected function to throw an Error.`
3. https://github.com/timostamm/protobuf-ts/blob/2f0ed591475e943df16653d49f1ca9f1ec678fe7/packages/runtime/spec/pb-long.spec.ts#L37-L40 `Expected '-1' to be '18446744073709551615'.`
4. https://github.com/timostamm/protobuf-ts/blob/2f0ed591475e943df16653d49f1ca9f1ec678fe7/packages/runtime/spec/pb-long.spec.ts#L109-L112 `Expected '--9223372036854776000' to be '-9223372036854775808'.`

This change fixes those issues, ensures all pb-long tests are performed with and without BI support so the testing runtime environment doesn't strictly limit what can be tested. It also improves the test coverage for pb-long.