### PR TITLE
Improve IDE quality of life using tsconfig paths

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,9 @@
       "name": "root",
       "license": "(Apache-2.0 AND BSD-3-Clause)",
       "devDependencies": {
-        "lerna": "^3.22.1"
+        "@types/jasmine": "^3.5.10",
+        "lerna": "^3.22.1",
+        "typescript": ">=3.8.3 <4"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1340,6 +1342,12 @@
         "@types/minimatch": "*",
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/jasmine": {
+      "version": "3.5.11",
+      "resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-3.5.11.tgz",
+      "integrity": "sha512-fg1rOd/DehQTIJTifGqGVY6q92lDgnLfs7C6t1ccSwQrMyoTGSoH6wWzhJDZb6ezhsdwAX4EIBLe8w5fXWmEng==",
+      "dev": true
     },
     "node_modules/@types/minimatch": {
       "version": "3.0.3",
@@ -7887,6 +7895,19 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
     },
+    "node_modules/typescript": {
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.6.tgz",
+      "integrity": "sha512-Pspx3oKAPJtjNwE92YS05HQoY7z2SFyOpHo9MqJor3BXAGNaPUs83CuVp9VISFkSjyRfiTpmKuAYGJB7S7hOxw==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
     "node_modules/uglify-js": {
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.10.0.tgz",
@@ -9583,6 +9604,12 @@
         "@types/minimatch": "*",
         "@types/node": "*"
       }
+    },
+    "@types/jasmine": {
+      "version": "3.5.11",
+      "resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-3.5.11.tgz",
+      "integrity": "sha512-fg1rOd/DehQTIJTifGqGVY6q92lDgnLfs7C6t1ccSwQrMyoTGSoH6wWzhJDZb6ezhsdwAX4EIBLe8w5fXWmEng==",
+      "dev": true
     },
     "@types/minimatch": {
       "version": "3.0.3",
@@ -14888,6 +14915,12 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true
+    },
+    "typescript": {
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.6.tgz",
+      "integrity": "sha512-Pspx3oKAPJtjNwE92YS05HQoY7z2SFyOpHo9MqJor3BXAGNaPUs83CuVp9VISFkSjyRfiTpmKuAYGJB7S7hOxw==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,9 @@
   "name": "root",
   "private": true,
   "devDependencies": {
-    "lerna": "^3.22.1"
+    "@types/jasmine": "^3.5.10",
+    "lerna": "^3.22.1",
+    "typescript": ">=3.8.3 <4"
   },
   "license": "(Apache-2.0 AND BSD-3-Clause)"
 }

--- a/packages/grpc-backend/Makefile
+++ b/packages/grpc-backend/Makefile
@@ -5,9 +5,9 @@ SPECS := $(shell find spec -name '*.spec.ts')
 default: clean build test
 
 build:
-	@./node_modules/.bin/tsc --project tsconfig.json --module es2015 --outDir build/es2015;
+	@./node_modules/.bin/tsc --project tsconfig.build.json --module es2015 --outDir build/es2015;
 	@echo "es6 done"
-	@./node_modules/.bin/tsc --project tsconfig.json --module commonjs --outDir build/commonjs \
+	@./node_modules/.bin/tsc --project tsconfig.build.json --module commonjs --outDir build/commonjs \
 		--declaration --declarationDir build/types;
 	@echo "cjs done"
 

--- a/packages/grpc-backend/tsconfig.build.json
+++ b/packages/grpc-backend/tsconfig.build.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "paths": {},
+  }
+}

--- a/packages/grpc-backend/tsconfig.json
+++ b/packages/grpc-backend/tsconfig.json
@@ -11,6 +11,9 @@
     "moduleResolution": "node",
     "forceConsistentCasingInFileNames": true,
     "skipLibCheck": false,
+    "paths": {
+      "@protobuf-ts/*": ["../*/src"]
+    },
     "lib": [
       "es2017",
       "dom"

--- a/packages/grpc-backend/tsconfig.test.json
+++ b/packages/grpc-backend/tsconfig.test.json
@@ -7,6 +7,6 @@
   "compilerOptions": {
     "module": "CommonJS",
     "declaration": false,
-    "paths": {}
+    "sourceMap": true
   }
 }

--- a/packages/grpc-transport/Makefile
+++ b/packages/grpc-transport/Makefile
@@ -5,9 +5,9 @@ SPECS := $(shell find spec -name '*.spec.ts')
 default: clean build test
 
 build:
-	@./node_modules/.bin/tsc --project tsconfig.json --module es2015 --outDir build/es2015;
+	@./node_modules/.bin/tsc --project tsconfig.build.json --module es2015 --outDir build/es2015;
 	@echo "es6 done"
-	@./node_modules/.bin/tsc --project tsconfig.json --module commonjs --outDir build/commonjs \
+	@./node_modules/.bin/tsc --project tsconfig.build.json --module commonjs --outDir build/commonjs \
 		--declaration --declarationDir build/types;
 	@echo "cjs done"
 

--- a/packages/grpc-transport/tsconfig.build.json
+++ b/packages/grpc-transport/tsconfig.build.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "paths": {},
+  }
+}

--- a/packages/grpc-transport/tsconfig.json
+++ b/packages/grpc-transport/tsconfig.json
@@ -11,6 +11,9 @@
     "moduleResolution": "node",
     "forceConsistentCasingInFileNames": true,
     "skipLibCheck": false,
+    "paths": {
+      "@protobuf-ts/*": ["../*/src"]
+    },
     "lib": [
       "es2017",
       "dom"

--- a/packages/grpc-transport/tsconfig.test.json
+++ b/packages/grpc-transport/tsconfig.test.json
@@ -7,6 +7,6 @@
   "compilerOptions": {
     "module": "CommonJS",
     "declaration": false,
-    "paths": {}
+    "sourceMap": true
   }
 }

--- a/packages/grpcweb-transport/Makefile
+++ b/packages/grpcweb-transport/Makefile
@@ -5,9 +5,9 @@ SPECS := $(shell find spec -name '*.spec.ts')
 default: clean build test
 
 build:
-	@./node_modules/.bin/tsc --project tsconfig.json --module es2015 --outDir build/es2015;
+	@./node_modules/.bin/tsc --project tsconfig.build.json --module es2015 --outDir build/es2015;
 	@echo "es6 done"
-	@./node_modules/.bin/tsc --project tsconfig.json --module commonjs --outDir build/commonjs \
+	@./node_modules/.bin/tsc --project tsconfig.build.json --module commonjs --outDir build/commonjs \
 		--declaration --declarationDir build/types;
 	@echo "cjs done"
 

--- a/packages/grpcweb-transport/karma.conf.js
+++ b/packages/grpcweb-transport/karma.conf.js
@@ -21,6 +21,11 @@ module.exports = function (config) {
         browsers: ["ChromeHeadless"],
         singleRun: true,
         karmaTypescriptConfig: {
+            coverageOptions: {
+                exclude: [
+                    /(^|\/)spec\//i,
+                ]
+            },
             tsconfig: './tsconfig.test.json'
         },
         client: {

--- a/packages/grpcweb-transport/tsconfig.build.json
+++ b/packages/grpcweb-transport/tsconfig.build.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "paths": {},
+  }
+}

--- a/packages/grpcweb-transport/tsconfig.json
+++ b/packages/grpcweb-transport/tsconfig.json
@@ -11,6 +11,9 @@
     "moduleResolution": "node",
     "forceConsistentCasingInFileNames": true,
     "skipLibCheck": false,
+    "paths": {
+      "@protobuf-ts/*": ["../*/src"]
+    },
     "lib": [
       "es2017",
       "dom"

--- a/packages/grpcweb-transport/tsconfig.test.json
+++ b/packages/grpcweb-transport/tsconfig.test.json
@@ -7,7 +7,6 @@
   "compilerOptions": {
     "sourceMap": true,
     "module": "CommonJS",
-    "declaration": false,
-    "paths": {}
+    "declaration": false
   }
 }

--- a/packages/plugin-framework/Makefile
+++ b/packages/plugin-framework/Makefile
@@ -7,9 +7,9 @@ SPECS := $(shell find spec -name '*.spec.ts')
 default: clean build test
 
 build:
-	@./node_modules/.bin/tsc --project tsconfig.json --module es2015 --outDir build/es2015;
+	@./node_modules/.bin/tsc --project tsconfig.build.json --module es2015 --outDir build/es2015;
 	@echo "es6 done"
-	@./node_modules/.bin/tsc --project tsconfig.json --module commonjs --outDir build/commonjs \
+	@./node_modules/.bin/tsc --project tsconfig.build.json --module commonjs --outDir build/commonjs \
 		--declaration --declarationDir build/types;
 	@echo "cjs done"
 

--- a/packages/plugin-framework/tsconfig.build.json
+++ b/packages/plugin-framework/tsconfig.build.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "paths": {},
+  }
+}

--- a/packages/plugin-framework/tsconfig.json
+++ b/packages/plugin-framework/tsconfig.json
@@ -11,6 +11,9 @@
     "moduleResolution": "node",
     "forceConsistentCasingInFileNames": true,
     "skipLibCheck": false,
+    "paths": {
+      "@protobuf-ts/*": ["../*/src"]
+    },
     "lib": [
       "es2017",
       "dom"

--- a/packages/plugin-framework/tsconfig.test.json
+++ b/packages/plugin-framework/tsconfig.test.json
@@ -7,10 +7,7 @@
   "compilerOptions": {
     "module": "CommonJS",
     "declaration": false,
-    "paths": {
-      "@protobuf-ts/runtime": [
-        "../runtime"
-      ]
-    }
+    "sourceMap": true,
+    "paths": {}
   }
 }

--- a/packages/plugin/spec/protobufts-plugin-long.spec.ts
+++ b/packages/plugin/spec/protobufts-plugin-long.spec.ts
@@ -1,6 +1,6 @@
 import {getCodeGeneratorRequest} from "./support/helpers";
 import {ProtobuftsPlugin} from "../src/protobufts-plugin";
-import {GeneratedFile} from "@protobuf-ts/plugin-framework/src";
+import {GeneratedFile} from "@protobuf-ts/plugin-framework";
 
 const stringSnippets = [
     // Message

--- a/packages/plugin/tsconfig.build.json
+++ b/packages/plugin/tsconfig.build.json
@@ -4,6 +4,9 @@
     "src/protobufts-plugin.ts",
     "src/dump-plugin.ts"
   ],
+  "compilerOptions": {
+    "paths": {},
+  },
   "include": [
     "src/**/*.d.ts"
   ],

--- a/packages/plugin/tsconfig.json
+++ b/packages/plugin/tsconfig.json
@@ -12,6 +12,9 @@
     "resolveJsonModule": true,
     "forceConsistentCasingInFileNames": true,
     "skipLibCheck": false,
+    "paths": {
+      "@protobuf-ts/*": ["../*/src"]
+    },
     "lib": [
       "es2017",
       "dom"

--- a/packages/plugin/tsconfig.test.json
+++ b/packages/plugin/tsconfig.test.json
@@ -5,11 +5,11 @@
     "spec/support/*.ts"
   ],
   "compilerOptions": {
+    "skipLibCheck": true,
+    "sourceMap": true,
     "outDir": "/tmp",
     "paths": {
-      "@protobuf-ts/runtime": [
-        "../runtime"
-      ]
-    }
+      "@protobuf-ts/*": ["../*/src"]
+    },
   }
 }

--- a/packages/runtime-rpc/Makefile
+++ b/packages/runtime-rpc/Makefile
@@ -5,9 +5,9 @@ SPECS := $(shell find spec -name '*.spec.ts')
 default: clean build test
 
 build:
-	@./node_modules/.bin/tsc --project tsconfig.json --module es2015 --outDir build/es2015;
+	@./node_modules/.bin/tsc --project tsconfig.build.json --module es2015 --outDir build/es2015;
 	@echo "es6 done"
-	@./node_modules/.bin/tsc --project tsconfig.json --module commonjs --outDir build/commonjs \
+	@./node_modules/.bin/tsc --project tsconfig.build.json --module commonjs --outDir build/commonjs \
 		--declaration --declarationDir build/types;
 	@echo "cjs done"
 

--- a/packages/runtime-rpc/karma.conf.js
+++ b/packages/runtime-rpc/karma.conf.js
@@ -21,6 +21,11 @@ module.exports = function (config) {
         browsers: ["ChromeHeadless"],
         singleRun: true,
         karmaTypescriptConfig: {
+            coverageOptions: {
+                exclude: [
+                    /(^|\/)spec\//i,
+                ]
+            },
             tsconfig: './tsconfig.test.json'
         },
         client: {

--- a/packages/runtime-rpc/tsconfig.build.json
+++ b/packages/runtime-rpc/tsconfig.build.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "paths": {},
+  }
+}

--- a/packages/runtime-rpc/tsconfig.json
+++ b/packages/runtime-rpc/tsconfig.json
@@ -17,6 +17,9 @@
     // svelte requires this option
     "importsNotUsedAsValues": "error",
 
+    "paths": {
+      "@protobuf-ts/*": ["../*/src"]
+    },
     "lib": [
       "es2017",
       "dom",

--- a/packages/runtime-rpc/tsconfig.test.json
+++ b/packages/runtime-rpc/tsconfig.test.json
@@ -7,6 +7,6 @@
   "compilerOptions": {
     "module": "CommonJS",
     "declaration": false,
-    "paths": {}
+    "sourceMap": true
   }
 }

--- a/packages/runtime/karma.conf.js
+++ b/packages/runtime/karma.conf.js
@@ -21,6 +21,11 @@ module.exports = function (config) {
         browsers: ["ChromeHeadless"],
         singleRun: true,
         karmaTypescriptConfig: {
+            coverageOptions: {
+                exclude: [
+                    /(^|\/)spec\//i,
+                ]
+            },
             tsconfig: './tsconfig.test.json'
         },
         client: {

--- a/packages/runtime/tsconfig.base.json
+++ b/packages/runtime/tsconfig.base.json
@@ -19,10 +19,8 @@
     ],
 
     "paths": {
-      "@protobuf-ts/runtime": [
-        "./src"
-      ]
-    }
+      "@protobuf-ts/*": ["../*/src"]
+    },
 
   }
 }

--- a/packages/runtime/tsconfig.build.json
+++ b/packages/runtime/tsconfig.build.json
@@ -5,5 +5,6 @@
   ],
   "include": [],
   "compilerOptions": {
+    "paths": {},
   }
 }

--- a/packages/runtime/tsconfig.test.json
+++ b/packages/runtime/tsconfig.test.json
@@ -6,6 +6,7 @@
     "spec/**/*.ts"
   ],
   "compilerOptions": {
+    "sourceMap": true,
     "module": "CommonJS"
   }
 }

--- a/packages/test-generated/Makefile
+++ b/packages/test-generated/Makefile
@@ -19,7 +19,7 @@ clean:
 
 test-spec:
 	@./node_modules/.bin/ts-node \
-		--project tsconfig.json \
+		--project tsconfig.test.json \
 		--require tsconfig-paths/register \
 		./node_modules/.bin/jasmine --helper="spec/support/reporter.ts" \
 		$(SPECS)

--- a/packages/test-generated/tsconfig.bigint.json
+++ b/packages/test-generated/tsconfig.bigint.json
@@ -1,5 +1,5 @@
 {
-  "extends": "./tsconfig.json",
+  "extends": "./tsconfig.test.json",
   "compilerOptions": {
 
     // compiler requires this target for bigint

--- a/packages/test-generated/tsconfig.json
+++ b/packages/test-generated/tsconfig.json
@@ -9,18 +9,6 @@
     "module": "CommonJS",
     "target": "ES2015",
     "baseUrl": "./",
-
-
-    // activated for issue #3
-    // react sets this option, breaking const enum
-    "isolatedModules": true,
-
-
-    // activated for issue #94
-    // svelte requires this option
-    "importsNotUsedAsValues": "error",
-
-
     "strict": true,
     "lib": [
       "es2017",
@@ -28,9 +16,7 @@
       "es2020.bigint"
     ],
     "paths": {
-      "@protobuf-ts/runtime": [
-        "../runtime"
-      ]
-    }
+      "@protobuf-ts/*": ["../*/src"]
+    },
   }
 }

--- a/packages/test-generated/tsconfig.test.json
+++ b/packages/test-generated/tsconfig.test.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    // activated for issue #3
+    // react sets this option, breaking const enum
+    "isolatedModules": true,
+
+
+    // activated for issue #94
+    // svelte requires this option
+    "importsNotUsedAsValues": "error",
+    "paths": {},
+  }
+}

--- a/packages/twirp-transport/Makefile
+++ b/packages/twirp-transport/Makefile
@@ -5,9 +5,9 @@ SPECS := $(shell find spec -name '*.spec.ts')
 default: clean build test clientcompat
 
 build:
-	@./node_modules/.bin/tsc --project tsconfig.json --module es2015 --outDir build/es2015;
+	@./node_modules/.bin/tsc --project tsconfig.build.json --module es2015 --outDir build/es2015;
 	@echo "es6 done"
-	@./node_modules/.bin/tsc --project tsconfig.json --module commonjs --outDir build/commonjs \
+	@./node_modules/.bin/tsc --project tsconfig.build.json --module commonjs --outDir build/commonjs \
 		--declaration --declarationDir build/types;
 	@echo "cjs done"
 

--- a/packages/twirp-transport/karma.conf.js
+++ b/packages/twirp-transport/karma.conf.js
@@ -21,6 +21,11 @@ module.exports = function (config) {
         browsers: ["ChromeHeadless"],
         singleRun: true,
         karmaTypescriptConfig: {
+            coverageOptions: {
+                exclude: [
+                    /(^|\/)spec\//i,
+                ]
+            },
             tsconfig: './tsconfig.test.json'
         },
         client: {

--- a/packages/twirp-transport/tsconfig.build.json
+++ b/packages/twirp-transport/tsconfig.build.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "paths": {},
+  }
+}

--- a/packages/twirp-transport/tsconfig.json
+++ b/packages/twirp-transport/tsconfig.json
@@ -11,6 +11,9 @@
     "moduleResolution": "node",
     "forceConsistentCasingInFileNames": true,
     "skipLibCheck": false,
+    "paths": {
+      "@protobuf-ts/*": ["../*/src"]
+    },
     "lib": [
       "es2017",
       "es2015.collection",

--- a/packages/twirp-transport/tsconfig.test.json
+++ b/packages/twirp-transport/tsconfig.test.json
@@ -7,6 +7,6 @@
   "compilerOptions": {
     "module": "CommonJS",
     "declaration": false,
-    "paths": {}
+    "sourceMap": true
   }
 }


### PR DESCRIPTION
There are some minor annoyances when developing locally that this PR attempts to address:

1. In vscode (and likely other IDEs) when trying to "Go to definition" on something that was imported from another protobuf-ts package it will take you to the .d.ts file in the symlinked build folder. This makes navigating the repo more difficult than it need be.

   In an ideal world we would be able to use [TypeScript's "Project References"](https://www.typescriptlang.org/docs/handbook/project-references.html) which can handle automatically *building* other referenced packages when it detects a file has changed. Unfortunately ts-node (used for running tests, etc.) doesn't support this functionality: https://github.com/TypeStrong/ts-node/issues/897

   So for now there is still a manual process of having to re-run `make build` in whatever package directory before re-running tests from another package directory which depended on that other package.

2. Improve karma code coverage results by turning on source maps during testing and ignoring the `/spec` directory (we don't need coverage results of the test suite itself).
3. Add top-level dev dependency for jasmine types so that you don't see red underlines on all the global jasmine functions: describe, test, it, expect, etc.
4. Add top-level dev dependency for typescript so that vscode (and likely other IDEs) can find/use the [correct typescript lib (3.9.6) for inline type checking](https://code.visualstudio.com/docs/typescript/typescript-compiling#_using-the-workspace-version-of-typescript)