### PR TITLE
Make field writing order consistent between CODE_SIZE and SPEED

### DIFF
--- a/packages/plugin/src/interpreter.ts
+++ b/packages/plugin/src/interpreter.ts
@@ -382,7 +382,7 @@ export class Interpreter {
                 result.push(fi);
             }
         }
-        return result;
+        return result.sort((a, b) => a.no - b.no);
     }
 
 

--- a/packages/test-generated/spec/generated-binary-compat.spec.ts
+++ b/packages/test-generated/spec/generated-binary-compat.spec.ts
@@ -1,4 +1,4 @@
-import {IMessageType, MessageType} from "@protobuf-ts/runtime";
+import {IMessageType, MessageType, base64encode} from "@protobuf-ts/runtime";
 import {EnumFieldMessage} from "../ts-out/msg-enum";
 import {JsonNamesMessage} from "../ts-out/msg-json-names";
 import {MessageFieldMessage} from "../ts-out/msg-message";
@@ -6,6 +6,7 @@ import {OneofMessageMemberMessage, OneofScalarMemberMessage} from "../ts-out/msg
 import {Proto2OptionalsMessage} from "../ts-out/msg-proto2-optionals";
 import {Proto3OptionalsMessage} from "../ts-out/msg-proto3-optionals";
 import {RepeatedScalarValuesMessage, ScalarValuesMessage} from "../ts-out/msg-scalar";
+import {TestFieldOrderings} from "../ts-out/google/protobuf/unittest";
 
 let generatedRegistry: IMessageType<any>[] = [
     EnumFieldMessage,
@@ -38,6 +39,21 @@ describe('generated code compatibility', () => {
             });
         }
     });
+
+    it('should have same serialization order regardless of optimization options', function () {
+        const reflectionType = new MessageType<TestFieldOrderings>(TestFieldOrderings.typeName, [...TestFieldOrderings.fields].reverse());
+        const message = TestFieldOrderings.fromJson({
+            myFloat: 0.1,
+            myInt: "1",
+            myString: "1",
+            optionalNestedMessage: {
+                bb: 2,
+                oo: "2"
+            }
+        });
+        expect(base64encode(TestFieldOrderings.toBinary(message)))
+            .toBe(base64encode(reflectionType.toBinary(message)));
+    })
 
 });
 


### PR DESCRIPTION
Fixes https://github.com/timostamm/protobuf-ts/issues/453

Binary serialization is explicitly **not** expected to be consistent between different code generators and languages, but we should at least be self-consistent within protobuf-ts.

https://github.com/timostamm/protobuf-ts/blob/3a7ce47d43113d1a80cacd0ae70630b3727eda3e/packages/proto/google/protobuf/unittest.proto#L568-L570