### PR TITLE
Improve from Binary/Json/Partial performance by roughly 30%

### DIFF
--- a/packages/runtime/src/message-type-contract.ts
+++ b/packages/runtime/src/message-type-contract.ts
@@ -58,6 +58,12 @@ export interface IMessageType<T extends object> extends MessageInfo {
      */
     readonly options: { [extensionName: string]: JsonValue };
 
+    /**
+     * Contains the prototype for messages returned by create() which
+     * includes the `MESSAGE_TYPE` symbol pointing back to `this`.
+     */
+    readonly messagePrototype?: Readonly<{}>;
+
 
     /**
      * Create a new message with default values.

--- a/packages/runtime/src/message-type.ts
+++ b/packages/runtime/src/message-type.ts
@@ -1,4 +1,5 @@
 import type {IMessageType, PartialMessage} from "./message-type-contract";
+import {MESSAGE_TYPE} from "./message-type-contract";
 import type {FieldInfo, PartialFieldInfo} from "./reflection-info";
 import {normalizeFieldInfo} from "./reflection-info";
 import {ReflectionTypeCheck} from "./reflection-type-check";
@@ -49,6 +50,11 @@ export class MessageType<T extends object> implements IMessageType<T> {
      */
     readonly options: JsonOptionsMap;
 
+    /**
+     * Contains the prototype for messages returned by create() which
+     * includes the `MESSAGE_TYPE` symbol pointing back to `this`.
+     */
+    readonly messagePrototype: Readonly<{}> | undefined;
 
     protected readonly defaultCheckDepth = 16;
     protected readonly refTypeCheck: ReflectionTypeCheck;
@@ -61,6 +67,7 @@ export class MessageType<T extends object> implements IMessageType<T> {
         this.typeName = name;
         this.fields = fields.map(normalizeFieldInfo);
         this.options = options ?? {};
+        this.messagePrototype = Object.defineProperty({}, MESSAGE_TYPE, { value: this });
         this.refTypeCheck = new ReflectionTypeCheck(this);
         this.refJsonReader = new ReflectionJsonReader(this);
         this.refJsonWriter = new ReflectionJsonWriter(this);

--- a/packages/runtime/src/reflection-create.ts
+++ b/packages/runtime/src/reflection-create.ts
@@ -8,8 +8,9 @@ import {MESSAGE_TYPE} from './message-type-contract';
  * information.
  */
 export function reflectionCreate<T extends object>(type: IMessageType<T>): T {
-    const msg: UnknownMessage = {};
-    Object.defineProperty(msg, MESSAGE_TYPE, {enumerable: false, value: type});
+    const msg: UnknownMessage = type.messagePrototype
+        ? Object.create(type.messagePrototype)
+        : Object.defineProperty({}, MESSAGE_TYPE, {value: type});
     for (let field of type.fields) {
         let name = field.localName;
         if (field.opt)

--- a/packages/runtime/src/reflection-create.ts
+++ b/packages/runtime/src/reflection-create.ts
@@ -8,6 +8,16 @@ import {MESSAGE_TYPE} from './message-type-contract';
  * information.
  */
 export function reflectionCreate<T extends object>(type: IMessageType<T>): T {
+    /**
+     * This ternary can be removed in the next major version.
+     * The `Object.create()` code path utilizes a new `messagePrototype`
+     * property on the `IMessageType` which has this same `MESSAGE_TYPE`
+     * non-enumerable property on it. Doing it this way means that we only
+     * pay the cost of `Object.defineProperty()` once per `IMessageType`
+     * class of once per "instance". The falsy code path is only provided
+     * for backwards compatibility in cases where the runtime library is
+     * updated without also updating the generated code.
+     */
     const msg: UnknownMessage = type.messagePrototype
         ? Object.create(type.messagePrototype)
         : Object.defineProperty({}, MESSAGE_TYPE, {value: type});


### PR DESCRIPTION
As mentioned in https://github.com/timostamm/protobuf-ts/issues/306#issuecomment-1711935782 there is a non-trivial performance hit for using `Object.defineProperty()`. Searching around you can find [plenty](https://github.com/mrdoob/three.js/issues/21284) of other [mentions](https://humanwhocodes.com/blog/2015/11/performance-implication-object-defineproperty/) of this.

Originally my plan was to create a `MessageInstance` class property on the base `MessageType` class and then call `const message = new this.MessageInstance()` inside the `create()` method. Unfortunately jasmine seems consider two object to **NOT** be deeply equal to each other when one was created via `new this.MessageInstance()` vs. an object literal with the exact same structure. However, if instead we utilize `Object.create()` and pass in our prototype as the first argument (which should effectively be the same thing) then jasmine will consider the two objects deeply equal 🤷.

This change adds an **optional** `messagePrototype` property to the `IMessageType` interface (I'm hoping this isn't considered a backwards incompatible change). This `messagePrototype` is created inside the `MessageType` constructor and is stamped with the non-enumerable `MESSAGE_TYPE` symbol pointing back to `this`. Performing the stamping here means that we only are penalized for the `Object.defineProperty()` once per message "class" instead of once per message "instance".

I believe this change should be backwards compatible. Any old generated code should continue to work with the new runtime version, but newly generated code (only when optimized for speed) will not work with old runtime versions (optimized for size code will continue to work since it would go through `reflectCreate()` instead of generated code).

The below benchmarks were run with nodejs v20.6.1 (latest as of time of writing). According to these protobuf-ts (speed, bigint) will now read binary messages **~20% faster than protobufjs**.

Before:
```
### read binary
google-protobuf                           :      12.485 ops/s
ts-proto                                  :      28.737 ops/s
protobuf-ts (speed)                       :      29.579 ops/s
protobuf-ts (speed, bigint)               :      30.049 ops/s
protobuf-ts (size)                        :      25.837 ops/s
protobuf-ts (size, bigint)                :      25.751 ops/s
protobufjs                                :      34.636 ops/s
### from partial
ts-proto                                  :      44.974 ops/s
protobuf-ts (speed)                       :      24.363 ops/s
protobuf-ts (size)                        :      22.906 ops/s
### read json object
ts-proto                                  :      44.283 ops/s
protobuf-ts (speed)                       :      18.129 ops/s
protobuf-ts (size)                        :      18.235 ops/s
protobufjs                                :      46.67  ops/s
```

After
```
### read binary
google-protobuf                           :      12.642 ops/s
ts-proto                                  :      28.755 ops/s
protobuf-ts (speed)            (+34.967%) :      39.922 ops/s
protobuf-ts (speed, bigint)    (+39.326%) :      41.866 ops/s
protobuf-ts (size)             (+29.551%) :      32.935 ops/s
protobuf-ts (size, bigint)     (+29.983%) :      33.472 ops/s
protobufjs                                :      34.89  ops/s
### from partial
ts-proto                                  :      44.282 ops/s
protobuf-ts (speed)            (+31.954%) :      32.148 ops/s
protobuf-ts (size)             (+19.226%) :      27.31  ops/s
### read json object
ts-proto                                  :      44.131 ops/s
protobuf-ts (speed)            (+27.690%) :      23.149 ops/s
protobuf-ts (size)             (+19.962%) :      21.875 ops/s
protobufjs                                :      48.058 ops/s
```