### PR TITLE
ref Object from globalThis in speed-optimized code for serializing map fields

### DIFF
--- a/packages/plugin/src/message-type-extensions/internal-binary-write.ts
+++ b/packages/plugin/src/message-type-extensions/internal-binary-write.ts
@@ -610,7 +610,13 @@ export class InternalBinaryWrite implements CustomMethodGenerator {
             undefined,
             ts.createVariableDeclarationList([ts.createVariableDeclaration(ts.createIdentifier("k"), undefined, undefined)], ts.NodeFlags.Let),
             ts.createCall(
-                ts.createPropertyAccess(ts.createIdentifier("Object"), ts.createIdentifier("keys")),
+                ts.createPropertyAccess(
+                    ts.createPropertyAccess(
+                        ts.createIdentifier("globalThis"),
+                        ts.createIdentifier("Object")
+                    ),
+                    ts.createIdentifier("keys")
+                ),
                 undefined,
                 [fieldPropertyAccess]
             ),


### PR DESCRIPTION
fixes #610 

The generated code references the global `Object` (e.g. `Object.keys`) without explicitly referencing 'globalThis.' Therefore, if there is a message named 'Object,' issue arises due to incorrect reference (see details at #610). I modified it to access `Object` through `globalThis`.