### PR TITLE
Extend Object prototype for message instances

### DIFF
--- a/packages/runtime/src/message-type.ts
+++ b/packages/runtime/src/message-type.ts
@@ -69,7 +69,7 @@ export class MessageType<T extends object> implements IMessageType<T> {
         this.typeName = name;
         this.fields = fields.map(normalizeFieldInfo);
         this.options = options ?? {};
-        this.messagePrototype = Object.create(null, { ...baseDescriptors, [MESSAGE_TYPE]: { value: this } });;
+        this.messagePrototype = Object.create(null, { ...baseDescriptors, [MESSAGE_TYPE]: { value: this } });
         this.refTypeCheck = new ReflectionTypeCheck(this);
         this.refJsonReader = new ReflectionJsonReader(this);
         this.refJsonWriter = new ReflectionJsonWriter(this);

--- a/packages/runtime/src/message-type.ts
+++ b/packages/runtime/src/message-type.ts
@@ -67,7 +67,14 @@ export class MessageType<T extends object> implements IMessageType<T> {
         this.typeName = name;
         this.fields = fields.map(normalizeFieldInfo);
         this.options = options ?? {};
-        this.messagePrototype = Object.defineProperty({}, MESSAGE_TYPE, { value: this });
+        this.messagePrototype = this.messagePrototype = Object.defineProperty(
+            Object.create(
+              null,
+              Object.getOwnPropertyDescriptors(Object.getPrototypeOf({}))
+            ),
+            MESSAGE_TYPE,
+            { value: this },
+        );
         this.refTypeCheck = new ReflectionTypeCheck(this);
         this.refJsonReader = new ReflectionJsonReader(this);
         this.refJsonWriter = new ReflectionJsonWriter(this);

--- a/packages/runtime/src/message-type.ts
+++ b/packages/runtime/src/message-type.ts
@@ -19,6 +19,8 @@ import type {UnknownMessage} from "./unknown-types";
 import {binaryWriteOptions} from "./binary-writer";
 import {binaryReadOptions} from "./binary-reader";
 
+const baseDescriptors = Object.getOwnPropertyDescriptors(Object.getPrototypeOf({}));
+
 /**
  * This standard message type provides reflection-based
  * operations to work with a message.
@@ -67,14 +69,7 @@ export class MessageType<T extends object> implements IMessageType<T> {
         this.typeName = name;
         this.fields = fields.map(normalizeFieldInfo);
         this.options = options ?? {};
-        this.messagePrototype = this.messagePrototype = Object.defineProperty(
-            Object.create(
-              null,
-              Object.getOwnPropertyDescriptors(Object.getPrototypeOf({}))
-            ),
-            MESSAGE_TYPE,
-            { value: this },
-        );
+        this.messagePrototype = Object.create(null, { ...baseDescriptors, [MESSAGE_TYPE]: { value: this } });;
         this.refTypeCheck = new ReflectionTypeCheck(this);
         this.refJsonReader = new ReflectionJsonReader(this);
         this.refJsonWriter = new ReflectionJsonWriter(this);


### PR DESCRIPTION
After https://github.com/timostamm/protobuf-ts/pull/582, message instances don't behave exactly like simple objects, as their prototype only includes a `Symbol("protobuf-ts/message-type")` field and is missing fields normally present in a simple object (e.g. `constructor`). For us, this specifically causes an issue when using [mobx](https://github.com/mobxjs/mobx)  to observe changes to message instances - it only allows observing objects that have a `constructor` method in their prototype that matches the method for simple objects.

This fixes the problem by copying the default object prototype and adding a `Symbol("protobuf-ts/message-type")` field, rather than starting from an empty prototype.