### PR TITLE
Update go version for twirp compat tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,7 @@ jobs:
         if: success()
         uses: actions/setup-go@v3
         with:
-          go-version: 1.17.14
+          go-version: 1.17.13
 
       - name: Setup Node
         if: success()

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,7 @@ jobs:
         if: success()
         uses: actions/setup-go@v3
         with:
-          go-version: 1.16.4
+          go-version: 1.17.14
 
       - name: Setup Node
         if: success()


### PR DESCRIPTION
CI started failing with:

```
@protobuf-ts/twirp-transport: go: downloading google.golang.org/protobuf v1.33.0
Error: @protobuf-ts/twirp-transport: /home/runner/go/pkg/mod/github.com/golang/protobuf@v1.5.4/jsonpb/decode.go:19:2: //go:build comment without // +build comment
```

This updates to 1.17 to support the new build constraints.
