### PR TITLE
Maintain field order in generated type and reflection info

### DIFF
--- a/packages/benchmarks/gen/protobuf-ts.speed-bigint/google/protobuf/descriptor.ts
+++ b/packages/benchmarks/gen/protobuf-ts.speed-bigint/google/protobuf/descriptor.ts
@@ -2249,12 +2249,6 @@ class FileDescriptorProto$Type extends MessageType<FileDescriptorProto> {
         /* repeated string dependency = 3; */
         for (let i = 0; i < message.dependency.length; i++)
             writer.tag(3, WireType.LengthDelimited).string(message.dependency[i]);
-        /* repeated int32 public_dependency = 10; */
-        for (let i = 0; i < message.publicDependency.length; i++)
-            writer.tag(10, WireType.Varint).int32(message.publicDependency[i]);
-        /* repeated int32 weak_dependency = 11; */
-        for (let i = 0; i < message.weakDependency.length; i++)
-            writer.tag(11, WireType.Varint).int32(message.weakDependency[i]);
         /* repeated google.protobuf.DescriptorProto message_type = 4; */
         for (let i = 0; i < message.messageType.length; i++)
             DescriptorProto.internalBinaryWrite(message.messageType[i], writer.tag(4, WireType.LengthDelimited).fork(), options).join();
@@ -2273,6 +2267,12 @@ class FileDescriptorProto$Type extends MessageType<FileDescriptorProto> {
         /* optional google.protobuf.SourceCodeInfo source_code_info = 9; */
         if (message.sourceCodeInfo)
             SourceCodeInfo.internalBinaryWrite(message.sourceCodeInfo, writer.tag(9, WireType.LengthDelimited).fork(), options).join();
+        /* repeated int32 public_dependency = 10; */
+        for (let i = 0; i < message.publicDependency.length; i++)
+            writer.tag(10, WireType.Varint).int32(message.publicDependency[i]);
+        /* repeated int32 weak_dependency = 11; */
+        for (let i = 0; i < message.weakDependency.length; i++)
+            writer.tag(11, WireType.Varint).int32(message.weakDependency[i]);
         /* optional string syntax = 12; */
         if (message.syntax !== undefined)
             writer.tag(12, WireType.LengthDelimited).string(message.syntax);
@@ -2372,9 +2372,6 @@ class DescriptorProto$Type extends MessageType<DescriptorProto> {
         /* repeated google.protobuf.FieldDescriptorProto field = 2; */
         for (let i = 0; i < message.field.length; i++)
             FieldDescriptorProto.internalBinaryWrite(message.field[i], writer.tag(2, WireType.LengthDelimited).fork(), options).join();
-        /* repeated google.protobuf.FieldDescriptorProto extension = 6; */
-        for (let i = 0; i < message.extension.length; i++)
-            FieldDescriptorProto.internalBinaryWrite(message.extension[i], writer.tag(6, WireType.LengthDelimited).fork(), options).join();
         /* repeated google.protobuf.DescriptorProto nested_type = 3; */
         for (let i = 0; i < message.nestedType.length; i++)
             DescriptorProto.internalBinaryWrite(message.nestedType[i], writer.tag(3, WireType.LengthDelimited).fork(), options).join();
@@ -2384,12 +2381,15 @@ class DescriptorProto$Type extends MessageType<DescriptorProto> {
         /* repeated google.protobuf.DescriptorProto.ExtensionRange extension_range = 5; */
         for (let i = 0; i < message.extensionRange.length; i++)
             DescriptorProto_ExtensionRange.internalBinaryWrite(message.extensionRange[i], writer.tag(5, WireType.LengthDelimited).fork(), options).join();
-        /* repeated google.protobuf.OneofDescriptorProto oneof_decl = 8; */
-        for (let i = 0; i < message.oneofDecl.length; i++)
-            OneofDescriptorProto.internalBinaryWrite(message.oneofDecl[i], writer.tag(8, WireType.LengthDelimited).fork(), options).join();
+        /* repeated google.protobuf.FieldDescriptorProto extension = 6; */
+        for (let i = 0; i < message.extension.length; i++)
+            FieldDescriptorProto.internalBinaryWrite(message.extension[i], writer.tag(6, WireType.LengthDelimited).fork(), options).join();
         /* optional google.protobuf.MessageOptions options = 7; */
         if (message.options)
             MessageOptions.internalBinaryWrite(message.options, writer.tag(7, WireType.LengthDelimited).fork(), options).join();
+        /* repeated google.protobuf.OneofDescriptorProto oneof_decl = 8; */
+        for (let i = 0; i < message.oneofDecl.length; i++)
+            OneofDescriptorProto.internalBinaryWrite(message.oneofDecl[i], writer.tag(8, WireType.LengthDelimited).fork(), options).join();
         /* repeated google.protobuf.DescriptorProto.ReservedRange reserved_range = 9; */
         for (let i = 0; i < message.reservedRange.length; i++)
             DescriptorProto_ReservedRange.internalBinaryWrite(message.reservedRange[i], writer.tag(9, WireType.LengthDelimited).fork(), options).join();
@@ -2566,18 +2566,18 @@ class ExtensionRangeOptions$Type extends MessageType<ExtensionRangeOptions> {
         return message;
     }
     internalBinaryWrite(message: ExtensionRangeOptions, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
-        /* repeated google.protobuf.UninterpretedOption uninterpreted_option = 999; */
-        for (let i = 0; i < message.uninterpretedOption.length; i++)
-            UninterpretedOption.internalBinaryWrite(message.uninterpretedOption[i], writer.tag(999, WireType.LengthDelimited).fork(), options).join();
         /* repeated google.protobuf.ExtensionRangeOptions.Declaration declaration = 2; */
         for (let i = 0; i < message.declaration.length; i++)
             ExtensionRangeOptions_Declaration.internalBinaryWrite(message.declaration[i], writer.tag(2, WireType.LengthDelimited).fork(), options).join();
-        /* optional google.protobuf.FeatureSet features = 50; */
-        if (message.features)
-            FeatureSet.internalBinaryWrite(message.features, writer.tag(50, WireType.LengthDelimited).fork(), options).join();
         /* optional google.protobuf.ExtensionRangeOptions.VerificationState verification = 3; */
         if (message.verification !== undefined)
             writer.tag(3, WireType.Varint).int32(message.verification);
+        /* optional google.protobuf.FeatureSet features = 50; */
+        if (message.features)
+            FeatureSet.internalBinaryWrite(message.features, writer.tag(50, WireType.LengthDelimited).fork(), options).join();
+        /* repeated google.protobuf.UninterpretedOption uninterpreted_option = 999; */
+        for (let i = 0; i < message.uninterpretedOption.length; i++)
+            UninterpretedOption.internalBinaryWrite(message.uninterpretedOption[i], writer.tag(999, WireType.LengthDelimited).fork(), options).join();
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
@@ -2738,6 +2738,9 @@ class FieldDescriptorProto$Type extends MessageType<FieldDescriptorProto> {
         /* optional string name = 1; */
         if (message.name !== undefined)
             writer.tag(1, WireType.LengthDelimited).string(message.name);
+        /* optional string extendee = 2; */
+        if (message.extendee !== undefined)
+            writer.tag(2, WireType.LengthDelimited).string(message.extendee);
         /* optional int32 number = 3; */
         if (message.number !== undefined)
             writer.tag(3, WireType.Varint).int32(message.number);
@@ -2750,21 +2753,18 @@ class FieldDescriptorProto$Type extends MessageType<FieldDescriptorProto> {
         /* optional string type_name = 6; */
         if (message.typeName !== undefined)
             writer.tag(6, WireType.LengthDelimited).string(message.typeName);
-        /* optional string extendee = 2; */
-        if (message.extendee !== undefined)
-            writer.tag(2, WireType.LengthDelimited).string(message.extendee);
         /* optional string default_value = 7; */
         if (message.defaultValue !== undefined)
             writer.tag(7, WireType.LengthDelimited).string(message.defaultValue);
+        /* optional google.protobuf.FieldOptions options = 8; */
+        if (message.options)
+            FieldOptions.internalBinaryWrite(message.options, writer.tag(8, WireType.LengthDelimited).fork(), options).join();
         /* optional int32 oneof_index = 9; */
         if (message.oneofIndex !== undefined)
             writer.tag(9, WireType.Varint).int32(message.oneofIndex);
         /* optional string json_name = 10; */
         if (message.jsonName !== undefined)
             writer.tag(10, WireType.LengthDelimited).string(message.jsonName);
-        /* optional google.protobuf.FieldOptions options = 8; */
-        if (message.options)
-            FieldOptions.internalBinaryWrite(message.options, writer.tag(8, WireType.LengthDelimited).fork(), options).join();
         /* optional bool proto3_optional = 17; */
         if (message.proto3Optional !== undefined)
             writer.tag(17, WireType.Varint).bool(message.proto3Optional);
@@ -3283,18 +3283,12 @@ class FileOptions$Type extends MessageType<FileOptions> {
         /* optional string java_outer_classname = 8; */
         if (message.javaOuterClassname !== undefined)
             writer.tag(8, WireType.LengthDelimited).string(message.javaOuterClassname);
-        /* optional bool java_multiple_files = 10; */
-        if (message.javaMultipleFiles !== undefined)
-            writer.tag(10, WireType.Varint).bool(message.javaMultipleFiles);
-        /* optional bool java_generate_equals_and_hash = 20 [deprecated = true]; */
-        if (message.javaGenerateEqualsAndHash !== undefined)
-            writer.tag(20, WireType.Varint).bool(message.javaGenerateEqualsAndHash);
-        /* optional bool java_string_check_utf8 = 27; */
-        if (message.javaStringCheckUtf8 !== undefined)
-            writer.tag(27, WireType.Varint).bool(message.javaStringCheckUtf8);
         /* optional google.protobuf.FileOptions.OptimizeMode optimize_for = 9; */
         if (message.optimizeFor !== undefined)
             writer.tag(9, WireType.Varint).int32(message.optimizeFor);
+        /* optional bool java_multiple_files = 10; */
+        if (message.javaMultipleFiles !== undefined)
+            writer.tag(10, WireType.Varint).bool(message.javaMultipleFiles);
         /* optional string go_package = 11; */
         if (message.goPackage !== undefined)
             writer.tag(11, WireType.LengthDelimited).string(message.goPackage);
@@ -3307,9 +3301,15 @@ class FileOptions$Type extends MessageType<FileOptions> {
         /* optional bool py_generic_services = 18; */
         if (message.pyGenericServices !== undefined)
             writer.tag(18, WireType.Varint).bool(message.pyGenericServices);
+        /* optional bool java_generate_equals_and_hash = 20 [deprecated = true]; */
+        if (message.javaGenerateEqualsAndHash !== undefined)
+            writer.tag(20, WireType.Varint).bool(message.javaGenerateEqualsAndHash);
         /* optional bool deprecated = 23; */
         if (message.deprecated !== undefined)
             writer.tag(23, WireType.Varint).bool(message.deprecated);
+        /* optional bool java_string_check_utf8 = 27; */
+        if (message.javaStringCheckUtf8 !== undefined)
+            writer.tag(27, WireType.Varint).bool(message.javaStringCheckUtf8);
         /* optional bool cc_enable_arenas = 31; */
         if (message.ccEnableArenas !== undefined)
             writer.tag(31, WireType.Varint).bool(message.ccEnableArenas);
@@ -3537,21 +3537,21 @@ class FieldOptions$Type extends MessageType<FieldOptions> {
         /* optional bool packed = 2; */
         if (message.packed !== undefined)
             writer.tag(2, WireType.Varint).bool(message.packed);
-        /* optional google.protobuf.FieldOptions.JSType jstype = 6; */
-        if (message.jstype !== undefined)
-            writer.tag(6, WireType.Varint).int32(message.jstype);
-        /* optional bool lazy = 5; */
-        if (message.lazy !== undefined)
-            writer.tag(5, WireType.Varint).bool(message.lazy);
-        /* optional bool unverified_lazy = 15; */
-        if (message.unverifiedLazy !== undefined)
-            writer.tag(15, WireType.Varint).bool(message.unverifiedLazy);
         /* optional bool deprecated = 3; */
         if (message.deprecated !== undefined)
             writer.tag(3, WireType.Varint).bool(message.deprecated);
+        /* optional bool lazy = 5; */
+        if (message.lazy !== undefined)
+            writer.tag(5, WireType.Varint).bool(message.lazy);
+        /* optional google.protobuf.FieldOptions.JSType jstype = 6; */
+        if (message.jstype !== undefined)
+            writer.tag(6, WireType.Varint).int32(message.jstype);
         /* optional bool weak = 10; */
         if (message.weak !== undefined)
             writer.tag(10, WireType.Varint).bool(message.weak);
+        /* optional bool unverified_lazy = 15; */
+        if (message.unverifiedLazy !== undefined)
+            writer.tag(15, WireType.Varint).bool(message.unverifiedLazy);
         /* optional bool debug_redact = 16; */
         if (message.debugRedact !== undefined)
             writer.tag(16, WireType.Varint).bool(message.debugRedact);
@@ -3620,12 +3620,12 @@ class FieldOptions_EditionDefault$Type extends MessageType<FieldOptions_EditionD
         return message;
     }
     internalBinaryWrite(message: FieldOptions_EditionDefault, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
-        /* optional google.protobuf.Edition edition = 3; */
-        if (message.edition !== undefined)
-            writer.tag(3, WireType.Varint).int32(message.edition);
         /* optional string value = 2; */
         if (message.value !== undefined)
             writer.tag(2, WireType.LengthDelimited).string(message.value);
+        /* optional google.protobuf.Edition edition = 3; */
+        if (message.edition !== undefined)
+            writer.tag(3, WireType.Varint).int32(message.edition);
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
@@ -3949,12 +3949,12 @@ class ServiceOptions$Type extends MessageType<ServiceOptions> {
         return message;
     }
     internalBinaryWrite(message: ServiceOptions, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
-        /* optional google.protobuf.FeatureSet features = 34; */
-        if (message.features)
-            FeatureSet.internalBinaryWrite(message.features, writer.tag(34, WireType.LengthDelimited).fork(), options).join();
         /* optional bool deprecated = 33; */
         if (message.deprecated !== undefined)
             writer.tag(33, WireType.Varint).bool(message.deprecated);
+        /* optional google.protobuf.FeatureSet features = 34; */
+        if (message.features)
+            FeatureSet.internalBinaryWrite(message.features, writer.tag(34, WireType.LengthDelimited).fork(), options).join();
         /* repeated google.protobuf.UninterpretedOption uninterpreted_option = 999; */
         for (let i = 0; i < message.uninterpretedOption.length; i++)
             UninterpretedOption.internalBinaryWrite(message.uninterpretedOption[i], writer.tag(999, WireType.LengthDelimited).fork(), options).join();

--- a/packages/benchmarks/gen/protobuf-ts.speed/google/protobuf/descriptor.ts
+++ b/packages/benchmarks/gen/protobuf-ts.speed/google/protobuf/descriptor.ts
@@ -2249,12 +2249,6 @@ class FileDescriptorProto$Type extends MessageType<FileDescriptorProto> {
         /* repeated string dependency = 3; */
         for (let i = 0; i < message.dependency.length; i++)
             writer.tag(3, WireType.LengthDelimited).string(message.dependency[i]);
-        /* repeated int32 public_dependency = 10; */
-        for (let i = 0; i < message.publicDependency.length; i++)
-            writer.tag(10, WireType.Varint).int32(message.publicDependency[i]);
-        /* repeated int32 weak_dependency = 11; */
-        for (let i = 0; i < message.weakDependency.length; i++)
-            writer.tag(11, WireType.Varint).int32(message.weakDependency[i]);
         /* repeated google.protobuf.DescriptorProto message_type = 4; */
         for (let i = 0; i < message.messageType.length; i++)
             DescriptorProto.internalBinaryWrite(message.messageType[i], writer.tag(4, WireType.LengthDelimited).fork(), options).join();
@@ -2273,6 +2267,12 @@ class FileDescriptorProto$Type extends MessageType<FileDescriptorProto> {
         /* optional google.protobuf.SourceCodeInfo source_code_info = 9; */
         if (message.sourceCodeInfo)
             SourceCodeInfo.internalBinaryWrite(message.sourceCodeInfo, writer.tag(9, WireType.LengthDelimited).fork(), options).join();
+        /* repeated int32 public_dependency = 10; */
+        for (let i = 0; i < message.publicDependency.length; i++)
+            writer.tag(10, WireType.Varint).int32(message.publicDependency[i]);
+        /* repeated int32 weak_dependency = 11; */
+        for (let i = 0; i < message.weakDependency.length; i++)
+            writer.tag(11, WireType.Varint).int32(message.weakDependency[i]);
         /* optional string syntax = 12; */
         if (message.syntax !== undefined)
             writer.tag(12, WireType.LengthDelimited).string(message.syntax);
@@ -2372,9 +2372,6 @@ class DescriptorProto$Type extends MessageType<DescriptorProto> {
         /* repeated google.protobuf.FieldDescriptorProto field = 2; */
         for (let i = 0; i < message.field.length; i++)
             FieldDescriptorProto.internalBinaryWrite(message.field[i], writer.tag(2, WireType.LengthDelimited).fork(), options).join();
-        /* repeated google.protobuf.FieldDescriptorProto extension = 6; */
-        for (let i = 0; i < message.extension.length; i++)
-            FieldDescriptorProto.internalBinaryWrite(message.extension[i], writer.tag(6, WireType.LengthDelimited).fork(), options).join();
         /* repeated google.protobuf.DescriptorProto nested_type = 3; */
         for (let i = 0; i < message.nestedType.length; i++)
             DescriptorProto.internalBinaryWrite(message.nestedType[i], writer.tag(3, WireType.LengthDelimited).fork(), options).join();
@@ -2384,12 +2381,15 @@ class DescriptorProto$Type extends MessageType<DescriptorProto> {
         /* repeated google.protobuf.DescriptorProto.ExtensionRange extension_range = 5; */
         for (let i = 0; i < message.extensionRange.length; i++)
             DescriptorProto_ExtensionRange.internalBinaryWrite(message.extensionRange[i], writer.tag(5, WireType.LengthDelimited).fork(), options).join();
-        /* repeated google.protobuf.OneofDescriptorProto oneof_decl = 8; */
-        for (let i = 0; i < message.oneofDecl.length; i++)
-            OneofDescriptorProto.internalBinaryWrite(message.oneofDecl[i], writer.tag(8, WireType.LengthDelimited).fork(), options).join();
+        /* repeated google.protobuf.FieldDescriptorProto extension = 6; */
+        for (let i = 0; i < message.extension.length; i++)
+            FieldDescriptorProto.internalBinaryWrite(message.extension[i], writer.tag(6, WireType.LengthDelimited).fork(), options).join();
         /* optional google.protobuf.MessageOptions options = 7; */
         if (message.options)
             MessageOptions.internalBinaryWrite(message.options, writer.tag(7, WireType.LengthDelimited).fork(), options).join();
+        /* repeated google.protobuf.OneofDescriptorProto oneof_decl = 8; */
+        for (let i = 0; i < message.oneofDecl.length; i++)
+            OneofDescriptorProto.internalBinaryWrite(message.oneofDecl[i], writer.tag(8, WireType.LengthDelimited).fork(), options).join();
         /* repeated google.protobuf.DescriptorProto.ReservedRange reserved_range = 9; */
         for (let i = 0; i < message.reservedRange.length; i++)
             DescriptorProto_ReservedRange.internalBinaryWrite(message.reservedRange[i], writer.tag(9, WireType.LengthDelimited).fork(), options).join();
@@ -2566,18 +2566,18 @@ class ExtensionRangeOptions$Type extends MessageType<ExtensionRangeOptions> {
         return message;
     }
     internalBinaryWrite(message: ExtensionRangeOptions, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
-        /* repeated google.protobuf.UninterpretedOption uninterpreted_option = 999; */
-        for (let i = 0; i < message.uninterpretedOption.length; i++)
-            UninterpretedOption.internalBinaryWrite(message.uninterpretedOption[i], writer.tag(999, WireType.LengthDelimited).fork(), options).join();
         /* repeated google.protobuf.ExtensionRangeOptions.Declaration declaration = 2; */
         for (let i = 0; i < message.declaration.length; i++)
             ExtensionRangeOptions_Declaration.internalBinaryWrite(message.declaration[i], writer.tag(2, WireType.LengthDelimited).fork(), options).join();
-        /* optional google.protobuf.FeatureSet features = 50; */
-        if (message.features)
-            FeatureSet.internalBinaryWrite(message.features, writer.tag(50, WireType.LengthDelimited).fork(), options).join();
         /* optional google.protobuf.ExtensionRangeOptions.VerificationState verification = 3; */
         if (message.verification !== undefined)
             writer.tag(3, WireType.Varint).int32(message.verification);
+        /* optional google.protobuf.FeatureSet features = 50; */
+        if (message.features)
+            FeatureSet.internalBinaryWrite(message.features, writer.tag(50, WireType.LengthDelimited).fork(), options).join();
+        /* repeated google.protobuf.UninterpretedOption uninterpreted_option = 999; */
+        for (let i = 0; i < message.uninterpretedOption.length; i++)
+            UninterpretedOption.internalBinaryWrite(message.uninterpretedOption[i], writer.tag(999, WireType.LengthDelimited).fork(), options).join();
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
@@ -2738,6 +2738,9 @@ class FieldDescriptorProto$Type extends MessageType<FieldDescriptorProto> {
         /* optional string name = 1; */
         if (message.name !== undefined)
             writer.tag(1, WireType.LengthDelimited).string(message.name);
+        /* optional string extendee = 2; */
+        if (message.extendee !== undefined)
+            writer.tag(2, WireType.LengthDelimited).string(message.extendee);
         /* optional int32 number = 3; */
         if (message.number !== undefined)
             writer.tag(3, WireType.Varint).int32(message.number);
@@ -2750,21 +2753,18 @@ class FieldDescriptorProto$Type extends MessageType<FieldDescriptorProto> {
         /* optional string type_name = 6; */
         if (message.typeName !== undefined)
             writer.tag(6, WireType.LengthDelimited).string(message.typeName);
-        /* optional string extendee = 2; */
-        if (message.extendee !== undefined)
-            writer.tag(2, WireType.LengthDelimited).string(message.extendee);
         /* optional string default_value = 7; */
         if (message.defaultValue !== undefined)
             writer.tag(7, WireType.LengthDelimited).string(message.defaultValue);
+        /* optional google.protobuf.FieldOptions options = 8; */
+        if (message.options)
+            FieldOptions.internalBinaryWrite(message.options, writer.tag(8, WireType.LengthDelimited).fork(), options).join();
         /* optional int32 oneof_index = 9; */
         if (message.oneofIndex !== undefined)
             writer.tag(9, WireType.Varint).int32(message.oneofIndex);
         /* optional string json_name = 10; */
         if (message.jsonName !== undefined)
             writer.tag(10, WireType.LengthDelimited).string(message.jsonName);
-        /* optional google.protobuf.FieldOptions options = 8; */
-        if (message.options)
-            FieldOptions.internalBinaryWrite(message.options, writer.tag(8, WireType.LengthDelimited).fork(), options).join();
         /* optional bool proto3_optional = 17; */
         if (message.proto3Optional !== undefined)
             writer.tag(17, WireType.Varint).bool(message.proto3Optional);
@@ -3283,18 +3283,12 @@ class FileOptions$Type extends MessageType<FileOptions> {
         /* optional string java_outer_classname = 8; */
         if (message.javaOuterClassname !== undefined)
             writer.tag(8, WireType.LengthDelimited).string(message.javaOuterClassname);
-        /* optional bool java_multiple_files = 10; */
-        if (message.javaMultipleFiles !== undefined)
-            writer.tag(10, WireType.Varint).bool(message.javaMultipleFiles);
-        /* optional bool java_generate_equals_and_hash = 20 [deprecated = true]; */
-        if (message.javaGenerateEqualsAndHash !== undefined)
-            writer.tag(20, WireType.Varint).bool(message.javaGenerateEqualsAndHash);
-        /* optional bool java_string_check_utf8 = 27; */
-        if (message.javaStringCheckUtf8 !== undefined)
-            writer.tag(27, WireType.Varint).bool(message.javaStringCheckUtf8);
         /* optional google.protobuf.FileOptions.OptimizeMode optimize_for = 9; */
         if (message.optimizeFor !== undefined)
             writer.tag(9, WireType.Varint).int32(message.optimizeFor);
+        /* optional bool java_multiple_files = 10; */
+        if (message.javaMultipleFiles !== undefined)
+            writer.tag(10, WireType.Varint).bool(message.javaMultipleFiles);
         /* optional string go_package = 11; */
         if (message.goPackage !== undefined)
             writer.tag(11, WireType.LengthDelimited).string(message.goPackage);
@@ -3307,9 +3301,15 @@ class FileOptions$Type extends MessageType<FileOptions> {
         /* optional bool py_generic_services = 18; */
         if (message.pyGenericServices !== undefined)
             writer.tag(18, WireType.Varint).bool(message.pyGenericServices);
+        /* optional bool java_generate_equals_and_hash = 20 [deprecated = true]; */
+        if (message.javaGenerateEqualsAndHash !== undefined)
+            writer.tag(20, WireType.Varint).bool(message.javaGenerateEqualsAndHash);
         /* optional bool deprecated = 23; */
         if (message.deprecated !== undefined)
             writer.tag(23, WireType.Varint).bool(message.deprecated);
+        /* optional bool java_string_check_utf8 = 27; */
+        if (message.javaStringCheckUtf8 !== undefined)
+            writer.tag(27, WireType.Varint).bool(message.javaStringCheckUtf8);
         /* optional bool cc_enable_arenas = 31; */
         if (message.ccEnableArenas !== undefined)
             writer.tag(31, WireType.Varint).bool(message.ccEnableArenas);
@@ -3537,21 +3537,21 @@ class FieldOptions$Type extends MessageType<FieldOptions> {
         /* optional bool packed = 2; */
         if (message.packed !== undefined)
             writer.tag(2, WireType.Varint).bool(message.packed);
-        /* optional google.protobuf.FieldOptions.JSType jstype = 6; */
-        if (message.jstype !== undefined)
-            writer.tag(6, WireType.Varint).int32(message.jstype);
-        /* optional bool lazy = 5; */
-        if (message.lazy !== undefined)
-            writer.tag(5, WireType.Varint).bool(message.lazy);
-        /* optional bool unverified_lazy = 15; */
-        if (message.unverifiedLazy !== undefined)
-            writer.tag(15, WireType.Varint).bool(message.unverifiedLazy);
         /* optional bool deprecated = 3; */
         if (message.deprecated !== undefined)
             writer.tag(3, WireType.Varint).bool(message.deprecated);
+        /* optional bool lazy = 5; */
+        if (message.lazy !== undefined)
+            writer.tag(5, WireType.Varint).bool(message.lazy);
+        /* optional google.protobuf.FieldOptions.JSType jstype = 6; */
+        if (message.jstype !== undefined)
+            writer.tag(6, WireType.Varint).int32(message.jstype);
         /* optional bool weak = 10; */
         if (message.weak !== undefined)
             writer.tag(10, WireType.Varint).bool(message.weak);
+        /* optional bool unverified_lazy = 15; */
+        if (message.unverifiedLazy !== undefined)
+            writer.tag(15, WireType.Varint).bool(message.unverifiedLazy);
         /* optional bool debug_redact = 16; */
         if (message.debugRedact !== undefined)
             writer.tag(16, WireType.Varint).bool(message.debugRedact);
@@ -3620,12 +3620,12 @@ class FieldOptions_EditionDefault$Type extends MessageType<FieldOptions_EditionD
         return message;
     }
     internalBinaryWrite(message: FieldOptions_EditionDefault, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
-        /* optional google.protobuf.Edition edition = 3; */
-        if (message.edition !== undefined)
-            writer.tag(3, WireType.Varint).int32(message.edition);
         /* optional string value = 2; */
         if (message.value !== undefined)
             writer.tag(2, WireType.LengthDelimited).string(message.value);
+        /* optional google.protobuf.Edition edition = 3; */
+        if (message.edition !== undefined)
+            writer.tag(3, WireType.Varint).int32(message.edition);
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
@@ -3949,12 +3949,12 @@ class ServiceOptions$Type extends MessageType<ServiceOptions> {
         return message;
     }
     internalBinaryWrite(message: ServiceOptions, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
-        /* optional google.protobuf.FeatureSet features = 34; */
-        if (message.features)
-            FeatureSet.internalBinaryWrite(message.features, writer.tag(34, WireType.LengthDelimited).fork(), options).join();
         /* optional bool deprecated = 33; */
         if (message.deprecated !== undefined)
             writer.tag(33, WireType.Varint).bool(message.deprecated);
+        /* optional google.protobuf.FeatureSet features = 34; */
+        if (message.features)
+            FeatureSet.internalBinaryWrite(message.features, writer.tag(34, WireType.LengthDelimited).fork(), options).join();
         /* repeated google.protobuf.UninterpretedOption uninterpreted_option = 999; */
         for (let i = 0; i < message.uninterpretedOption.length; i++)
             UninterpretedOption.internalBinaryWrite(message.uninterpretedOption[i], writer.tag(999, WireType.LengthDelimited).fork(), options).join();

--- a/packages/plugin/src/interpreter.ts
+++ b/packages/plugin/src/interpreter.ts
@@ -382,7 +382,7 @@ export class Interpreter {
                 result.push(fi);
             }
         }
-        return result.sort((a, b) => a.no - b.no);
+        return result;
     }
 
 

--- a/packages/plugin/src/message-type-extensions/internal-binary-write.ts
+++ b/packages/plugin/src/message-type-extensions/internal-binary-write.ts
@@ -124,7 +124,7 @@ export class InternalBinaryWrite implements CustomMethodGenerator {
             interpreterType = this.interpreter.getMessageType(descriptor),
             statements: ts.Statement[] = [];
 
-        for (let fieldInfo of interpreterType.fields) {
+        for (let fieldInfo of interpreterType.fields.concat().sort((a, b) => a.no - b.no)) {
 
             let fieldDescriptor = descriptor.field.find(fd => fd.number === fieldInfo.no);
             assert(fieldDescriptor !== undefined);

--- a/packages/test-default/gen/conformance/conformance.ts
+++ b/packages/test-default/gen/conformance/conformance.ts
@@ -539,12 +539,6 @@ class ConformanceRequest$Type extends MessageType<ConformanceRequest> {
         /* string json_payload = 2; */
         if (message.payload.oneofKind === "jsonPayload")
             writer.tag(2, WireType.LengthDelimited).string(message.payload.jsonPayload);
-        /* string jspb_payload = 7; */
-        if (message.payload.oneofKind === "jspbPayload")
-            writer.tag(7, WireType.LengthDelimited).string(message.payload.jspbPayload);
-        /* string text_payload = 8; */
-        if (message.payload.oneofKind === "textPayload")
-            writer.tag(8, WireType.LengthDelimited).string(message.payload.textPayload);
         /* conformance.WireFormat requested_output_format = 3; */
         if (message.requestedOutputFormat !== 0)
             writer.tag(3, WireType.Varint).int32(message.requestedOutputFormat);
@@ -557,6 +551,12 @@ class ConformanceRequest$Type extends MessageType<ConformanceRequest> {
         /* conformance.JspbEncodingConfig jspb_encoding_options = 6; */
         if (message.jspbEncodingOptions)
             JspbEncodingConfig.internalBinaryWrite(message.jspbEncodingOptions, writer.tag(6, WireType.LengthDelimited).fork(), options).join();
+        /* string jspb_payload = 7; */
+        if (message.payload.oneofKind === "jspbPayload")
+            writer.tag(7, WireType.LengthDelimited).string(message.payload.jspbPayload);
+        /* string text_payload = 8; */
+        if (message.payload.oneofKind === "textPayload")
+            writer.tag(8, WireType.LengthDelimited).string(message.payload.textPayload);
         /* bool print_unknown_fields = 9; */
         if (message.printUnknownFields !== false)
             writer.tag(9, WireType.Varint).bool(message.printUnknownFields);
@@ -666,12 +666,6 @@ class ConformanceResponse$Type extends MessageType<ConformanceResponse> {
         /* string parse_error = 1; */
         if (message.result.oneofKind === "parseError")
             writer.tag(1, WireType.LengthDelimited).string(message.result.parseError);
-        /* string serialize_error = 6; */
-        if (message.result.oneofKind === "serializeError")
-            writer.tag(6, WireType.LengthDelimited).string(message.result.serializeError);
-        /* string timeout_error = 9; */
-        if (message.result.oneofKind === "timeoutError")
-            writer.tag(9, WireType.LengthDelimited).string(message.result.timeoutError);
         /* string runtime_error = 2; */
         if (message.result.oneofKind === "runtimeError")
             writer.tag(2, WireType.LengthDelimited).string(message.result.runtimeError);
@@ -684,12 +678,18 @@ class ConformanceResponse$Type extends MessageType<ConformanceResponse> {
         /* string skipped = 5; */
         if (message.result.oneofKind === "skipped")
             writer.tag(5, WireType.LengthDelimited).string(message.result.skipped);
+        /* string serialize_error = 6; */
+        if (message.result.oneofKind === "serializeError")
+            writer.tag(6, WireType.LengthDelimited).string(message.result.serializeError);
         /* string jspb_payload = 7; */
         if (message.result.oneofKind === "jspbPayload")
             writer.tag(7, WireType.LengthDelimited).string(message.result.jspbPayload);
         /* string text_payload = 8; */
         if (message.result.oneofKind === "textPayload")
             writer.tag(8, WireType.LengthDelimited).string(message.result.textPayload);
+        /* string timeout_error = 9; */
+        if (message.result.oneofKind === "timeoutError")
+            writer.tag(9, WireType.LengthDelimited).string(message.result.timeoutError);
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);

--- a/packages/test-default/gen/google/api/http.ts
+++ b/packages/test-default/gen/google/api/http.ts
@@ -608,18 +608,18 @@ class HttpRule$Type extends MessageType<HttpRule> {
         /* string patch = 6; */
         if (message.pattern.oneofKind === "patch")
             writer.tag(6, WireType.LengthDelimited).string(message.pattern.patch);
-        /* google.api.CustomHttpPattern custom = 8; */
-        if (message.pattern.oneofKind === "custom")
-            CustomHttpPattern.internalBinaryWrite(message.pattern.custom, writer.tag(8, WireType.LengthDelimited).fork(), options).join();
         /* string body = 7; */
         if (message.body !== "")
             writer.tag(7, WireType.LengthDelimited).string(message.body);
-        /* string response_body = 12; */
-        if (message.responseBody !== "")
-            writer.tag(12, WireType.LengthDelimited).string(message.responseBody);
+        /* google.api.CustomHttpPattern custom = 8; */
+        if (message.pattern.oneofKind === "custom")
+            CustomHttpPattern.internalBinaryWrite(message.pattern.custom, writer.tag(8, WireType.LengthDelimited).fork(), options).join();
         /* repeated google.api.HttpRule additional_bindings = 11; */
         for (let i = 0; i < message.additionalBindings.length; i++)
             HttpRule.internalBinaryWrite(message.additionalBindings[i], writer.tag(11, WireType.LengthDelimited).fork(), options).join();
+        /* string response_body = 12; */
+        if (message.responseBody !== "")
+            writer.tag(12, WireType.LengthDelimited).string(message.responseBody);
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);

--- a/packages/test-default/gen/google/protobuf/compiler/plugin.ts
+++ b/packages/test-default/gen/google/protobuf/compiler/plugin.ts
@@ -391,15 +391,15 @@ class CodeGeneratorRequest$Type extends MessageType<CodeGeneratorRequest> {
         /* optional string parameter = 2; */
         if (message.parameter !== undefined)
             writer.tag(2, WireType.LengthDelimited).string(message.parameter);
+        /* optional google.protobuf.compiler.Version compiler_version = 3; */
+        if (message.compilerVersion)
+            Version.internalBinaryWrite(message.compilerVersion, writer.tag(3, WireType.LengthDelimited).fork(), options).join();
         /* repeated google.protobuf.FileDescriptorProto proto_file = 15; */
         for (let i = 0; i < message.protoFile.length; i++)
             FileDescriptorProto.internalBinaryWrite(message.protoFile[i], writer.tag(15, WireType.LengthDelimited).fork(), options).join();
         /* repeated google.protobuf.FileDescriptorProto source_file_descriptors = 17; */
         for (let i = 0; i < message.sourceFileDescriptors.length; i++)
             FileDescriptorProto.internalBinaryWrite(message.sourceFileDescriptors[i], writer.tag(17, WireType.LengthDelimited).fork(), options).join();
-        /* optional google.protobuf.compiler.Version compiler_version = 3; */
-        if (message.compilerVersion)
-            Version.internalBinaryWrite(message.compilerVersion, writer.tag(3, WireType.LengthDelimited).fork(), options).join();
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);

--- a/packages/test-default/gen/google/protobuf/descriptor.ts
+++ b/packages/test-default/gen/google/protobuf/descriptor.ts
@@ -2249,12 +2249,6 @@ class FileDescriptorProto$Type extends MessageType<FileDescriptorProto> {
         /* repeated string dependency = 3; */
         for (let i = 0; i < message.dependency.length; i++)
             writer.tag(3, WireType.LengthDelimited).string(message.dependency[i]);
-        /* repeated int32 public_dependency = 10; */
-        for (let i = 0; i < message.publicDependency.length; i++)
-            writer.tag(10, WireType.Varint).int32(message.publicDependency[i]);
-        /* repeated int32 weak_dependency = 11; */
-        for (let i = 0; i < message.weakDependency.length; i++)
-            writer.tag(11, WireType.Varint).int32(message.weakDependency[i]);
         /* repeated google.protobuf.DescriptorProto message_type = 4; */
         for (let i = 0; i < message.messageType.length; i++)
             DescriptorProto.internalBinaryWrite(message.messageType[i], writer.tag(4, WireType.LengthDelimited).fork(), options).join();
@@ -2273,6 +2267,12 @@ class FileDescriptorProto$Type extends MessageType<FileDescriptorProto> {
         /* optional google.protobuf.SourceCodeInfo source_code_info = 9; */
         if (message.sourceCodeInfo)
             SourceCodeInfo.internalBinaryWrite(message.sourceCodeInfo, writer.tag(9, WireType.LengthDelimited).fork(), options).join();
+        /* repeated int32 public_dependency = 10; */
+        for (let i = 0; i < message.publicDependency.length; i++)
+            writer.tag(10, WireType.Varint).int32(message.publicDependency[i]);
+        /* repeated int32 weak_dependency = 11; */
+        for (let i = 0; i < message.weakDependency.length; i++)
+            writer.tag(11, WireType.Varint).int32(message.weakDependency[i]);
         /* optional string syntax = 12; */
         if (message.syntax !== undefined)
             writer.tag(12, WireType.LengthDelimited).string(message.syntax);
@@ -2372,9 +2372,6 @@ class DescriptorProto$Type extends MessageType<DescriptorProto> {
         /* repeated google.protobuf.FieldDescriptorProto field = 2; */
         for (let i = 0; i < message.field.length; i++)
             FieldDescriptorProto.internalBinaryWrite(message.field[i], writer.tag(2, WireType.LengthDelimited).fork(), options).join();
-        /* repeated google.protobuf.FieldDescriptorProto extension = 6; */
-        for (let i = 0; i < message.extension.length; i++)
-            FieldDescriptorProto.internalBinaryWrite(message.extension[i], writer.tag(6, WireType.LengthDelimited).fork(), options).join();
         /* repeated google.protobuf.DescriptorProto nested_type = 3; */
         for (let i = 0; i < message.nestedType.length; i++)
             DescriptorProto.internalBinaryWrite(message.nestedType[i], writer.tag(3, WireType.LengthDelimited).fork(), options).join();
@@ -2384,12 +2381,15 @@ class DescriptorProto$Type extends MessageType<DescriptorProto> {
         /* repeated google.protobuf.DescriptorProto.ExtensionRange extension_range = 5; */
         for (let i = 0; i < message.extensionRange.length; i++)
             DescriptorProto_ExtensionRange.internalBinaryWrite(message.extensionRange[i], writer.tag(5, WireType.LengthDelimited).fork(), options).join();
-        /* repeated google.protobuf.OneofDescriptorProto oneof_decl = 8; */
-        for (let i = 0; i < message.oneofDecl.length; i++)
-            OneofDescriptorProto.internalBinaryWrite(message.oneofDecl[i], writer.tag(8, WireType.LengthDelimited).fork(), options).join();
+        /* repeated google.protobuf.FieldDescriptorProto extension = 6; */
+        for (let i = 0; i < message.extension.length; i++)
+            FieldDescriptorProto.internalBinaryWrite(message.extension[i], writer.tag(6, WireType.LengthDelimited).fork(), options).join();
         /* optional google.protobuf.MessageOptions options = 7; */
         if (message.options)
             MessageOptions.internalBinaryWrite(message.options, writer.tag(7, WireType.LengthDelimited).fork(), options).join();
+        /* repeated google.protobuf.OneofDescriptorProto oneof_decl = 8; */
+        for (let i = 0; i < message.oneofDecl.length; i++)
+            OneofDescriptorProto.internalBinaryWrite(message.oneofDecl[i], writer.tag(8, WireType.LengthDelimited).fork(), options).join();
         /* repeated google.protobuf.DescriptorProto.ReservedRange reserved_range = 9; */
         for (let i = 0; i < message.reservedRange.length; i++)
             DescriptorProto_ReservedRange.internalBinaryWrite(message.reservedRange[i], writer.tag(9, WireType.LengthDelimited).fork(), options).join();
@@ -2566,18 +2566,18 @@ class ExtensionRangeOptions$Type extends MessageType<ExtensionRangeOptions> {
         return message;
     }
     internalBinaryWrite(message: ExtensionRangeOptions, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
-        /* repeated google.protobuf.UninterpretedOption uninterpreted_option = 999; */
-        for (let i = 0; i < message.uninterpretedOption.length; i++)
-            UninterpretedOption.internalBinaryWrite(message.uninterpretedOption[i], writer.tag(999, WireType.LengthDelimited).fork(), options).join();
         /* repeated google.protobuf.ExtensionRangeOptions.Declaration declaration = 2; */
         for (let i = 0; i < message.declaration.length; i++)
             ExtensionRangeOptions_Declaration.internalBinaryWrite(message.declaration[i], writer.tag(2, WireType.LengthDelimited).fork(), options).join();
-        /* optional google.protobuf.FeatureSet features = 50; */
-        if (message.features)
-            FeatureSet.internalBinaryWrite(message.features, writer.tag(50, WireType.LengthDelimited).fork(), options).join();
         /* optional google.protobuf.ExtensionRangeOptions.VerificationState verification = 3; */
         if (message.verification !== undefined)
             writer.tag(3, WireType.Varint).int32(message.verification);
+        /* optional google.protobuf.FeatureSet features = 50; */
+        if (message.features)
+            FeatureSet.internalBinaryWrite(message.features, writer.tag(50, WireType.LengthDelimited).fork(), options).join();
+        /* repeated google.protobuf.UninterpretedOption uninterpreted_option = 999; */
+        for (let i = 0; i < message.uninterpretedOption.length; i++)
+            UninterpretedOption.internalBinaryWrite(message.uninterpretedOption[i], writer.tag(999, WireType.LengthDelimited).fork(), options).join();
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
@@ -2738,6 +2738,9 @@ class FieldDescriptorProto$Type extends MessageType<FieldDescriptorProto> {
         /* optional string name = 1; */
         if (message.name !== undefined)
             writer.tag(1, WireType.LengthDelimited).string(message.name);
+        /* optional string extendee = 2; */
+        if (message.extendee !== undefined)
+            writer.tag(2, WireType.LengthDelimited).string(message.extendee);
         /* optional int32 number = 3; */
         if (message.number !== undefined)
             writer.tag(3, WireType.Varint).int32(message.number);
@@ -2750,21 +2753,18 @@ class FieldDescriptorProto$Type extends MessageType<FieldDescriptorProto> {
         /* optional string type_name = 6; */
         if (message.typeName !== undefined)
             writer.tag(6, WireType.LengthDelimited).string(message.typeName);
-        /* optional string extendee = 2; */
-        if (message.extendee !== undefined)
-            writer.tag(2, WireType.LengthDelimited).string(message.extendee);
         /* optional string default_value = 7; */
         if (message.defaultValue !== undefined)
             writer.tag(7, WireType.LengthDelimited).string(message.defaultValue);
+        /* optional google.protobuf.FieldOptions options = 8; */
+        if (message.options)
+            FieldOptions.internalBinaryWrite(message.options, writer.tag(8, WireType.LengthDelimited).fork(), options).join();
         /* optional int32 oneof_index = 9; */
         if (message.oneofIndex !== undefined)
             writer.tag(9, WireType.Varint).int32(message.oneofIndex);
         /* optional string json_name = 10; */
         if (message.jsonName !== undefined)
             writer.tag(10, WireType.LengthDelimited).string(message.jsonName);
-        /* optional google.protobuf.FieldOptions options = 8; */
-        if (message.options)
-            FieldOptions.internalBinaryWrite(message.options, writer.tag(8, WireType.LengthDelimited).fork(), options).join();
         /* optional bool proto3_optional = 17; */
         if (message.proto3Optional !== undefined)
             writer.tag(17, WireType.Varint).bool(message.proto3Optional);
@@ -3283,18 +3283,12 @@ class FileOptions$Type extends MessageType<FileOptions> {
         /* optional string java_outer_classname = 8; */
         if (message.javaOuterClassname !== undefined)
             writer.tag(8, WireType.LengthDelimited).string(message.javaOuterClassname);
-        /* optional bool java_multiple_files = 10; */
-        if (message.javaMultipleFiles !== undefined)
-            writer.tag(10, WireType.Varint).bool(message.javaMultipleFiles);
-        /* optional bool java_generate_equals_and_hash = 20 [deprecated = true]; */
-        if (message.javaGenerateEqualsAndHash !== undefined)
-            writer.tag(20, WireType.Varint).bool(message.javaGenerateEqualsAndHash);
-        /* optional bool java_string_check_utf8 = 27; */
-        if (message.javaStringCheckUtf8 !== undefined)
-            writer.tag(27, WireType.Varint).bool(message.javaStringCheckUtf8);
         /* optional google.protobuf.FileOptions.OptimizeMode optimize_for = 9; */
         if (message.optimizeFor !== undefined)
             writer.tag(9, WireType.Varint).int32(message.optimizeFor);
+        /* optional bool java_multiple_files = 10; */
+        if (message.javaMultipleFiles !== undefined)
+            writer.tag(10, WireType.Varint).bool(message.javaMultipleFiles);
         /* optional string go_package = 11; */
         if (message.goPackage !== undefined)
             writer.tag(11, WireType.LengthDelimited).string(message.goPackage);
@@ -3307,9 +3301,15 @@ class FileOptions$Type extends MessageType<FileOptions> {
         /* optional bool py_generic_services = 18; */
         if (message.pyGenericServices !== undefined)
             writer.tag(18, WireType.Varint).bool(message.pyGenericServices);
+        /* optional bool java_generate_equals_and_hash = 20 [deprecated = true]; */
+        if (message.javaGenerateEqualsAndHash !== undefined)
+            writer.tag(20, WireType.Varint).bool(message.javaGenerateEqualsAndHash);
         /* optional bool deprecated = 23; */
         if (message.deprecated !== undefined)
             writer.tag(23, WireType.Varint).bool(message.deprecated);
+        /* optional bool java_string_check_utf8 = 27; */
+        if (message.javaStringCheckUtf8 !== undefined)
+            writer.tag(27, WireType.Varint).bool(message.javaStringCheckUtf8);
         /* optional bool cc_enable_arenas = 31; */
         if (message.ccEnableArenas !== undefined)
             writer.tag(31, WireType.Varint).bool(message.ccEnableArenas);
@@ -3537,21 +3537,21 @@ class FieldOptions$Type extends MessageType<FieldOptions> {
         /* optional bool packed = 2; */
         if (message.packed !== undefined)
             writer.tag(2, WireType.Varint).bool(message.packed);
-        /* optional google.protobuf.FieldOptions.JSType jstype = 6; */
-        if (message.jstype !== undefined)
-            writer.tag(6, WireType.Varint).int32(message.jstype);
-        /* optional bool lazy = 5; */
-        if (message.lazy !== undefined)
-            writer.tag(5, WireType.Varint).bool(message.lazy);
-        /* optional bool unverified_lazy = 15; */
-        if (message.unverifiedLazy !== undefined)
-            writer.tag(15, WireType.Varint).bool(message.unverifiedLazy);
         /* optional bool deprecated = 3; */
         if (message.deprecated !== undefined)
             writer.tag(3, WireType.Varint).bool(message.deprecated);
+        /* optional bool lazy = 5; */
+        if (message.lazy !== undefined)
+            writer.tag(5, WireType.Varint).bool(message.lazy);
+        /* optional google.protobuf.FieldOptions.JSType jstype = 6; */
+        if (message.jstype !== undefined)
+            writer.tag(6, WireType.Varint).int32(message.jstype);
         /* optional bool weak = 10; */
         if (message.weak !== undefined)
             writer.tag(10, WireType.Varint).bool(message.weak);
+        /* optional bool unverified_lazy = 15; */
+        if (message.unverifiedLazy !== undefined)
+            writer.tag(15, WireType.Varint).bool(message.unverifiedLazy);
         /* optional bool debug_redact = 16; */
         if (message.debugRedact !== undefined)
             writer.tag(16, WireType.Varint).bool(message.debugRedact);
@@ -3620,12 +3620,12 @@ class FieldOptions_EditionDefault$Type extends MessageType<FieldOptions_EditionD
         return message;
     }
     internalBinaryWrite(message: FieldOptions_EditionDefault, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
-        /* optional google.protobuf.Edition edition = 3; */
-        if (message.edition !== undefined)
-            writer.tag(3, WireType.Varint).int32(message.edition);
         /* optional string value = 2; */
         if (message.value !== undefined)
             writer.tag(2, WireType.LengthDelimited).string(message.value);
+        /* optional google.protobuf.Edition edition = 3; */
+        if (message.edition !== undefined)
+            writer.tag(3, WireType.Varint).int32(message.edition);
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
@@ -3949,12 +3949,12 @@ class ServiceOptions$Type extends MessageType<ServiceOptions> {
         return message;
     }
     internalBinaryWrite(message: ServiceOptions, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
-        /* optional google.protobuf.FeatureSet features = 34; */
-        if (message.features)
-            FeatureSet.internalBinaryWrite(message.features, writer.tag(34, WireType.LengthDelimited).fork(), options).join();
         /* optional bool deprecated = 33; */
         if (message.deprecated !== undefined)
             writer.tag(33, WireType.Varint).bool(message.deprecated);
+        /* optional google.protobuf.FeatureSet features = 34; */
+        if (message.features)
+            FeatureSet.internalBinaryWrite(message.features, writer.tag(34, WireType.LengthDelimited).fork(), options).join();
         /* repeated google.protobuf.UninterpretedOption uninterpreted_option = 999; */
         for (let i = 0; i < message.uninterpretedOption.length; i++)
             UninterpretedOption.internalBinaryWrite(message.uninterpretedOption[i], writer.tag(999, WireType.LengthDelimited).fork(), options).join();

--- a/packages/test-default/gen/google/protobuf/test_messages_proto2.ts
+++ b/packages/test-default/gen/google/protobuf/test_messages_proto2.ts
@@ -2354,6 +2354,71 @@ class TestAllTypesProto2$Type extends MessageType<TestAllTypesProto2> {
         /* repeated string repeated_cord = 55; */
         for (let i = 0; i < message.repeatedCord.length; i++)
             writer.tag(55, WireType.LengthDelimited).string(message.repeatedCord[i]);
+        /* map<int32, int32> map_int32_int32 = 56; */
+        for (let k of globalThis.Object.keys(message.mapInt32Int32))
+            writer.tag(56, WireType.LengthDelimited).fork().tag(1, WireType.Varint).int32(parseInt(k)).tag(2, WireType.Varint).int32(message.mapInt32Int32[k as any]).join();
+        /* map<int64, int64> map_int64_int64 = 57; */
+        for (let k of globalThis.Object.keys(message.mapInt64Int64))
+            writer.tag(57, WireType.LengthDelimited).fork().tag(1, WireType.Varint).int64(k).tag(2, WireType.Varint).int64(message.mapInt64Int64[k]).join();
+        /* map<uint32, uint32> map_uint32_uint32 = 58; */
+        for (let k of globalThis.Object.keys(message.mapUint32Uint32))
+            writer.tag(58, WireType.LengthDelimited).fork().tag(1, WireType.Varint).uint32(parseInt(k)).tag(2, WireType.Varint).uint32(message.mapUint32Uint32[k as any]).join();
+        /* map<uint64, uint64> map_uint64_uint64 = 59; */
+        for (let k of globalThis.Object.keys(message.mapUint64Uint64))
+            writer.tag(59, WireType.LengthDelimited).fork().tag(1, WireType.Varint).uint64(k).tag(2, WireType.Varint).uint64(message.mapUint64Uint64[k]).join();
+        /* map<sint32, sint32> map_sint32_sint32 = 60; */
+        for (let k of globalThis.Object.keys(message.mapSint32Sint32))
+            writer.tag(60, WireType.LengthDelimited).fork().tag(1, WireType.Varint).sint32(parseInt(k)).tag(2, WireType.Varint).sint32(message.mapSint32Sint32[k as any]).join();
+        /* map<sint64, sint64> map_sint64_sint64 = 61; */
+        for (let k of globalThis.Object.keys(message.mapSint64Sint64))
+            writer.tag(61, WireType.LengthDelimited).fork().tag(1, WireType.Varint).sint64(k).tag(2, WireType.Varint).sint64(message.mapSint64Sint64[k]).join();
+        /* map<fixed32, fixed32> map_fixed32_fixed32 = 62; */
+        for (let k of globalThis.Object.keys(message.mapFixed32Fixed32))
+            writer.tag(62, WireType.LengthDelimited).fork().tag(1, WireType.Bit32).fixed32(parseInt(k)).tag(2, WireType.Bit32).fixed32(message.mapFixed32Fixed32[k as any]).join();
+        /* map<fixed64, fixed64> map_fixed64_fixed64 = 63; */
+        for (let k of globalThis.Object.keys(message.mapFixed64Fixed64))
+            writer.tag(63, WireType.LengthDelimited).fork().tag(1, WireType.Bit64).fixed64(k).tag(2, WireType.Bit64).fixed64(message.mapFixed64Fixed64[k]).join();
+        /* map<sfixed32, sfixed32> map_sfixed32_sfixed32 = 64; */
+        for (let k of globalThis.Object.keys(message.mapSfixed32Sfixed32))
+            writer.tag(64, WireType.LengthDelimited).fork().tag(1, WireType.Bit32).sfixed32(parseInt(k)).tag(2, WireType.Bit32).sfixed32(message.mapSfixed32Sfixed32[k as any]).join();
+        /* map<sfixed64, sfixed64> map_sfixed64_sfixed64 = 65; */
+        for (let k of globalThis.Object.keys(message.mapSfixed64Sfixed64))
+            writer.tag(65, WireType.LengthDelimited).fork().tag(1, WireType.Bit64).sfixed64(k).tag(2, WireType.Bit64).sfixed64(message.mapSfixed64Sfixed64[k]).join();
+        /* map<int32, float> map_int32_float = 66; */
+        for (let k of globalThis.Object.keys(message.mapInt32Float))
+            writer.tag(66, WireType.LengthDelimited).fork().tag(1, WireType.Varint).int32(parseInt(k)).tag(2, WireType.Bit32).float(message.mapInt32Float[k as any]).join();
+        /* map<int32, double> map_int32_double = 67; */
+        for (let k of globalThis.Object.keys(message.mapInt32Double))
+            writer.tag(67, WireType.LengthDelimited).fork().tag(1, WireType.Varint).int32(parseInt(k)).tag(2, WireType.Bit64).double(message.mapInt32Double[k as any]).join();
+        /* map<bool, bool> map_bool_bool = 68; */
+        for (let k of globalThis.Object.keys(message.mapBoolBool))
+            writer.tag(68, WireType.LengthDelimited).fork().tag(1, WireType.Varint).bool(k === "true").tag(2, WireType.Varint).bool(message.mapBoolBool[k]).join();
+        /* map<string, string> map_string_string = 69; */
+        for (let k of globalThis.Object.keys(message.mapStringString))
+            writer.tag(69, WireType.LengthDelimited).fork().tag(1, WireType.LengthDelimited).string(k).tag(2, WireType.LengthDelimited).string(message.mapStringString[k]).join();
+        /* map<string, bytes> map_string_bytes = 70; */
+        for (let k of globalThis.Object.keys(message.mapStringBytes))
+            writer.tag(70, WireType.LengthDelimited).fork().tag(1, WireType.LengthDelimited).string(k).tag(2, WireType.LengthDelimited).bytes(message.mapStringBytes[k]).join();
+        /* map<string, protobuf_test_messages.proto2.TestAllTypesProto2.NestedMessage> map_string_nested_message = 71; */
+        for (let k of globalThis.Object.keys(message.mapStringNestedMessage)) {
+            writer.tag(71, WireType.LengthDelimited).fork().tag(1, WireType.LengthDelimited).string(k);
+            writer.tag(2, WireType.LengthDelimited).fork();
+            TestAllTypesProto2_NestedMessage.internalBinaryWrite(message.mapStringNestedMessage[k], writer, options);
+            writer.join().join();
+        }
+        /* map<string, protobuf_test_messages.proto2.ForeignMessageProto2> map_string_foreign_message = 72; */
+        for (let k of globalThis.Object.keys(message.mapStringForeignMessage)) {
+            writer.tag(72, WireType.LengthDelimited).fork().tag(1, WireType.LengthDelimited).string(k);
+            writer.tag(2, WireType.LengthDelimited).fork();
+            ForeignMessageProto2.internalBinaryWrite(message.mapStringForeignMessage[k], writer, options);
+            writer.join().join();
+        }
+        /* map<string, protobuf_test_messages.proto2.TestAllTypesProto2.NestedEnum> map_string_nested_enum = 73; */
+        for (let k of globalThis.Object.keys(message.mapStringNestedEnum))
+            writer.tag(73, WireType.LengthDelimited).fork().tag(1, WireType.LengthDelimited).string(k).tag(2, WireType.Varint).int32(message.mapStringNestedEnum[k]).join();
+        /* map<string, protobuf_test_messages.proto2.ForeignEnumProto2> map_string_foreign_enum = 74; */
+        for (let k of globalThis.Object.keys(message.mapStringForeignEnum))
+            writer.tag(74, WireType.LengthDelimited).fork().tag(1, WireType.LengthDelimited).string(k).tag(2, WireType.Varint).int32(message.mapStringForeignEnum[k]).join();
         /* repeated int32 packed_int32 = 75 [packed = true]; */
         if (message.packedInt32.length) {
             writer.tag(75, WireType.LengthDelimited).fork();
@@ -2494,71 +2559,6 @@ class TestAllTypesProto2$Type extends MessageType<TestAllTypesProto2> {
         /* repeated protobuf_test_messages.proto2.TestAllTypesProto2.NestedEnum unpacked_nested_enum = 102 [packed = false]; */
         for (let i = 0; i < message.unpackedNestedEnum.length; i++)
             writer.tag(102, WireType.Varint).int32(message.unpackedNestedEnum[i]);
-        /* map<int32, int32> map_int32_int32 = 56; */
-        for (let k of globalThis.Object.keys(message.mapInt32Int32))
-            writer.tag(56, WireType.LengthDelimited).fork().tag(1, WireType.Varint).int32(parseInt(k)).tag(2, WireType.Varint).int32(message.mapInt32Int32[k as any]).join();
-        /* map<int64, int64> map_int64_int64 = 57; */
-        for (let k of globalThis.Object.keys(message.mapInt64Int64))
-            writer.tag(57, WireType.LengthDelimited).fork().tag(1, WireType.Varint).int64(k).tag(2, WireType.Varint).int64(message.mapInt64Int64[k]).join();
-        /* map<uint32, uint32> map_uint32_uint32 = 58; */
-        for (let k of globalThis.Object.keys(message.mapUint32Uint32))
-            writer.tag(58, WireType.LengthDelimited).fork().tag(1, WireType.Varint).uint32(parseInt(k)).tag(2, WireType.Varint).uint32(message.mapUint32Uint32[k as any]).join();
-        /* map<uint64, uint64> map_uint64_uint64 = 59; */
-        for (let k of globalThis.Object.keys(message.mapUint64Uint64))
-            writer.tag(59, WireType.LengthDelimited).fork().tag(1, WireType.Varint).uint64(k).tag(2, WireType.Varint).uint64(message.mapUint64Uint64[k]).join();
-        /* map<sint32, sint32> map_sint32_sint32 = 60; */
-        for (let k of globalThis.Object.keys(message.mapSint32Sint32))
-            writer.tag(60, WireType.LengthDelimited).fork().tag(1, WireType.Varint).sint32(parseInt(k)).tag(2, WireType.Varint).sint32(message.mapSint32Sint32[k as any]).join();
-        /* map<sint64, sint64> map_sint64_sint64 = 61; */
-        for (let k of globalThis.Object.keys(message.mapSint64Sint64))
-            writer.tag(61, WireType.LengthDelimited).fork().tag(1, WireType.Varint).sint64(k).tag(2, WireType.Varint).sint64(message.mapSint64Sint64[k]).join();
-        /* map<fixed32, fixed32> map_fixed32_fixed32 = 62; */
-        for (let k of globalThis.Object.keys(message.mapFixed32Fixed32))
-            writer.tag(62, WireType.LengthDelimited).fork().tag(1, WireType.Bit32).fixed32(parseInt(k)).tag(2, WireType.Bit32).fixed32(message.mapFixed32Fixed32[k as any]).join();
-        /* map<fixed64, fixed64> map_fixed64_fixed64 = 63; */
-        for (let k of globalThis.Object.keys(message.mapFixed64Fixed64))
-            writer.tag(63, WireType.LengthDelimited).fork().tag(1, WireType.Bit64).fixed64(k).tag(2, WireType.Bit64).fixed64(message.mapFixed64Fixed64[k]).join();
-        /* map<sfixed32, sfixed32> map_sfixed32_sfixed32 = 64; */
-        for (let k of globalThis.Object.keys(message.mapSfixed32Sfixed32))
-            writer.tag(64, WireType.LengthDelimited).fork().tag(1, WireType.Bit32).sfixed32(parseInt(k)).tag(2, WireType.Bit32).sfixed32(message.mapSfixed32Sfixed32[k as any]).join();
-        /* map<sfixed64, sfixed64> map_sfixed64_sfixed64 = 65; */
-        for (let k of globalThis.Object.keys(message.mapSfixed64Sfixed64))
-            writer.tag(65, WireType.LengthDelimited).fork().tag(1, WireType.Bit64).sfixed64(k).tag(2, WireType.Bit64).sfixed64(message.mapSfixed64Sfixed64[k]).join();
-        /* map<int32, float> map_int32_float = 66; */
-        for (let k of globalThis.Object.keys(message.mapInt32Float))
-            writer.tag(66, WireType.LengthDelimited).fork().tag(1, WireType.Varint).int32(parseInt(k)).tag(2, WireType.Bit32).float(message.mapInt32Float[k as any]).join();
-        /* map<int32, double> map_int32_double = 67; */
-        for (let k of globalThis.Object.keys(message.mapInt32Double))
-            writer.tag(67, WireType.LengthDelimited).fork().tag(1, WireType.Varint).int32(parseInt(k)).tag(2, WireType.Bit64).double(message.mapInt32Double[k as any]).join();
-        /* map<bool, bool> map_bool_bool = 68; */
-        for (let k of globalThis.Object.keys(message.mapBoolBool))
-            writer.tag(68, WireType.LengthDelimited).fork().tag(1, WireType.Varint).bool(k === "true").tag(2, WireType.Varint).bool(message.mapBoolBool[k]).join();
-        /* map<string, string> map_string_string = 69; */
-        for (let k of globalThis.Object.keys(message.mapStringString))
-            writer.tag(69, WireType.LengthDelimited).fork().tag(1, WireType.LengthDelimited).string(k).tag(2, WireType.LengthDelimited).string(message.mapStringString[k]).join();
-        /* map<string, bytes> map_string_bytes = 70; */
-        for (let k of globalThis.Object.keys(message.mapStringBytes))
-            writer.tag(70, WireType.LengthDelimited).fork().tag(1, WireType.LengthDelimited).string(k).tag(2, WireType.LengthDelimited).bytes(message.mapStringBytes[k]).join();
-        /* map<string, protobuf_test_messages.proto2.TestAllTypesProto2.NestedMessage> map_string_nested_message = 71; */
-        for (let k of globalThis.Object.keys(message.mapStringNestedMessage)) {
-            writer.tag(71, WireType.LengthDelimited).fork().tag(1, WireType.LengthDelimited).string(k);
-            writer.tag(2, WireType.LengthDelimited).fork();
-            TestAllTypesProto2_NestedMessage.internalBinaryWrite(message.mapStringNestedMessage[k], writer, options);
-            writer.join().join();
-        }
-        /* map<string, protobuf_test_messages.proto2.ForeignMessageProto2> map_string_foreign_message = 72; */
-        for (let k of globalThis.Object.keys(message.mapStringForeignMessage)) {
-            writer.tag(72, WireType.LengthDelimited).fork().tag(1, WireType.LengthDelimited).string(k);
-            writer.tag(2, WireType.LengthDelimited).fork();
-            ForeignMessageProto2.internalBinaryWrite(message.mapStringForeignMessage[k], writer, options);
-            writer.join().join();
-        }
-        /* map<string, protobuf_test_messages.proto2.TestAllTypesProto2.NestedEnum> map_string_nested_enum = 73; */
-        for (let k of globalThis.Object.keys(message.mapStringNestedEnum))
-            writer.tag(73, WireType.LengthDelimited).fork().tag(1, WireType.LengthDelimited).string(k).tag(2, WireType.Varint).int32(message.mapStringNestedEnum[k]).join();
-        /* map<string, protobuf_test_messages.proto2.ForeignEnumProto2> map_string_foreign_enum = 74; */
-        for (let k of globalThis.Object.keys(message.mapStringForeignEnum))
-            writer.tag(74, WireType.LengthDelimited).fork().tag(1, WireType.LengthDelimited).string(k).tag(2, WireType.Varint).int32(message.mapStringForeignEnum[k]).join();
         /* uint32 oneof_uint32 = 111; */
         if (message.oneofField.oneofKind === "oneofUint32")
             writer.tag(111, WireType.Varint).uint32(message.oneofField.oneofUint32);

--- a/packages/test-default/gen/google/protobuf/test_messages_proto3.ts
+++ b/packages/test-default/gen/google/protobuf/test_messages_proto3.ts
@@ -2307,6 +2307,71 @@ class TestAllTypesProto3$Type extends MessageType<TestAllTypesProto3> {
         /* repeated string repeated_cord = 55; */
         for (let i = 0; i < message.repeatedCord.length; i++)
             writer.tag(55, WireType.LengthDelimited).string(message.repeatedCord[i]);
+        /* map<int32, int32> map_int32_int32 = 56; */
+        for (let k of globalThis.Object.keys(message.mapInt32Int32))
+            writer.tag(56, WireType.LengthDelimited).fork().tag(1, WireType.Varint).int32(parseInt(k)).tag(2, WireType.Varint).int32(message.mapInt32Int32[k as any]).join();
+        /* map<int64, int64> map_int64_int64 = 57; */
+        for (let k of globalThis.Object.keys(message.mapInt64Int64))
+            writer.tag(57, WireType.LengthDelimited).fork().tag(1, WireType.Varint).int64(k).tag(2, WireType.Varint).int64(message.mapInt64Int64[k]).join();
+        /* map<uint32, uint32> map_uint32_uint32 = 58; */
+        for (let k of globalThis.Object.keys(message.mapUint32Uint32))
+            writer.tag(58, WireType.LengthDelimited).fork().tag(1, WireType.Varint).uint32(parseInt(k)).tag(2, WireType.Varint).uint32(message.mapUint32Uint32[k as any]).join();
+        /* map<uint64, uint64> map_uint64_uint64 = 59; */
+        for (let k of globalThis.Object.keys(message.mapUint64Uint64))
+            writer.tag(59, WireType.LengthDelimited).fork().tag(1, WireType.Varint).uint64(k).tag(2, WireType.Varint).uint64(message.mapUint64Uint64[k]).join();
+        /* map<sint32, sint32> map_sint32_sint32 = 60; */
+        for (let k of globalThis.Object.keys(message.mapSint32Sint32))
+            writer.tag(60, WireType.LengthDelimited).fork().tag(1, WireType.Varint).sint32(parseInt(k)).tag(2, WireType.Varint).sint32(message.mapSint32Sint32[k as any]).join();
+        /* map<sint64, sint64> map_sint64_sint64 = 61; */
+        for (let k of globalThis.Object.keys(message.mapSint64Sint64))
+            writer.tag(61, WireType.LengthDelimited).fork().tag(1, WireType.Varint).sint64(k).tag(2, WireType.Varint).sint64(message.mapSint64Sint64[k]).join();
+        /* map<fixed32, fixed32> map_fixed32_fixed32 = 62; */
+        for (let k of globalThis.Object.keys(message.mapFixed32Fixed32))
+            writer.tag(62, WireType.LengthDelimited).fork().tag(1, WireType.Bit32).fixed32(parseInt(k)).tag(2, WireType.Bit32).fixed32(message.mapFixed32Fixed32[k as any]).join();
+        /* map<fixed64, fixed64> map_fixed64_fixed64 = 63; */
+        for (let k of globalThis.Object.keys(message.mapFixed64Fixed64))
+            writer.tag(63, WireType.LengthDelimited).fork().tag(1, WireType.Bit64).fixed64(k).tag(2, WireType.Bit64).fixed64(message.mapFixed64Fixed64[k]).join();
+        /* map<sfixed32, sfixed32> map_sfixed32_sfixed32 = 64; */
+        for (let k of globalThis.Object.keys(message.mapSfixed32Sfixed32))
+            writer.tag(64, WireType.LengthDelimited).fork().tag(1, WireType.Bit32).sfixed32(parseInt(k)).tag(2, WireType.Bit32).sfixed32(message.mapSfixed32Sfixed32[k as any]).join();
+        /* map<sfixed64, sfixed64> map_sfixed64_sfixed64 = 65; */
+        for (let k of globalThis.Object.keys(message.mapSfixed64Sfixed64))
+            writer.tag(65, WireType.LengthDelimited).fork().tag(1, WireType.Bit64).sfixed64(k).tag(2, WireType.Bit64).sfixed64(message.mapSfixed64Sfixed64[k]).join();
+        /* map<int32, float> map_int32_float = 66; */
+        for (let k of globalThis.Object.keys(message.mapInt32Float))
+            writer.tag(66, WireType.LengthDelimited).fork().tag(1, WireType.Varint).int32(parseInt(k)).tag(2, WireType.Bit32).float(message.mapInt32Float[k as any]).join();
+        /* map<int32, double> map_int32_double = 67; */
+        for (let k of globalThis.Object.keys(message.mapInt32Double))
+            writer.tag(67, WireType.LengthDelimited).fork().tag(1, WireType.Varint).int32(parseInt(k)).tag(2, WireType.Bit64).double(message.mapInt32Double[k as any]).join();
+        /* map<bool, bool> map_bool_bool = 68; */
+        for (let k of globalThis.Object.keys(message.mapBoolBool))
+            writer.tag(68, WireType.LengthDelimited).fork().tag(1, WireType.Varint).bool(k === "true").tag(2, WireType.Varint).bool(message.mapBoolBool[k]).join();
+        /* map<string, string> map_string_string = 69; */
+        for (let k of globalThis.Object.keys(message.mapStringString))
+            writer.tag(69, WireType.LengthDelimited).fork().tag(1, WireType.LengthDelimited).string(k).tag(2, WireType.LengthDelimited).string(message.mapStringString[k]).join();
+        /* map<string, bytes> map_string_bytes = 70; */
+        for (let k of globalThis.Object.keys(message.mapStringBytes))
+            writer.tag(70, WireType.LengthDelimited).fork().tag(1, WireType.LengthDelimited).string(k).tag(2, WireType.LengthDelimited).bytes(message.mapStringBytes[k]).join();
+        /* map<string, protobuf_test_messages.proto3.TestAllTypesProto3.NestedMessage> map_string_nested_message = 71; */
+        for (let k of globalThis.Object.keys(message.mapStringNestedMessage)) {
+            writer.tag(71, WireType.LengthDelimited).fork().tag(1, WireType.LengthDelimited).string(k);
+            writer.tag(2, WireType.LengthDelimited).fork();
+            TestAllTypesProto3_NestedMessage.internalBinaryWrite(message.mapStringNestedMessage[k], writer, options);
+            writer.join().join();
+        }
+        /* map<string, protobuf_test_messages.proto3.ForeignMessage> map_string_foreign_message = 72; */
+        for (let k of globalThis.Object.keys(message.mapStringForeignMessage)) {
+            writer.tag(72, WireType.LengthDelimited).fork().tag(1, WireType.LengthDelimited).string(k);
+            writer.tag(2, WireType.LengthDelimited).fork();
+            ForeignMessage.internalBinaryWrite(message.mapStringForeignMessage[k], writer, options);
+            writer.join().join();
+        }
+        /* map<string, protobuf_test_messages.proto3.TestAllTypesProto3.NestedEnum> map_string_nested_enum = 73; */
+        for (let k of globalThis.Object.keys(message.mapStringNestedEnum))
+            writer.tag(73, WireType.LengthDelimited).fork().tag(1, WireType.LengthDelimited).string(k).tag(2, WireType.Varint).int32(message.mapStringNestedEnum[k]).join();
+        /* map<string, protobuf_test_messages.proto3.ForeignEnum> map_string_foreign_enum = 74; */
+        for (let k of globalThis.Object.keys(message.mapStringForeignEnum))
+            writer.tag(74, WireType.LengthDelimited).fork().tag(1, WireType.LengthDelimited).string(k).tag(2, WireType.Varint).int32(message.mapStringForeignEnum[k]).join();
         /* repeated int32 packed_int32 = 75 [packed = true]; */
         if (message.packedInt32.length) {
             writer.tag(75, WireType.LengthDelimited).fork();
@@ -2447,71 +2512,6 @@ class TestAllTypesProto3$Type extends MessageType<TestAllTypesProto3> {
         /* repeated protobuf_test_messages.proto3.TestAllTypesProto3.NestedEnum unpacked_nested_enum = 102 [packed = false]; */
         for (let i = 0; i < message.unpackedNestedEnum.length; i++)
             writer.tag(102, WireType.Varint).int32(message.unpackedNestedEnum[i]);
-        /* map<int32, int32> map_int32_int32 = 56; */
-        for (let k of globalThis.Object.keys(message.mapInt32Int32))
-            writer.tag(56, WireType.LengthDelimited).fork().tag(1, WireType.Varint).int32(parseInt(k)).tag(2, WireType.Varint).int32(message.mapInt32Int32[k as any]).join();
-        /* map<int64, int64> map_int64_int64 = 57; */
-        for (let k of globalThis.Object.keys(message.mapInt64Int64))
-            writer.tag(57, WireType.LengthDelimited).fork().tag(1, WireType.Varint).int64(k).tag(2, WireType.Varint).int64(message.mapInt64Int64[k]).join();
-        /* map<uint32, uint32> map_uint32_uint32 = 58; */
-        for (let k of globalThis.Object.keys(message.mapUint32Uint32))
-            writer.tag(58, WireType.LengthDelimited).fork().tag(1, WireType.Varint).uint32(parseInt(k)).tag(2, WireType.Varint).uint32(message.mapUint32Uint32[k as any]).join();
-        /* map<uint64, uint64> map_uint64_uint64 = 59; */
-        for (let k of globalThis.Object.keys(message.mapUint64Uint64))
-            writer.tag(59, WireType.LengthDelimited).fork().tag(1, WireType.Varint).uint64(k).tag(2, WireType.Varint).uint64(message.mapUint64Uint64[k]).join();
-        /* map<sint32, sint32> map_sint32_sint32 = 60; */
-        for (let k of globalThis.Object.keys(message.mapSint32Sint32))
-            writer.tag(60, WireType.LengthDelimited).fork().tag(1, WireType.Varint).sint32(parseInt(k)).tag(2, WireType.Varint).sint32(message.mapSint32Sint32[k as any]).join();
-        /* map<sint64, sint64> map_sint64_sint64 = 61; */
-        for (let k of globalThis.Object.keys(message.mapSint64Sint64))
-            writer.tag(61, WireType.LengthDelimited).fork().tag(1, WireType.Varint).sint64(k).tag(2, WireType.Varint).sint64(message.mapSint64Sint64[k]).join();
-        /* map<fixed32, fixed32> map_fixed32_fixed32 = 62; */
-        for (let k of globalThis.Object.keys(message.mapFixed32Fixed32))
-            writer.tag(62, WireType.LengthDelimited).fork().tag(1, WireType.Bit32).fixed32(parseInt(k)).tag(2, WireType.Bit32).fixed32(message.mapFixed32Fixed32[k as any]).join();
-        /* map<fixed64, fixed64> map_fixed64_fixed64 = 63; */
-        for (let k of globalThis.Object.keys(message.mapFixed64Fixed64))
-            writer.tag(63, WireType.LengthDelimited).fork().tag(1, WireType.Bit64).fixed64(k).tag(2, WireType.Bit64).fixed64(message.mapFixed64Fixed64[k]).join();
-        /* map<sfixed32, sfixed32> map_sfixed32_sfixed32 = 64; */
-        for (let k of globalThis.Object.keys(message.mapSfixed32Sfixed32))
-            writer.tag(64, WireType.LengthDelimited).fork().tag(1, WireType.Bit32).sfixed32(parseInt(k)).tag(2, WireType.Bit32).sfixed32(message.mapSfixed32Sfixed32[k as any]).join();
-        /* map<sfixed64, sfixed64> map_sfixed64_sfixed64 = 65; */
-        for (let k of globalThis.Object.keys(message.mapSfixed64Sfixed64))
-            writer.tag(65, WireType.LengthDelimited).fork().tag(1, WireType.Bit64).sfixed64(k).tag(2, WireType.Bit64).sfixed64(message.mapSfixed64Sfixed64[k]).join();
-        /* map<int32, float> map_int32_float = 66; */
-        for (let k of globalThis.Object.keys(message.mapInt32Float))
-            writer.tag(66, WireType.LengthDelimited).fork().tag(1, WireType.Varint).int32(parseInt(k)).tag(2, WireType.Bit32).float(message.mapInt32Float[k as any]).join();
-        /* map<int32, double> map_int32_double = 67; */
-        for (let k of globalThis.Object.keys(message.mapInt32Double))
-            writer.tag(67, WireType.LengthDelimited).fork().tag(1, WireType.Varint).int32(parseInt(k)).tag(2, WireType.Bit64).double(message.mapInt32Double[k as any]).join();
-        /* map<bool, bool> map_bool_bool = 68; */
-        for (let k of globalThis.Object.keys(message.mapBoolBool))
-            writer.tag(68, WireType.LengthDelimited).fork().tag(1, WireType.Varint).bool(k === "true").tag(2, WireType.Varint).bool(message.mapBoolBool[k]).join();
-        /* map<string, string> map_string_string = 69; */
-        for (let k of globalThis.Object.keys(message.mapStringString))
-            writer.tag(69, WireType.LengthDelimited).fork().tag(1, WireType.LengthDelimited).string(k).tag(2, WireType.LengthDelimited).string(message.mapStringString[k]).join();
-        /* map<string, bytes> map_string_bytes = 70; */
-        for (let k of globalThis.Object.keys(message.mapStringBytes))
-            writer.tag(70, WireType.LengthDelimited).fork().tag(1, WireType.LengthDelimited).string(k).tag(2, WireType.LengthDelimited).bytes(message.mapStringBytes[k]).join();
-        /* map<string, protobuf_test_messages.proto3.TestAllTypesProto3.NestedMessage> map_string_nested_message = 71; */
-        for (let k of globalThis.Object.keys(message.mapStringNestedMessage)) {
-            writer.tag(71, WireType.LengthDelimited).fork().tag(1, WireType.LengthDelimited).string(k);
-            writer.tag(2, WireType.LengthDelimited).fork();
-            TestAllTypesProto3_NestedMessage.internalBinaryWrite(message.mapStringNestedMessage[k], writer, options);
-            writer.join().join();
-        }
-        /* map<string, protobuf_test_messages.proto3.ForeignMessage> map_string_foreign_message = 72; */
-        for (let k of globalThis.Object.keys(message.mapStringForeignMessage)) {
-            writer.tag(72, WireType.LengthDelimited).fork().tag(1, WireType.LengthDelimited).string(k);
-            writer.tag(2, WireType.LengthDelimited).fork();
-            ForeignMessage.internalBinaryWrite(message.mapStringForeignMessage[k], writer, options);
-            writer.join().join();
-        }
-        /* map<string, protobuf_test_messages.proto3.TestAllTypesProto3.NestedEnum> map_string_nested_enum = 73; */
-        for (let k of globalThis.Object.keys(message.mapStringNestedEnum))
-            writer.tag(73, WireType.LengthDelimited).fork().tag(1, WireType.LengthDelimited).string(k).tag(2, WireType.Varint).int32(message.mapStringNestedEnum[k]).join();
-        /* map<string, protobuf_test_messages.proto3.ForeignEnum> map_string_foreign_enum = 74; */
-        for (let k of globalThis.Object.keys(message.mapStringForeignEnum))
-            writer.tag(74, WireType.LengthDelimited).fork().tag(1, WireType.LengthDelimited).string(k).tag(2, WireType.Varint).int32(message.mapStringForeignEnum[k]).join();
         /* uint32 oneof_uint32 = 111; */
         if (message.oneofField.oneofKind === "oneofUint32")
             writer.tag(111, WireType.Varint).uint32(message.oneofField.oneofUint32);
@@ -2626,9 +2626,6 @@ class TestAllTypesProto3$Type extends MessageType<TestAllTypesProto3> {
         /* repeated google.protobuf.FieldMask repeated_fieldmask = 313; */
         for (let i = 0; i < message.repeatedFieldmask.length; i++)
             FieldMask.internalBinaryWrite(message.repeatedFieldmask[i], writer.tag(313, WireType.LengthDelimited).fork(), options).join();
-        /* repeated google.protobuf.Struct repeated_struct = 324; */
-        for (let i = 0; i < message.repeatedStruct.length; i++)
-            Struct.internalBinaryWrite(message.repeatedStruct[i], writer.tag(324, WireType.LengthDelimited).fork(), options).join();
         /* repeated google.protobuf.Any repeated_any = 315; */
         for (let i = 0; i < message.repeatedAny.length; i++)
             Any.internalBinaryWrite(message.repeatedAny[i], writer.tag(315, WireType.LengthDelimited).fork(), options).join();
@@ -2638,6 +2635,9 @@ class TestAllTypesProto3$Type extends MessageType<TestAllTypesProto3> {
         /* repeated google.protobuf.ListValue repeated_list_value = 317; */
         for (let i = 0; i < message.repeatedListValue.length; i++)
             ListValue.internalBinaryWrite(message.repeatedListValue[i], writer.tag(317, WireType.LengthDelimited).fork(), options).join();
+        /* repeated google.protobuf.Struct repeated_struct = 324; */
+        for (let i = 0; i < message.repeatedStruct.length; i++)
+            Struct.internalBinaryWrite(message.repeatedStruct[i], writer.tag(324, WireType.LengthDelimited).fork(), options).join();
         /* int32 fieldname1 = 401; */
         if (message.fieldname1 !== 0)
             writer.tag(401, WireType.Varint).int32(message.fieldname1);

--- a/packages/test-default/gen/google/protobuf/unittest_mset.ts
+++ b/packages/test-default/gen/google/protobuf/unittest_mset.ts
@@ -290,12 +290,12 @@ class NestedTestInt$Type extends MessageType<NestedTestInt> {
         /* optional fixed32 a = 1; */
         if (message.a !== undefined)
             writer.tag(1, WireType.Bit32).fixed32(message.a);
-        /* optional int32 b = 3; */
-        if (message.b !== undefined)
-            writer.tag(3, WireType.Varint).int32(message.b);
         /* optional protobuf_unittest.NestedTestInt child = 2; */
         if (message.child)
             NestedTestInt.internalBinaryWrite(message.child, writer.tag(2, WireType.LengthDelimited).fork(), options).join();
+        /* optional int32 b = 3; */
+        if (message.b !== undefined)
+            writer.tag(3, WireType.Varint).int32(message.b);
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);

--- a/packages/test-default/gen/google/protobuf/unittest_proto3.ts
+++ b/packages/test-default/gen/google/protobuf/unittest_proto3.ts
@@ -1282,9 +1282,6 @@ class TestAllTypes$Type extends MessageType<TestAllTypes> {
         /* proto3_unittest.TestAllTypes.NestedMessage optional_unverified_lazy_message = 28; */
         if (message.optionalUnverifiedLazyMessage)
             TestAllTypes_NestedMessage.internalBinaryWrite(message.optionalUnverifiedLazyMessage, writer.tag(28, WireType.LengthDelimited).fork(), options).join();
-        /* protobuf_unittest_import.ImportMessage optional_lazy_import_message = 115; */
-        if (message.optionalLazyImportMessage)
-            ImportMessage.internalBinaryWrite(message.optionalLazyImportMessage, writer.tag(115, WireType.LengthDelimited).fork(), options).join();
         /* repeated int32 repeated_int32 = 31; */
         if (message.repeatedInt32.length) {
             writer.tag(31, WireType.LengthDelimited).fork();
@@ -1426,6 +1423,9 @@ class TestAllTypes$Type extends MessageType<TestAllTypes> {
         /* bytes oneof_bytes = 114; */
         if (message.oneofField.oneofKind === "oneofBytes")
             writer.tag(114, WireType.LengthDelimited).bytes(message.oneofField.oneofBytes);
+        /* protobuf_unittest_import.ImportMessage optional_lazy_import_message = 115; */
+        if (message.optionalLazyImportMessage)
+            ImportMessage.internalBinaryWrite(message.optionalLazyImportMessage, writer.tag(115, WireType.LengthDelimited).fork(), options).join();
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);

--- a/packages/test-default/gen/google/protobuf/unittest_proto3_arena.ts
+++ b/packages/test-default/gen/google/protobuf/unittest_proto3_arena.ts
@@ -973,9 +973,6 @@ class TestAllTypes$Type extends MessageType<TestAllTypes> {
         /* proto3_arena_unittest.TestAllTypes.NestedMessage optional_lazy_message = 27; */
         if (message.optionalLazyMessage)
             TestAllTypes_NestedMessage.internalBinaryWrite(message.optionalLazyMessage, writer.tag(27, WireType.LengthDelimited).fork(), options).join();
-        /* protobuf_unittest_import.ImportMessage optional_lazy_import_message = 115; */
-        if (message.optionalLazyImportMessage)
-            ImportMessage.internalBinaryWrite(message.optionalLazyImportMessage, writer.tag(115, WireType.LengthDelimited).fork(), options).join();
         /* repeated int32 repeated_int32 = 31; */
         if (message.repeatedInt32.length) {
             writer.tag(31, WireType.LengthDelimited).fork();
@@ -1117,6 +1114,9 @@ class TestAllTypes$Type extends MessageType<TestAllTypes> {
         /* bytes oneof_bytes = 114; */
         if (message.oneofField.oneofKind === "oneofBytes")
             writer.tag(114, WireType.LengthDelimited).bytes(message.oneofField.oneofBytes);
+        /* protobuf_unittest_import.ImportMessage optional_lazy_import_message = 115; */
+        if (message.optionalLazyImportMessage)
+            ImportMessage.internalBinaryWrite(message.optionalLazyImportMessage, writer.tag(115, WireType.LengthDelimited).fork(), options).join();
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);

--- a/packages/test-default/gen/google/rpc/context/attribute_context.ts
+++ b/packages/test-default/gen/google/rpc/context/attribute_context.ts
@@ -504,9 +504,6 @@ class AttributeContext$Type extends MessageType<AttributeContext> {
         return message;
     }
     internalBinaryWrite(message: AttributeContext, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
-        /* google.rpc.context.AttributeContext.Peer origin = 7; */
-        if (message.origin)
-            AttributeContext_Peer.internalBinaryWrite(message.origin, writer.tag(7, WireType.LengthDelimited).fork(), options).join();
         /* google.rpc.context.AttributeContext.Peer source = 1; */
         if (message.source)
             AttributeContext_Peer.internalBinaryWrite(message.source, writer.tag(1, WireType.LengthDelimited).fork(), options).join();
@@ -525,6 +522,9 @@ class AttributeContext$Type extends MessageType<AttributeContext> {
         /* google.rpc.context.AttributeContext.Api api = 6; */
         if (message.api)
             AttributeContext_Api.internalBinaryWrite(message.api, writer.tag(6, WireType.LengthDelimited).fork(), options).join();
+        /* google.rpc.context.AttributeContext.Peer origin = 7; */
+        if (message.origin)
+            AttributeContext_Peer.internalBinaryWrite(message.origin, writer.tag(7, WireType.LengthDelimited).fork(), options).join();
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);

--- a/packages/test-default/spec/generated-binary-read-compat.spec.ts
+++ b/packages/test-default/spec/generated-binary-read-compat.spec.ts
@@ -1,4 +1,4 @@
-import {IMessageType, MessageType} from "@protobuf-ts/runtime";
+import {IMessageType, MessageType, base64encode} from "@protobuf-ts/runtime";
 import {EnumFieldMessage} from "../gen/msg-enum";
 import {JsonNamesMessage} from "../gen/msg-json-names";
 import {MessageFieldMessage} from "../gen/msg-message";
@@ -6,6 +6,7 @@ import {OneofMessageMemberMessage, OneofScalarMemberMessage} from "../gen/msg-on
 import {Proto2OptionalsMessage} from "../gen/msg-proto2-optionals";
 import {Proto3OptionalsMessage} from "../gen/msg-proto3-optionals";
 import {RepeatedScalarValuesMessage, ScalarValuesMessage} from "../gen/msg-scalar";
+import {TestAllTypesProto3} from "../gen/google/protobuf/test_messages_proto3";
 
 let generatedRegistry: IMessageType<any>[] = [
     EnumFieldMessage,
@@ -38,6 +39,20 @@ describe('generated code compatibility', () => {
             });
         }
     });
+
+    it('should have same serialization order regardless of optimization options', function () {
+        const reflectionType = new MessageType<TestAllTypesProto3>(TestAllTypesProto3.typeName, [...TestAllTypesProto3.fields].reverse());
+        const message = TestAllTypesProto3.fromJson({
+            optionalInt32: 123,
+            optionalInt64: "1",
+            optionalString: "1",
+            optionalNestedMessage: {
+                a: 2,
+            }
+        });
+        expect(base64encode(TestAllTypesProto3.toBinary(message)))
+            .toBe(base64encode(reflectionType.toBinary(message)));
+    })
 
 });
 

--- a/packages/test-force_optimize_code_size/spec/generated-binary-read-compat.spec.ts
+++ b/packages/test-force_optimize_code_size/spec/generated-binary-read-compat.spec.ts
@@ -1,4 +1,4 @@
-import {IMessageType, MessageType} from "@protobuf-ts/runtime";
+import {IMessageType, MessageType, base64encode} from "@protobuf-ts/runtime";
 import {EnumFieldMessage} from "../gen/msg-enum";
 import {JsonNamesMessage} from "../gen/msg-json-names";
 import {MessageFieldMessage} from "../gen/msg-message";
@@ -6,6 +6,7 @@ import {OneofMessageMemberMessage, OneofScalarMemberMessage} from "../gen/msg-on
 import {Proto2OptionalsMessage} from "../gen/msg-proto2-optionals";
 import {Proto3OptionalsMessage} from "../gen/msg-proto3-optionals";
 import {RepeatedScalarValuesMessage, ScalarValuesMessage} from "../gen/msg-scalar";
+import {TestAllTypesProto3} from "../gen/google/protobuf/test_messages_proto3";
 
 // Copied from test-default/generated-binary-read-compat.spec.ts. Do not edit.
 let generatedRegistry: IMessageType<any>[] = [
@@ -39,6 +40,20 @@ describe('generated code compatibility', () => {
             });
         }
     });
+
+    it('should have same serialization order regardless of optimization options', function () {
+        const reflectionType = new MessageType<TestAllTypesProto3>(TestAllTypesProto3.typeName, [...TestAllTypesProto3.fields].reverse());
+        const message = TestAllTypesProto3.fromJson({
+            optionalInt32: 123,
+            optionalInt64: "1",
+            optionalString: "1",
+            optionalNestedMessage: {
+                a: 2,
+            }
+        });
+        expect(base64encode(TestAllTypesProto3.toBinary(message)))
+            .toBe(base64encode(reflectionType.toBinary(message)));
+    })
 
 });
 

--- a/packages/test-force_optimize_speed-long_type_string/gen/conformance/conformance.ts
+++ b/packages/test-force_optimize_speed-long_type_string/gen/conformance/conformance.ts
@@ -539,12 +539,6 @@ class ConformanceRequest$Type extends MessageType<ConformanceRequest> {
         /* string json_payload = 2; */
         if (message.payload.oneofKind === "jsonPayload")
             writer.tag(2, WireType.LengthDelimited).string(message.payload.jsonPayload);
-        /* string jspb_payload = 7; */
-        if (message.payload.oneofKind === "jspbPayload")
-            writer.tag(7, WireType.LengthDelimited).string(message.payload.jspbPayload);
-        /* string text_payload = 8; */
-        if (message.payload.oneofKind === "textPayload")
-            writer.tag(8, WireType.LengthDelimited).string(message.payload.textPayload);
         /* conformance.WireFormat requested_output_format = 3; */
         if (message.requestedOutputFormat !== 0)
             writer.tag(3, WireType.Varint).int32(message.requestedOutputFormat);
@@ -557,6 +551,12 @@ class ConformanceRequest$Type extends MessageType<ConformanceRequest> {
         /* conformance.JspbEncodingConfig jspb_encoding_options = 6; */
         if (message.jspbEncodingOptions)
             JspbEncodingConfig.internalBinaryWrite(message.jspbEncodingOptions, writer.tag(6, WireType.LengthDelimited).fork(), options).join();
+        /* string jspb_payload = 7; */
+        if (message.payload.oneofKind === "jspbPayload")
+            writer.tag(7, WireType.LengthDelimited).string(message.payload.jspbPayload);
+        /* string text_payload = 8; */
+        if (message.payload.oneofKind === "textPayload")
+            writer.tag(8, WireType.LengthDelimited).string(message.payload.textPayload);
         /* bool print_unknown_fields = 9; */
         if (message.printUnknownFields !== false)
             writer.tag(9, WireType.Varint).bool(message.printUnknownFields);
@@ -666,12 +666,6 @@ class ConformanceResponse$Type extends MessageType<ConformanceResponse> {
         /* string parse_error = 1; */
         if (message.result.oneofKind === "parseError")
             writer.tag(1, WireType.LengthDelimited).string(message.result.parseError);
-        /* string serialize_error = 6; */
-        if (message.result.oneofKind === "serializeError")
-            writer.tag(6, WireType.LengthDelimited).string(message.result.serializeError);
-        /* string timeout_error = 9; */
-        if (message.result.oneofKind === "timeoutError")
-            writer.tag(9, WireType.LengthDelimited).string(message.result.timeoutError);
         /* string runtime_error = 2; */
         if (message.result.oneofKind === "runtimeError")
             writer.tag(2, WireType.LengthDelimited).string(message.result.runtimeError);
@@ -684,12 +678,18 @@ class ConformanceResponse$Type extends MessageType<ConformanceResponse> {
         /* string skipped = 5; */
         if (message.result.oneofKind === "skipped")
             writer.tag(5, WireType.LengthDelimited).string(message.result.skipped);
+        /* string serialize_error = 6; */
+        if (message.result.oneofKind === "serializeError")
+            writer.tag(6, WireType.LengthDelimited).string(message.result.serializeError);
         /* string jspb_payload = 7; */
         if (message.result.oneofKind === "jspbPayload")
             writer.tag(7, WireType.LengthDelimited).string(message.result.jspbPayload);
         /* string text_payload = 8; */
         if (message.result.oneofKind === "textPayload")
             writer.tag(8, WireType.LengthDelimited).string(message.result.textPayload);
+        /* string timeout_error = 9; */
+        if (message.result.oneofKind === "timeoutError")
+            writer.tag(9, WireType.LengthDelimited).string(message.result.timeoutError);
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);

--- a/packages/test-force_optimize_speed-long_type_string/gen/google/api/http.ts
+++ b/packages/test-force_optimize_speed-long_type_string/gen/google/api/http.ts
@@ -608,18 +608,18 @@ class HttpRule$Type extends MessageType<HttpRule> {
         /* string patch = 6; */
         if (message.pattern.oneofKind === "patch")
             writer.tag(6, WireType.LengthDelimited).string(message.pattern.patch);
-        /* google.api.CustomHttpPattern custom = 8; */
-        if (message.pattern.oneofKind === "custom")
-            CustomHttpPattern.internalBinaryWrite(message.pattern.custom, writer.tag(8, WireType.LengthDelimited).fork(), options).join();
         /* string body = 7; */
         if (message.body !== "")
             writer.tag(7, WireType.LengthDelimited).string(message.body);
-        /* string response_body = 12; */
-        if (message.responseBody !== "")
-            writer.tag(12, WireType.LengthDelimited).string(message.responseBody);
+        /* google.api.CustomHttpPattern custom = 8; */
+        if (message.pattern.oneofKind === "custom")
+            CustomHttpPattern.internalBinaryWrite(message.pattern.custom, writer.tag(8, WireType.LengthDelimited).fork(), options).join();
         /* repeated google.api.HttpRule additional_bindings = 11; */
         for (let i = 0; i < message.additionalBindings.length; i++)
             HttpRule.internalBinaryWrite(message.additionalBindings[i], writer.tag(11, WireType.LengthDelimited).fork(), options).join();
+        /* string response_body = 12; */
+        if (message.responseBody !== "")
+            writer.tag(12, WireType.LengthDelimited).string(message.responseBody);
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);

--- a/packages/test-force_optimize_speed-long_type_string/gen/google/protobuf/compiler/plugin.ts
+++ b/packages/test-force_optimize_speed-long_type_string/gen/google/protobuf/compiler/plugin.ts
@@ -391,15 +391,15 @@ class CodeGeneratorRequest$Type extends MessageType<CodeGeneratorRequest> {
         /* optional string parameter = 2; */
         if (message.parameter !== undefined)
             writer.tag(2, WireType.LengthDelimited).string(message.parameter);
+        /* optional google.protobuf.compiler.Version compiler_version = 3; */
+        if (message.compilerVersion)
+            Version.internalBinaryWrite(message.compilerVersion, writer.tag(3, WireType.LengthDelimited).fork(), options).join();
         /* repeated google.protobuf.FileDescriptorProto proto_file = 15; */
         for (let i = 0; i < message.protoFile.length; i++)
             FileDescriptorProto.internalBinaryWrite(message.protoFile[i], writer.tag(15, WireType.LengthDelimited).fork(), options).join();
         /* repeated google.protobuf.FileDescriptorProto source_file_descriptors = 17; */
         for (let i = 0; i < message.sourceFileDescriptors.length; i++)
             FileDescriptorProto.internalBinaryWrite(message.sourceFileDescriptors[i], writer.tag(17, WireType.LengthDelimited).fork(), options).join();
-        /* optional google.protobuf.compiler.Version compiler_version = 3; */
-        if (message.compilerVersion)
-            Version.internalBinaryWrite(message.compilerVersion, writer.tag(3, WireType.LengthDelimited).fork(), options).join();
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);

--- a/packages/test-force_optimize_speed-long_type_string/gen/google/protobuf/descriptor.ts
+++ b/packages/test-force_optimize_speed-long_type_string/gen/google/protobuf/descriptor.ts
@@ -2249,12 +2249,6 @@ class FileDescriptorProto$Type extends MessageType<FileDescriptorProto> {
         /* repeated string dependency = 3; */
         for (let i = 0; i < message.dependency.length; i++)
             writer.tag(3, WireType.LengthDelimited).string(message.dependency[i]);
-        /* repeated int32 public_dependency = 10; */
-        for (let i = 0; i < message.publicDependency.length; i++)
-            writer.tag(10, WireType.Varint).int32(message.publicDependency[i]);
-        /* repeated int32 weak_dependency = 11; */
-        for (let i = 0; i < message.weakDependency.length; i++)
-            writer.tag(11, WireType.Varint).int32(message.weakDependency[i]);
         /* repeated google.protobuf.DescriptorProto message_type = 4; */
         for (let i = 0; i < message.messageType.length; i++)
             DescriptorProto.internalBinaryWrite(message.messageType[i], writer.tag(4, WireType.LengthDelimited).fork(), options).join();
@@ -2273,6 +2267,12 @@ class FileDescriptorProto$Type extends MessageType<FileDescriptorProto> {
         /* optional google.protobuf.SourceCodeInfo source_code_info = 9; */
         if (message.sourceCodeInfo)
             SourceCodeInfo.internalBinaryWrite(message.sourceCodeInfo, writer.tag(9, WireType.LengthDelimited).fork(), options).join();
+        /* repeated int32 public_dependency = 10; */
+        for (let i = 0; i < message.publicDependency.length; i++)
+            writer.tag(10, WireType.Varint).int32(message.publicDependency[i]);
+        /* repeated int32 weak_dependency = 11; */
+        for (let i = 0; i < message.weakDependency.length; i++)
+            writer.tag(11, WireType.Varint).int32(message.weakDependency[i]);
         /* optional string syntax = 12; */
         if (message.syntax !== undefined)
             writer.tag(12, WireType.LengthDelimited).string(message.syntax);
@@ -2372,9 +2372,6 @@ class DescriptorProto$Type extends MessageType<DescriptorProto> {
         /* repeated google.protobuf.FieldDescriptorProto field = 2; */
         for (let i = 0; i < message.field.length; i++)
             FieldDescriptorProto.internalBinaryWrite(message.field[i], writer.tag(2, WireType.LengthDelimited).fork(), options).join();
-        /* repeated google.protobuf.FieldDescriptorProto extension = 6; */
-        for (let i = 0; i < message.extension.length; i++)
-            FieldDescriptorProto.internalBinaryWrite(message.extension[i], writer.tag(6, WireType.LengthDelimited).fork(), options).join();
         /* repeated google.protobuf.DescriptorProto nested_type = 3; */
         for (let i = 0; i < message.nestedType.length; i++)
             DescriptorProto.internalBinaryWrite(message.nestedType[i], writer.tag(3, WireType.LengthDelimited).fork(), options).join();
@@ -2384,12 +2381,15 @@ class DescriptorProto$Type extends MessageType<DescriptorProto> {
         /* repeated google.protobuf.DescriptorProto.ExtensionRange extension_range = 5; */
         for (let i = 0; i < message.extensionRange.length; i++)
             DescriptorProto_ExtensionRange.internalBinaryWrite(message.extensionRange[i], writer.tag(5, WireType.LengthDelimited).fork(), options).join();
-        /* repeated google.protobuf.OneofDescriptorProto oneof_decl = 8; */
-        for (let i = 0; i < message.oneofDecl.length; i++)
-            OneofDescriptorProto.internalBinaryWrite(message.oneofDecl[i], writer.tag(8, WireType.LengthDelimited).fork(), options).join();
+        /* repeated google.protobuf.FieldDescriptorProto extension = 6; */
+        for (let i = 0; i < message.extension.length; i++)
+            FieldDescriptorProto.internalBinaryWrite(message.extension[i], writer.tag(6, WireType.LengthDelimited).fork(), options).join();
         /* optional google.protobuf.MessageOptions options = 7; */
         if (message.options)
             MessageOptions.internalBinaryWrite(message.options, writer.tag(7, WireType.LengthDelimited).fork(), options).join();
+        /* repeated google.protobuf.OneofDescriptorProto oneof_decl = 8; */
+        for (let i = 0; i < message.oneofDecl.length; i++)
+            OneofDescriptorProto.internalBinaryWrite(message.oneofDecl[i], writer.tag(8, WireType.LengthDelimited).fork(), options).join();
         /* repeated google.protobuf.DescriptorProto.ReservedRange reserved_range = 9; */
         for (let i = 0; i < message.reservedRange.length; i++)
             DescriptorProto_ReservedRange.internalBinaryWrite(message.reservedRange[i], writer.tag(9, WireType.LengthDelimited).fork(), options).join();
@@ -2566,18 +2566,18 @@ class ExtensionRangeOptions$Type extends MessageType<ExtensionRangeOptions> {
         return message;
     }
     internalBinaryWrite(message: ExtensionRangeOptions, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
-        /* repeated google.protobuf.UninterpretedOption uninterpreted_option = 999; */
-        for (let i = 0; i < message.uninterpretedOption.length; i++)
-            UninterpretedOption.internalBinaryWrite(message.uninterpretedOption[i], writer.tag(999, WireType.LengthDelimited).fork(), options).join();
         /* repeated google.protobuf.ExtensionRangeOptions.Declaration declaration = 2; */
         for (let i = 0; i < message.declaration.length; i++)
             ExtensionRangeOptions_Declaration.internalBinaryWrite(message.declaration[i], writer.tag(2, WireType.LengthDelimited).fork(), options).join();
-        /* optional google.protobuf.FeatureSet features = 50; */
-        if (message.features)
-            FeatureSet.internalBinaryWrite(message.features, writer.tag(50, WireType.LengthDelimited).fork(), options).join();
         /* optional google.protobuf.ExtensionRangeOptions.VerificationState verification = 3; */
         if (message.verification !== undefined)
             writer.tag(3, WireType.Varint).int32(message.verification);
+        /* optional google.protobuf.FeatureSet features = 50; */
+        if (message.features)
+            FeatureSet.internalBinaryWrite(message.features, writer.tag(50, WireType.LengthDelimited).fork(), options).join();
+        /* repeated google.protobuf.UninterpretedOption uninterpreted_option = 999; */
+        for (let i = 0; i < message.uninterpretedOption.length; i++)
+            UninterpretedOption.internalBinaryWrite(message.uninterpretedOption[i], writer.tag(999, WireType.LengthDelimited).fork(), options).join();
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
@@ -2738,6 +2738,9 @@ class FieldDescriptorProto$Type extends MessageType<FieldDescriptorProto> {
         /* optional string name = 1; */
         if (message.name !== undefined)
             writer.tag(1, WireType.LengthDelimited).string(message.name);
+        /* optional string extendee = 2; */
+        if (message.extendee !== undefined)
+            writer.tag(2, WireType.LengthDelimited).string(message.extendee);
         /* optional int32 number = 3; */
         if (message.number !== undefined)
             writer.tag(3, WireType.Varint).int32(message.number);
@@ -2750,21 +2753,18 @@ class FieldDescriptorProto$Type extends MessageType<FieldDescriptorProto> {
         /* optional string type_name = 6; */
         if (message.typeName !== undefined)
             writer.tag(6, WireType.LengthDelimited).string(message.typeName);
-        /* optional string extendee = 2; */
-        if (message.extendee !== undefined)
-            writer.tag(2, WireType.LengthDelimited).string(message.extendee);
         /* optional string default_value = 7; */
         if (message.defaultValue !== undefined)
             writer.tag(7, WireType.LengthDelimited).string(message.defaultValue);
+        /* optional google.protobuf.FieldOptions options = 8; */
+        if (message.options)
+            FieldOptions.internalBinaryWrite(message.options, writer.tag(8, WireType.LengthDelimited).fork(), options).join();
         /* optional int32 oneof_index = 9; */
         if (message.oneofIndex !== undefined)
             writer.tag(9, WireType.Varint).int32(message.oneofIndex);
         /* optional string json_name = 10; */
         if (message.jsonName !== undefined)
             writer.tag(10, WireType.LengthDelimited).string(message.jsonName);
-        /* optional google.protobuf.FieldOptions options = 8; */
-        if (message.options)
-            FieldOptions.internalBinaryWrite(message.options, writer.tag(8, WireType.LengthDelimited).fork(), options).join();
         /* optional bool proto3_optional = 17; */
         if (message.proto3Optional !== undefined)
             writer.tag(17, WireType.Varint).bool(message.proto3Optional);
@@ -3283,18 +3283,12 @@ class FileOptions$Type extends MessageType<FileOptions> {
         /* optional string java_outer_classname = 8; */
         if (message.javaOuterClassname !== undefined)
             writer.tag(8, WireType.LengthDelimited).string(message.javaOuterClassname);
-        /* optional bool java_multiple_files = 10; */
-        if (message.javaMultipleFiles !== undefined)
-            writer.tag(10, WireType.Varint).bool(message.javaMultipleFiles);
-        /* optional bool java_generate_equals_and_hash = 20 [deprecated = true]; */
-        if (message.javaGenerateEqualsAndHash !== undefined)
-            writer.tag(20, WireType.Varint).bool(message.javaGenerateEqualsAndHash);
-        /* optional bool java_string_check_utf8 = 27; */
-        if (message.javaStringCheckUtf8 !== undefined)
-            writer.tag(27, WireType.Varint).bool(message.javaStringCheckUtf8);
         /* optional google.protobuf.FileOptions.OptimizeMode optimize_for = 9; */
         if (message.optimizeFor !== undefined)
             writer.tag(9, WireType.Varint).int32(message.optimizeFor);
+        /* optional bool java_multiple_files = 10; */
+        if (message.javaMultipleFiles !== undefined)
+            writer.tag(10, WireType.Varint).bool(message.javaMultipleFiles);
         /* optional string go_package = 11; */
         if (message.goPackage !== undefined)
             writer.tag(11, WireType.LengthDelimited).string(message.goPackage);
@@ -3307,9 +3301,15 @@ class FileOptions$Type extends MessageType<FileOptions> {
         /* optional bool py_generic_services = 18; */
         if (message.pyGenericServices !== undefined)
             writer.tag(18, WireType.Varint).bool(message.pyGenericServices);
+        /* optional bool java_generate_equals_and_hash = 20 [deprecated = true]; */
+        if (message.javaGenerateEqualsAndHash !== undefined)
+            writer.tag(20, WireType.Varint).bool(message.javaGenerateEqualsAndHash);
         /* optional bool deprecated = 23; */
         if (message.deprecated !== undefined)
             writer.tag(23, WireType.Varint).bool(message.deprecated);
+        /* optional bool java_string_check_utf8 = 27; */
+        if (message.javaStringCheckUtf8 !== undefined)
+            writer.tag(27, WireType.Varint).bool(message.javaStringCheckUtf8);
         /* optional bool cc_enable_arenas = 31; */
         if (message.ccEnableArenas !== undefined)
             writer.tag(31, WireType.Varint).bool(message.ccEnableArenas);
@@ -3537,21 +3537,21 @@ class FieldOptions$Type extends MessageType<FieldOptions> {
         /* optional bool packed = 2; */
         if (message.packed !== undefined)
             writer.tag(2, WireType.Varint).bool(message.packed);
-        /* optional google.protobuf.FieldOptions.JSType jstype = 6; */
-        if (message.jstype !== undefined)
-            writer.tag(6, WireType.Varint).int32(message.jstype);
-        /* optional bool lazy = 5; */
-        if (message.lazy !== undefined)
-            writer.tag(5, WireType.Varint).bool(message.lazy);
-        /* optional bool unverified_lazy = 15; */
-        if (message.unverifiedLazy !== undefined)
-            writer.tag(15, WireType.Varint).bool(message.unverifiedLazy);
         /* optional bool deprecated = 3; */
         if (message.deprecated !== undefined)
             writer.tag(3, WireType.Varint).bool(message.deprecated);
+        /* optional bool lazy = 5; */
+        if (message.lazy !== undefined)
+            writer.tag(5, WireType.Varint).bool(message.lazy);
+        /* optional google.protobuf.FieldOptions.JSType jstype = 6; */
+        if (message.jstype !== undefined)
+            writer.tag(6, WireType.Varint).int32(message.jstype);
         /* optional bool weak = 10; */
         if (message.weak !== undefined)
             writer.tag(10, WireType.Varint).bool(message.weak);
+        /* optional bool unverified_lazy = 15; */
+        if (message.unverifiedLazy !== undefined)
+            writer.tag(15, WireType.Varint).bool(message.unverifiedLazy);
         /* optional bool debug_redact = 16; */
         if (message.debugRedact !== undefined)
             writer.tag(16, WireType.Varint).bool(message.debugRedact);
@@ -3620,12 +3620,12 @@ class FieldOptions_EditionDefault$Type extends MessageType<FieldOptions_EditionD
         return message;
     }
     internalBinaryWrite(message: FieldOptions_EditionDefault, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
-        /* optional google.protobuf.Edition edition = 3; */
-        if (message.edition !== undefined)
-            writer.tag(3, WireType.Varint).int32(message.edition);
         /* optional string value = 2; */
         if (message.value !== undefined)
             writer.tag(2, WireType.LengthDelimited).string(message.value);
+        /* optional google.protobuf.Edition edition = 3; */
+        if (message.edition !== undefined)
+            writer.tag(3, WireType.Varint).int32(message.edition);
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
@@ -3949,12 +3949,12 @@ class ServiceOptions$Type extends MessageType<ServiceOptions> {
         return message;
     }
     internalBinaryWrite(message: ServiceOptions, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
-        /* optional google.protobuf.FeatureSet features = 34; */
-        if (message.features)
-            FeatureSet.internalBinaryWrite(message.features, writer.tag(34, WireType.LengthDelimited).fork(), options).join();
         /* optional bool deprecated = 33; */
         if (message.deprecated !== undefined)
             writer.tag(33, WireType.Varint).bool(message.deprecated);
+        /* optional google.protobuf.FeatureSet features = 34; */
+        if (message.features)
+            FeatureSet.internalBinaryWrite(message.features, writer.tag(34, WireType.LengthDelimited).fork(), options).join();
         /* repeated google.protobuf.UninterpretedOption uninterpreted_option = 999; */
         for (let i = 0; i < message.uninterpretedOption.length; i++)
             UninterpretedOption.internalBinaryWrite(message.uninterpretedOption[i], writer.tag(999, WireType.LengthDelimited).fork(), options).join();

--- a/packages/test-force_optimize_speed-long_type_string/gen/google/protobuf/test_messages_proto2.ts
+++ b/packages/test-force_optimize_speed-long_type_string/gen/google/protobuf/test_messages_proto2.ts
@@ -2354,6 +2354,71 @@ class TestAllTypesProto2$Type extends MessageType<TestAllTypesProto2> {
         /* repeated string repeated_cord = 55; */
         for (let i = 0; i < message.repeatedCord.length; i++)
             writer.tag(55, WireType.LengthDelimited).string(message.repeatedCord[i]);
+        /* map<int32, int32> map_int32_int32 = 56; */
+        for (let k of globalThis.Object.keys(message.mapInt32Int32))
+            writer.tag(56, WireType.LengthDelimited).fork().tag(1, WireType.Varint).int32(parseInt(k)).tag(2, WireType.Varint).int32(message.mapInt32Int32[k as any]).join();
+        /* map<int64, int64> map_int64_int64 = 57; */
+        for (let k of globalThis.Object.keys(message.mapInt64Int64))
+            writer.tag(57, WireType.LengthDelimited).fork().tag(1, WireType.Varint).int64(k).tag(2, WireType.Varint).int64(message.mapInt64Int64[k]).join();
+        /* map<uint32, uint32> map_uint32_uint32 = 58; */
+        for (let k of globalThis.Object.keys(message.mapUint32Uint32))
+            writer.tag(58, WireType.LengthDelimited).fork().tag(1, WireType.Varint).uint32(parseInt(k)).tag(2, WireType.Varint).uint32(message.mapUint32Uint32[k as any]).join();
+        /* map<uint64, uint64> map_uint64_uint64 = 59; */
+        for (let k of globalThis.Object.keys(message.mapUint64Uint64))
+            writer.tag(59, WireType.LengthDelimited).fork().tag(1, WireType.Varint).uint64(k).tag(2, WireType.Varint).uint64(message.mapUint64Uint64[k]).join();
+        /* map<sint32, sint32> map_sint32_sint32 = 60; */
+        for (let k of globalThis.Object.keys(message.mapSint32Sint32))
+            writer.tag(60, WireType.LengthDelimited).fork().tag(1, WireType.Varint).sint32(parseInt(k)).tag(2, WireType.Varint).sint32(message.mapSint32Sint32[k as any]).join();
+        /* map<sint64, sint64> map_sint64_sint64 = 61; */
+        for (let k of globalThis.Object.keys(message.mapSint64Sint64))
+            writer.tag(61, WireType.LengthDelimited).fork().tag(1, WireType.Varint).sint64(k).tag(2, WireType.Varint).sint64(message.mapSint64Sint64[k]).join();
+        /* map<fixed32, fixed32> map_fixed32_fixed32 = 62; */
+        for (let k of globalThis.Object.keys(message.mapFixed32Fixed32))
+            writer.tag(62, WireType.LengthDelimited).fork().tag(1, WireType.Bit32).fixed32(parseInt(k)).tag(2, WireType.Bit32).fixed32(message.mapFixed32Fixed32[k as any]).join();
+        /* map<fixed64, fixed64> map_fixed64_fixed64 = 63; */
+        for (let k of globalThis.Object.keys(message.mapFixed64Fixed64))
+            writer.tag(63, WireType.LengthDelimited).fork().tag(1, WireType.Bit64).fixed64(k).tag(2, WireType.Bit64).fixed64(message.mapFixed64Fixed64[k]).join();
+        /* map<sfixed32, sfixed32> map_sfixed32_sfixed32 = 64; */
+        for (let k of globalThis.Object.keys(message.mapSfixed32Sfixed32))
+            writer.tag(64, WireType.LengthDelimited).fork().tag(1, WireType.Bit32).sfixed32(parseInt(k)).tag(2, WireType.Bit32).sfixed32(message.mapSfixed32Sfixed32[k as any]).join();
+        /* map<sfixed64, sfixed64> map_sfixed64_sfixed64 = 65; */
+        for (let k of globalThis.Object.keys(message.mapSfixed64Sfixed64))
+            writer.tag(65, WireType.LengthDelimited).fork().tag(1, WireType.Bit64).sfixed64(k).tag(2, WireType.Bit64).sfixed64(message.mapSfixed64Sfixed64[k]).join();
+        /* map<int32, float> map_int32_float = 66; */
+        for (let k of globalThis.Object.keys(message.mapInt32Float))
+            writer.tag(66, WireType.LengthDelimited).fork().tag(1, WireType.Varint).int32(parseInt(k)).tag(2, WireType.Bit32).float(message.mapInt32Float[k as any]).join();
+        /* map<int32, double> map_int32_double = 67; */
+        for (let k of globalThis.Object.keys(message.mapInt32Double))
+            writer.tag(67, WireType.LengthDelimited).fork().tag(1, WireType.Varint).int32(parseInt(k)).tag(2, WireType.Bit64).double(message.mapInt32Double[k as any]).join();
+        /* map<bool, bool> map_bool_bool = 68; */
+        for (let k of globalThis.Object.keys(message.mapBoolBool))
+            writer.tag(68, WireType.LengthDelimited).fork().tag(1, WireType.Varint).bool(k === "true").tag(2, WireType.Varint).bool(message.mapBoolBool[k]).join();
+        /* map<string, string> map_string_string = 69; */
+        for (let k of globalThis.Object.keys(message.mapStringString))
+            writer.tag(69, WireType.LengthDelimited).fork().tag(1, WireType.LengthDelimited).string(k).tag(2, WireType.LengthDelimited).string(message.mapStringString[k]).join();
+        /* map<string, bytes> map_string_bytes = 70; */
+        for (let k of globalThis.Object.keys(message.mapStringBytes))
+            writer.tag(70, WireType.LengthDelimited).fork().tag(1, WireType.LengthDelimited).string(k).tag(2, WireType.LengthDelimited).bytes(message.mapStringBytes[k]).join();
+        /* map<string, protobuf_test_messages.proto2.TestAllTypesProto2.NestedMessage> map_string_nested_message = 71; */
+        for (let k of globalThis.Object.keys(message.mapStringNestedMessage)) {
+            writer.tag(71, WireType.LengthDelimited).fork().tag(1, WireType.LengthDelimited).string(k);
+            writer.tag(2, WireType.LengthDelimited).fork();
+            TestAllTypesProto2_NestedMessage.internalBinaryWrite(message.mapStringNestedMessage[k], writer, options);
+            writer.join().join();
+        }
+        /* map<string, protobuf_test_messages.proto2.ForeignMessageProto2> map_string_foreign_message = 72; */
+        for (let k of globalThis.Object.keys(message.mapStringForeignMessage)) {
+            writer.tag(72, WireType.LengthDelimited).fork().tag(1, WireType.LengthDelimited).string(k);
+            writer.tag(2, WireType.LengthDelimited).fork();
+            ForeignMessageProto2.internalBinaryWrite(message.mapStringForeignMessage[k], writer, options);
+            writer.join().join();
+        }
+        /* map<string, protobuf_test_messages.proto2.TestAllTypesProto2.NestedEnum> map_string_nested_enum = 73; */
+        for (let k of globalThis.Object.keys(message.mapStringNestedEnum))
+            writer.tag(73, WireType.LengthDelimited).fork().tag(1, WireType.LengthDelimited).string(k).tag(2, WireType.Varint).int32(message.mapStringNestedEnum[k]).join();
+        /* map<string, protobuf_test_messages.proto2.ForeignEnumProto2> map_string_foreign_enum = 74; */
+        for (let k of globalThis.Object.keys(message.mapStringForeignEnum))
+            writer.tag(74, WireType.LengthDelimited).fork().tag(1, WireType.LengthDelimited).string(k).tag(2, WireType.Varint).int32(message.mapStringForeignEnum[k]).join();
         /* repeated int32 packed_int32 = 75 [packed = true]; */
         if (message.packedInt32.length) {
             writer.tag(75, WireType.LengthDelimited).fork();
@@ -2494,71 +2559,6 @@ class TestAllTypesProto2$Type extends MessageType<TestAllTypesProto2> {
         /* repeated protobuf_test_messages.proto2.TestAllTypesProto2.NestedEnum unpacked_nested_enum = 102 [packed = false]; */
         for (let i = 0; i < message.unpackedNestedEnum.length; i++)
             writer.tag(102, WireType.Varint).int32(message.unpackedNestedEnum[i]);
-        /* map<int32, int32> map_int32_int32 = 56; */
-        for (let k of globalThis.Object.keys(message.mapInt32Int32))
-            writer.tag(56, WireType.LengthDelimited).fork().tag(1, WireType.Varint).int32(parseInt(k)).tag(2, WireType.Varint).int32(message.mapInt32Int32[k as any]).join();
-        /* map<int64, int64> map_int64_int64 = 57; */
-        for (let k of globalThis.Object.keys(message.mapInt64Int64))
-            writer.tag(57, WireType.LengthDelimited).fork().tag(1, WireType.Varint).int64(k).tag(2, WireType.Varint).int64(message.mapInt64Int64[k]).join();
-        /* map<uint32, uint32> map_uint32_uint32 = 58; */
-        for (let k of globalThis.Object.keys(message.mapUint32Uint32))
-            writer.tag(58, WireType.LengthDelimited).fork().tag(1, WireType.Varint).uint32(parseInt(k)).tag(2, WireType.Varint).uint32(message.mapUint32Uint32[k as any]).join();
-        /* map<uint64, uint64> map_uint64_uint64 = 59; */
-        for (let k of globalThis.Object.keys(message.mapUint64Uint64))
-            writer.tag(59, WireType.LengthDelimited).fork().tag(1, WireType.Varint).uint64(k).tag(2, WireType.Varint).uint64(message.mapUint64Uint64[k]).join();
-        /* map<sint32, sint32> map_sint32_sint32 = 60; */
-        for (let k of globalThis.Object.keys(message.mapSint32Sint32))
-            writer.tag(60, WireType.LengthDelimited).fork().tag(1, WireType.Varint).sint32(parseInt(k)).tag(2, WireType.Varint).sint32(message.mapSint32Sint32[k as any]).join();
-        /* map<sint64, sint64> map_sint64_sint64 = 61; */
-        for (let k of globalThis.Object.keys(message.mapSint64Sint64))
-            writer.tag(61, WireType.LengthDelimited).fork().tag(1, WireType.Varint).sint64(k).tag(2, WireType.Varint).sint64(message.mapSint64Sint64[k]).join();
-        /* map<fixed32, fixed32> map_fixed32_fixed32 = 62; */
-        for (let k of globalThis.Object.keys(message.mapFixed32Fixed32))
-            writer.tag(62, WireType.LengthDelimited).fork().tag(1, WireType.Bit32).fixed32(parseInt(k)).tag(2, WireType.Bit32).fixed32(message.mapFixed32Fixed32[k as any]).join();
-        /* map<fixed64, fixed64> map_fixed64_fixed64 = 63; */
-        for (let k of globalThis.Object.keys(message.mapFixed64Fixed64))
-            writer.tag(63, WireType.LengthDelimited).fork().tag(1, WireType.Bit64).fixed64(k).tag(2, WireType.Bit64).fixed64(message.mapFixed64Fixed64[k]).join();
-        /* map<sfixed32, sfixed32> map_sfixed32_sfixed32 = 64; */
-        for (let k of globalThis.Object.keys(message.mapSfixed32Sfixed32))
-            writer.tag(64, WireType.LengthDelimited).fork().tag(1, WireType.Bit32).sfixed32(parseInt(k)).tag(2, WireType.Bit32).sfixed32(message.mapSfixed32Sfixed32[k as any]).join();
-        /* map<sfixed64, sfixed64> map_sfixed64_sfixed64 = 65; */
-        for (let k of globalThis.Object.keys(message.mapSfixed64Sfixed64))
-            writer.tag(65, WireType.LengthDelimited).fork().tag(1, WireType.Bit64).sfixed64(k).tag(2, WireType.Bit64).sfixed64(message.mapSfixed64Sfixed64[k]).join();
-        /* map<int32, float> map_int32_float = 66; */
-        for (let k of globalThis.Object.keys(message.mapInt32Float))
-            writer.tag(66, WireType.LengthDelimited).fork().tag(1, WireType.Varint).int32(parseInt(k)).tag(2, WireType.Bit32).float(message.mapInt32Float[k as any]).join();
-        /* map<int32, double> map_int32_double = 67; */
-        for (let k of globalThis.Object.keys(message.mapInt32Double))
-            writer.tag(67, WireType.LengthDelimited).fork().tag(1, WireType.Varint).int32(parseInt(k)).tag(2, WireType.Bit64).double(message.mapInt32Double[k as any]).join();
-        /* map<bool, bool> map_bool_bool = 68; */
-        for (let k of globalThis.Object.keys(message.mapBoolBool))
-            writer.tag(68, WireType.LengthDelimited).fork().tag(1, WireType.Varint).bool(k === "true").tag(2, WireType.Varint).bool(message.mapBoolBool[k]).join();
-        /* map<string, string> map_string_string = 69; */
-        for (let k of globalThis.Object.keys(message.mapStringString))
-            writer.tag(69, WireType.LengthDelimited).fork().tag(1, WireType.LengthDelimited).string(k).tag(2, WireType.LengthDelimited).string(message.mapStringString[k]).join();
-        /* map<string, bytes> map_string_bytes = 70; */
-        for (let k of globalThis.Object.keys(message.mapStringBytes))
-            writer.tag(70, WireType.LengthDelimited).fork().tag(1, WireType.LengthDelimited).string(k).tag(2, WireType.LengthDelimited).bytes(message.mapStringBytes[k]).join();
-        /* map<string, protobuf_test_messages.proto2.TestAllTypesProto2.NestedMessage> map_string_nested_message = 71; */
-        for (let k of globalThis.Object.keys(message.mapStringNestedMessage)) {
-            writer.tag(71, WireType.LengthDelimited).fork().tag(1, WireType.LengthDelimited).string(k);
-            writer.tag(2, WireType.LengthDelimited).fork();
-            TestAllTypesProto2_NestedMessage.internalBinaryWrite(message.mapStringNestedMessage[k], writer, options);
-            writer.join().join();
-        }
-        /* map<string, protobuf_test_messages.proto2.ForeignMessageProto2> map_string_foreign_message = 72; */
-        for (let k of globalThis.Object.keys(message.mapStringForeignMessage)) {
-            writer.tag(72, WireType.LengthDelimited).fork().tag(1, WireType.LengthDelimited).string(k);
-            writer.tag(2, WireType.LengthDelimited).fork();
-            ForeignMessageProto2.internalBinaryWrite(message.mapStringForeignMessage[k], writer, options);
-            writer.join().join();
-        }
-        /* map<string, protobuf_test_messages.proto2.TestAllTypesProto2.NestedEnum> map_string_nested_enum = 73; */
-        for (let k of globalThis.Object.keys(message.mapStringNestedEnum))
-            writer.tag(73, WireType.LengthDelimited).fork().tag(1, WireType.LengthDelimited).string(k).tag(2, WireType.Varint).int32(message.mapStringNestedEnum[k]).join();
-        /* map<string, protobuf_test_messages.proto2.ForeignEnumProto2> map_string_foreign_enum = 74; */
-        for (let k of globalThis.Object.keys(message.mapStringForeignEnum))
-            writer.tag(74, WireType.LengthDelimited).fork().tag(1, WireType.LengthDelimited).string(k).tag(2, WireType.Varint).int32(message.mapStringForeignEnum[k]).join();
         /* uint32 oneof_uint32 = 111; */
         if (message.oneofField.oneofKind === "oneofUint32")
             writer.tag(111, WireType.Varint).uint32(message.oneofField.oneofUint32);

--- a/packages/test-force_optimize_speed-long_type_string/gen/google/protobuf/test_messages_proto3.ts
+++ b/packages/test-force_optimize_speed-long_type_string/gen/google/protobuf/test_messages_proto3.ts
@@ -2307,6 +2307,71 @@ class TestAllTypesProto3$Type extends MessageType<TestAllTypesProto3> {
         /* repeated string repeated_cord = 55; */
         for (let i = 0; i < message.repeatedCord.length; i++)
             writer.tag(55, WireType.LengthDelimited).string(message.repeatedCord[i]);
+        /* map<int32, int32> map_int32_int32 = 56; */
+        for (let k of globalThis.Object.keys(message.mapInt32Int32))
+            writer.tag(56, WireType.LengthDelimited).fork().tag(1, WireType.Varint).int32(parseInt(k)).tag(2, WireType.Varint).int32(message.mapInt32Int32[k as any]).join();
+        /* map<int64, int64> map_int64_int64 = 57; */
+        for (let k of globalThis.Object.keys(message.mapInt64Int64))
+            writer.tag(57, WireType.LengthDelimited).fork().tag(1, WireType.Varint).int64(k).tag(2, WireType.Varint).int64(message.mapInt64Int64[k]).join();
+        /* map<uint32, uint32> map_uint32_uint32 = 58; */
+        for (let k of globalThis.Object.keys(message.mapUint32Uint32))
+            writer.tag(58, WireType.LengthDelimited).fork().tag(1, WireType.Varint).uint32(parseInt(k)).tag(2, WireType.Varint).uint32(message.mapUint32Uint32[k as any]).join();
+        /* map<uint64, uint64> map_uint64_uint64 = 59; */
+        for (let k of globalThis.Object.keys(message.mapUint64Uint64))
+            writer.tag(59, WireType.LengthDelimited).fork().tag(1, WireType.Varint).uint64(k).tag(2, WireType.Varint).uint64(message.mapUint64Uint64[k]).join();
+        /* map<sint32, sint32> map_sint32_sint32 = 60; */
+        for (let k of globalThis.Object.keys(message.mapSint32Sint32))
+            writer.tag(60, WireType.LengthDelimited).fork().tag(1, WireType.Varint).sint32(parseInt(k)).tag(2, WireType.Varint).sint32(message.mapSint32Sint32[k as any]).join();
+        /* map<sint64, sint64> map_sint64_sint64 = 61; */
+        for (let k of globalThis.Object.keys(message.mapSint64Sint64))
+            writer.tag(61, WireType.LengthDelimited).fork().tag(1, WireType.Varint).sint64(k).tag(2, WireType.Varint).sint64(message.mapSint64Sint64[k]).join();
+        /* map<fixed32, fixed32> map_fixed32_fixed32 = 62; */
+        for (let k of globalThis.Object.keys(message.mapFixed32Fixed32))
+            writer.tag(62, WireType.LengthDelimited).fork().tag(1, WireType.Bit32).fixed32(parseInt(k)).tag(2, WireType.Bit32).fixed32(message.mapFixed32Fixed32[k as any]).join();
+        /* map<fixed64, fixed64> map_fixed64_fixed64 = 63; */
+        for (let k of globalThis.Object.keys(message.mapFixed64Fixed64))
+            writer.tag(63, WireType.LengthDelimited).fork().tag(1, WireType.Bit64).fixed64(k).tag(2, WireType.Bit64).fixed64(message.mapFixed64Fixed64[k]).join();
+        /* map<sfixed32, sfixed32> map_sfixed32_sfixed32 = 64; */
+        for (let k of globalThis.Object.keys(message.mapSfixed32Sfixed32))
+            writer.tag(64, WireType.LengthDelimited).fork().tag(1, WireType.Bit32).sfixed32(parseInt(k)).tag(2, WireType.Bit32).sfixed32(message.mapSfixed32Sfixed32[k as any]).join();
+        /* map<sfixed64, sfixed64> map_sfixed64_sfixed64 = 65; */
+        for (let k of globalThis.Object.keys(message.mapSfixed64Sfixed64))
+            writer.tag(65, WireType.LengthDelimited).fork().tag(1, WireType.Bit64).sfixed64(k).tag(2, WireType.Bit64).sfixed64(message.mapSfixed64Sfixed64[k]).join();
+        /* map<int32, float> map_int32_float = 66; */
+        for (let k of globalThis.Object.keys(message.mapInt32Float))
+            writer.tag(66, WireType.LengthDelimited).fork().tag(1, WireType.Varint).int32(parseInt(k)).tag(2, WireType.Bit32).float(message.mapInt32Float[k as any]).join();
+        /* map<int32, double> map_int32_double = 67; */
+        for (let k of globalThis.Object.keys(message.mapInt32Double))
+            writer.tag(67, WireType.LengthDelimited).fork().tag(1, WireType.Varint).int32(parseInt(k)).tag(2, WireType.Bit64).double(message.mapInt32Double[k as any]).join();
+        /* map<bool, bool> map_bool_bool = 68; */
+        for (let k of globalThis.Object.keys(message.mapBoolBool))
+            writer.tag(68, WireType.LengthDelimited).fork().tag(1, WireType.Varint).bool(k === "true").tag(2, WireType.Varint).bool(message.mapBoolBool[k]).join();
+        /* map<string, string> map_string_string = 69; */
+        for (let k of globalThis.Object.keys(message.mapStringString))
+            writer.tag(69, WireType.LengthDelimited).fork().tag(1, WireType.LengthDelimited).string(k).tag(2, WireType.LengthDelimited).string(message.mapStringString[k]).join();
+        /* map<string, bytes> map_string_bytes = 70; */
+        for (let k of globalThis.Object.keys(message.mapStringBytes))
+            writer.tag(70, WireType.LengthDelimited).fork().tag(1, WireType.LengthDelimited).string(k).tag(2, WireType.LengthDelimited).bytes(message.mapStringBytes[k]).join();
+        /* map<string, protobuf_test_messages.proto3.TestAllTypesProto3.NestedMessage> map_string_nested_message = 71; */
+        for (let k of globalThis.Object.keys(message.mapStringNestedMessage)) {
+            writer.tag(71, WireType.LengthDelimited).fork().tag(1, WireType.LengthDelimited).string(k);
+            writer.tag(2, WireType.LengthDelimited).fork();
+            TestAllTypesProto3_NestedMessage.internalBinaryWrite(message.mapStringNestedMessage[k], writer, options);
+            writer.join().join();
+        }
+        /* map<string, protobuf_test_messages.proto3.ForeignMessage> map_string_foreign_message = 72; */
+        for (let k of globalThis.Object.keys(message.mapStringForeignMessage)) {
+            writer.tag(72, WireType.LengthDelimited).fork().tag(1, WireType.LengthDelimited).string(k);
+            writer.tag(2, WireType.LengthDelimited).fork();
+            ForeignMessage.internalBinaryWrite(message.mapStringForeignMessage[k], writer, options);
+            writer.join().join();
+        }
+        /* map<string, protobuf_test_messages.proto3.TestAllTypesProto3.NestedEnum> map_string_nested_enum = 73; */
+        for (let k of globalThis.Object.keys(message.mapStringNestedEnum))
+            writer.tag(73, WireType.LengthDelimited).fork().tag(1, WireType.LengthDelimited).string(k).tag(2, WireType.Varint).int32(message.mapStringNestedEnum[k]).join();
+        /* map<string, protobuf_test_messages.proto3.ForeignEnum> map_string_foreign_enum = 74; */
+        for (let k of globalThis.Object.keys(message.mapStringForeignEnum))
+            writer.tag(74, WireType.LengthDelimited).fork().tag(1, WireType.LengthDelimited).string(k).tag(2, WireType.Varint).int32(message.mapStringForeignEnum[k]).join();
         /* repeated int32 packed_int32 = 75 [packed = true]; */
         if (message.packedInt32.length) {
             writer.tag(75, WireType.LengthDelimited).fork();
@@ -2447,71 +2512,6 @@ class TestAllTypesProto3$Type extends MessageType<TestAllTypesProto3> {
         /* repeated protobuf_test_messages.proto3.TestAllTypesProto3.NestedEnum unpacked_nested_enum = 102 [packed = false]; */
         for (let i = 0; i < message.unpackedNestedEnum.length; i++)
             writer.tag(102, WireType.Varint).int32(message.unpackedNestedEnum[i]);
-        /* map<int32, int32> map_int32_int32 = 56; */
-        for (let k of globalThis.Object.keys(message.mapInt32Int32))
-            writer.tag(56, WireType.LengthDelimited).fork().tag(1, WireType.Varint).int32(parseInt(k)).tag(2, WireType.Varint).int32(message.mapInt32Int32[k as any]).join();
-        /* map<int64, int64> map_int64_int64 = 57; */
-        for (let k of globalThis.Object.keys(message.mapInt64Int64))
-            writer.tag(57, WireType.LengthDelimited).fork().tag(1, WireType.Varint).int64(k).tag(2, WireType.Varint).int64(message.mapInt64Int64[k]).join();
-        /* map<uint32, uint32> map_uint32_uint32 = 58; */
-        for (let k of globalThis.Object.keys(message.mapUint32Uint32))
-            writer.tag(58, WireType.LengthDelimited).fork().tag(1, WireType.Varint).uint32(parseInt(k)).tag(2, WireType.Varint).uint32(message.mapUint32Uint32[k as any]).join();
-        /* map<uint64, uint64> map_uint64_uint64 = 59; */
-        for (let k of globalThis.Object.keys(message.mapUint64Uint64))
-            writer.tag(59, WireType.LengthDelimited).fork().tag(1, WireType.Varint).uint64(k).tag(2, WireType.Varint).uint64(message.mapUint64Uint64[k]).join();
-        /* map<sint32, sint32> map_sint32_sint32 = 60; */
-        for (let k of globalThis.Object.keys(message.mapSint32Sint32))
-            writer.tag(60, WireType.LengthDelimited).fork().tag(1, WireType.Varint).sint32(parseInt(k)).tag(2, WireType.Varint).sint32(message.mapSint32Sint32[k as any]).join();
-        /* map<sint64, sint64> map_sint64_sint64 = 61; */
-        for (let k of globalThis.Object.keys(message.mapSint64Sint64))
-            writer.tag(61, WireType.LengthDelimited).fork().tag(1, WireType.Varint).sint64(k).tag(2, WireType.Varint).sint64(message.mapSint64Sint64[k]).join();
-        /* map<fixed32, fixed32> map_fixed32_fixed32 = 62; */
-        for (let k of globalThis.Object.keys(message.mapFixed32Fixed32))
-            writer.tag(62, WireType.LengthDelimited).fork().tag(1, WireType.Bit32).fixed32(parseInt(k)).tag(2, WireType.Bit32).fixed32(message.mapFixed32Fixed32[k as any]).join();
-        /* map<fixed64, fixed64> map_fixed64_fixed64 = 63; */
-        for (let k of globalThis.Object.keys(message.mapFixed64Fixed64))
-            writer.tag(63, WireType.LengthDelimited).fork().tag(1, WireType.Bit64).fixed64(k).tag(2, WireType.Bit64).fixed64(message.mapFixed64Fixed64[k]).join();
-        /* map<sfixed32, sfixed32> map_sfixed32_sfixed32 = 64; */
-        for (let k of globalThis.Object.keys(message.mapSfixed32Sfixed32))
-            writer.tag(64, WireType.LengthDelimited).fork().tag(1, WireType.Bit32).sfixed32(parseInt(k)).tag(2, WireType.Bit32).sfixed32(message.mapSfixed32Sfixed32[k as any]).join();
-        /* map<sfixed64, sfixed64> map_sfixed64_sfixed64 = 65; */
-        for (let k of globalThis.Object.keys(message.mapSfixed64Sfixed64))
-            writer.tag(65, WireType.LengthDelimited).fork().tag(1, WireType.Bit64).sfixed64(k).tag(2, WireType.Bit64).sfixed64(message.mapSfixed64Sfixed64[k]).join();
-        /* map<int32, float> map_int32_float = 66; */
-        for (let k of globalThis.Object.keys(message.mapInt32Float))
-            writer.tag(66, WireType.LengthDelimited).fork().tag(1, WireType.Varint).int32(parseInt(k)).tag(2, WireType.Bit32).float(message.mapInt32Float[k as any]).join();
-        /* map<int32, double> map_int32_double = 67; */
-        for (let k of globalThis.Object.keys(message.mapInt32Double))
-            writer.tag(67, WireType.LengthDelimited).fork().tag(1, WireType.Varint).int32(parseInt(k)).tag(2, WireType.Bit64).double(message.mapInt32Double[k as any]).join();
-        /* map<bool, bool> map_bool_bool = 68; */
-        for (let k of globalThis.Object.keys(message.mapBoolBool))
-            writer.tag(68, WireType.LengthDelimited).fork().tag(1, WireType.Varint).bool(k === "true").tag(2, WireType.Varint).bool(message.mapBoolBool[k]).join();
-        /* map<string, string> map_string_string = 69; */
-        for (let k of globalThis.Object.keys(message.mapStringString))
-            writer.tag(69, WireType.LengthDelimited).fork().tag(1, WireType.LengthDelimited).string(k).tag(2, WireType.LengthDelimited).string(message.mapStringString[k]).join();
-        /* map<string, bytes> map_string_bytes = 70; */
-        for (let k of globalThis.Object.keys(message.mapStringBytes))
-            writer.tag(70, WireType.LengthDelimited).fork().tag(1, WireType.LengthDelimited).string(k).tag(2, WireType.LengthDelimited).bytes(message.mapStringBytes[k]).join();
-        /* map<string, protobuf_test_messages.proto3.TestAllTypesProto3.NestedMessage> map_string_nested_message = 71; */
-        for (let k of globalThis.Object.keys(message.mapStringNestedMessage)) {
-            writer.tag(71, WireType.LengthDelimited).fork().tag(1, WireType.LengthDelimited).string(k);
-            writer.tag(2, WireType.LengthDelimited).fork();
-            TestAllTypesProto3_NestedMessage.internalBinaryWrite(message.mapStringNestedMessage[k], writer, options);
-            writer.join().join();
-        }
-        /* map<string, protobuf_test_messages.proto3.ForeignMessage> map_string_foreign_message = 72; */
-        for (let k of globalThis.Object.keys(message.mapStringForeignMessage)) {
-            writer.tag(72, WireType.LengthDelimited).fork().tag(1, WireType.LengthDelimited).string(k);
-            writer.tag(2, WireType.LengthDelimited).fork();
-            ForeignMessage.internalBinaryWrite(message.mapStringForeignMessage[k], writer, options);
-            writer.join().join();
-        }
-        /* map<string, protobuf_test_messages.proto3.TestAllTypesProto3.NestedEnum> map_string_nested_enum = 73; */
-        for (let k of globalThis.Object.keys(message.mapStringNestedEnum))
-            writer.tag(73, WireType.LengthDelimited).fork().tag(1, WireType.LengthDelimited).string(k).tag(2, WireType.Varint).int32(message.mapStringNestedEnum[k]).join();
-        /* map<string, protobuf_test_messages.proto3.ForeignEnum> map_string_foreign_enum = 74; */
-        for (let k of globalThis.Object.keys(message.mapStringForeignEnum))
-            writer.tag(74, WireType.LengthDelimited).fork().tag(1, WireType.LengthDelimited).string(k).tag(2, WireType.Varint).int32(message.mapStringForeignEnum[k]).join();
         /* uint32 oneof_uint32 = 111; */
         if (message.oneofField.oneofKind === "oneofUint32")
             writer.tag(111, WireType.Varint).uint32(message.oneofField.oneofUint32);
@@ -2626,9 +2626,6 @@ class TestAllTypesProto3$Type extends MessageType<TestAllTypesProto3> {
         /* repeated google.protobuf.FieldMask repeated_fieldmask = 313; */
         for (let i = 0; i < message.repeatedFieldmask.length; i++)
             FieldMask.internalBinaryWrite(message.repeatedFieldmask[i], writer.tag(313, WireType.LengthDelimited).fork(), options).join();
-        /* repeated google.protobuf.Struct repeated_struct = 324; */
-        for (let i = 0; i < message.repeatedStruct.length; i++)
-            Struct.internalBinaryWrite(message.repeatedStruct[i], writer.tag(324, WireType.LengthDelimited).fork(), options).join();
         /* repeated google.protobuf.Any repeated_any = 315; */
         for (let i = 0; i < message.repeatedAny.length; i++)
             Any.internalBinaryWrite(message.repeatedAny[i], writer.tag(315, WireType.LengthDelimited).fork(), options).join();
@@ -2638,6 +2635,9 @@ class TestAllTypesProto3$Type extends MessageType<TestAllTypesProto3> {
         /* repeated google.protobuf.ListValue repeated_list_value = 317; */
         for (let i = 0; i < message.repeatedListValue.length; i++)
             ListValue.internalBinaryWrite(message.repeatedListValue[i], writer.tag(317, WireType.LengthDelimited).fork(), options).join();
+        /* repeated google.protobuf.Struct repeated_struct = 324; */
+        for (let i = 0; i < message.repeatedStruct.length; i++)
+            Struct.internalBinaryWrite(message.repeatedStruct[i], writer.tag(324, WireType.LengthDelimited).fork(), options).join();
         /* int32 fieldname1 = 401; */
         if (message.fieldname1 !== 0)
             writer.tag(401, WireType.Varint).int32(message.fieldname1);

--- a/packages/test-force_optimize_speed-long_type_string/gen/google/protobuf/unittest_mset.ts
+++ b/packages/test-force_optimize_speed-long_type_string/gen/google/protobuf/unittest_mset.ts
@@ -290,12 +290,12 @@ class NestedTestInt$Type extends MessageType<NestedTestInt> {
         /* optional fixed32 a = 1; */
         if (message.a !== undefined)
             writer.tag(1, WireType.Bit32).fixed32(message.a);
-        /* optional int32 b = 3; */
-        if (message.b !== undefined)
-            writer.tag(3, WireType.Varint).int32(message.b);
         /* optional protobuf_unittest.NestedTestInt child = 2; */
         if (message.child)
             NestedTestInt.internalBinaryWrite(message.child, writer.tag(2, WireType.LengthDelimited).fork(), options).join();
+        /* optional int32 b = 3; */
+        if (message.b !== undefined)
+            writer.tag(3, WireType.Varint).int32(message.b);
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);

--- a/packages/test-force_optimize_speed-long_type_string/gen/google/protobuf/unittest_proto3.ts
+++ b/packages/test-force_optimize_speed-long_type_string/gen/google/protobuf/unittest_proto3.ts
@@ -1282,9 +1282,6 @@ class TestAllTypes$Type extends MessageType<TestAllTypes> {
         /* proto3_unittest.TestAllTypes.NestedMessage optional_unverified_lazy_message = 28; */
         if (message.optionalUnverifiedLazyMessage)
             TestAllTypes_NestedMessage.internalBinaryWrite(message.optionalUnverifiedLazyMessage, writer.tag(28, WireType.LengthDelimited).fork(), options).join();
-        /* protobuf_unittest_import.ImportMessage optional_lazy_import_message = 115; */
-        if (message.optionalLazyImportMessage)
-            ImportMessage.internalBinaryWrite(message.optionalLazyImportMessage, writer.tag(115, WireType.LengthDelimited).fork(), options).join();
         /* repeated int32 repeated_int32 = 31; */
         if (message.repeatedInt32.length) {
             writer.tag(31, WireType.LengthDelimited).fork();
@@ -1426,6 +1423,9 @@ class TestAllTypes$Type extends MessageType<TestAllTypes> {
         /* bytes oneof_bytes = 114; */
         if (message.oneofField.oneofKind === "oneofBytes")
             writer.tag(114, WireType.LengthDelimited).bytes(message.oneofField.oneofBytes);
+        /* protobuf_unittest_import.ImportMessage optional_lazy_import_message = 115; */
+        if (message.optionalLazyImportMessage)
+            ImportMessage.internalBinaryWrite(message.optionalLazyImportMessage, writer.tag(115, WireType.LengthDelimited).fork(), options).join();
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);

--- a/packages/test-force_optimize_speed-long_type_string/gen/google/protobuf/unittest_proto3_arena.ts
+++ b/packages/test-force_optimize_speed-long_type_string/gen/google/protobuf/unittest_proto3_arena.ts
@@ -973,9 +973,6 @@ class TestAllTypes$Type extends MessageType<TestAllTypes> {
         /* proto3_arena_unittest.TestAllTypes.NestedMessage optional_lazy_message = 27; */
         if (message.optionalLazyMessage)
             TestAllTypes_NestedMessage.internalBinaryWrite(message.optionalLazyMessage, writer.tag(27, WireType.LengthDelimited).fork(), options).join();
-        /* protobuf_unittest_import.ImportMessage optional_lazy_import_message = 115; */
-        if (message.optionalLazyImportMessage)
-            ImportMessage.internalBinaryWrite(message.optionalLazyImportMessage, writer.tag(115, WireType.LengthDelimited).fork(), options).join();
         /* repeated int32 repeated_int32 = 31; */
         if (message.repeatedInt32.length) {
             writer.tag(31, WireType.LengthDelimited).fork();
@@ -1117,6 +1114,9 @@ class TestAllTypes$Type extends MessageType<TestAllTypes> {
         /* bytes oneof_bytes = 114; */
         if (message.oneofField.oneofKind === "oneofBytes")
             writer.tag(114, WireType.LengthDelimited).bytes(message.oneofField.oneofBytes);
+        /* protobuf_unittest_import.ImportMessage optional_lazy_import_message = 115; */
+        if (message.optionalLazyImportMessage)
+            ImportMessage.internalBinaryWrite(message.optionalLazyImportMessage, writer.tag(115, WireType.LengthDelimited).fork(), options).join();
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);

--- a/packages/test-force_optimize_speed-long_type_string/gen/google/rpc/context/attribute_context.ts
+++ b/packages/test-force_optimize_speed-long_type_string/gen/google/rpc/context/attribute_context.ts
@@ -504,9 +504,6 @@ class AttributeContext$Type extends MessageType<AttributeContext> {
         return message;
     }
     internalBinaryWrite(message: AttributeContext, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
-        /* google.rpc.context.AttributeContext.Peer origin = 7; */
-        if (message.origin)
-            AttributeContext_Peer.internalBinaryWrite(message.origin, writer.tag(7, WireType.LengthDelimited).fork(), options).join();
         /* google.rpc.context.AttributeContext.Peer source = 1; */
         if (message.source)
             AttributeContext_Peer.internalBinaryWrite(message.source, writer.tag(1, WireType.LengthDelimited).fork(), options).join();
@@ -525,6 +522,9 @@ class AttributeContext$Type extends MessageType<AttributeContext> {
         /* google.rpc.context.AttributeContext.Api api = 6; */
         if (message.api)
             AttributeContext_Api.internalBinaryWrite(message.api, writer.tag(6, WireType.LengthDelimited).fork(), options).join();
+        /* google.rpc.context.AttributeContext.Peer origin = 7; */
+        if (message.origin)
+            AttributeContext_Peer.internalBinaryWrite(message.origin, writer.tag(7, WireType.LengthDelimited).fork(), options).join();
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);

--- a/packages/test-force_optimize_speed-long_type_string/spec/generated-binary-read-compat.spec.ts
+++ b/packages/test-force_optimize_speed-long_type_string/spec/generated-binary-read-compat.spec.ts
@@ -1,4 +1,4 @@
-import {IMessageType, MessageType} from "@protobuf-ts/runtime";
+import {IMessageType, MessageType, base64encode} from "@protobuf-ts/runtime";
 import {EnumFieldMessage} from "../gen/msg-enum";
 import {JsonNamesMessage} from "../gen/msg-json-names";
 import {MessageFieldMessage} from "../gen/msg-message";
@@ -6,6 +6,7 @@ import {OneofMessageMemberMessage, OneofScalarMemberMessage} from "../gen/msg-on
 import {Proto2OptionalsMessage} from "../gen/msg-proto2-optionals";
 import {Proto3OptionalsMessage} from "../gen/msg-proto3-optionals";
 import {RepeatedScalarValuesMessage, ScalarValuesMessage} from "../gen/msg-scalar";
+import {TestAllTypesProto3} from "../gen/google/protobuf/test_messages_proto3";
 
 // Copied from test-default/generated-binary-read-compat.spec.ts. Do not edit.
 let generatedRegistry: IMessageType<any>[] = [
@@ -39,6 +40,20 @@ describe('generated code compatibility', () => {
             });
         }
     });
+
+    it('should have same serialization order regardless of optimization options', function () {
+        const reflectionType = new MessageType<TestAllTypesProto3>(TestAllTypesProto3.typeName, [...TestAllTypesProto3.fields].reverse());
+        const message = TestAllTypesProto3.fromJson({
+            optionalInt32: 123,
+            optionalInt64: "1",
+            optionalString: "1",
+            optionalNestedMessage: {
+                a: 2,
+            }
+        });
+        expect(base64encode(TestAllTypesProto3.toBinary(message)))
+            .toBe(base64encode(reflectionType.toBinary(message)));
+    })
 
 });
 

--- a/packages/test-force_optimize_speed/gen/conformance/conformance.ts
+++ b/packages/test-force_optimize_speed/gen/conformance/conformance.ts
@@ -539,12 +539,6 @@ class ConformanceRequest$Type extends MessageType<ConformanceRequest> {
         /* string json_payload = 2; */
         if (message.payload.oneofKind === "jsonPayload")
             writer.tag(2, WireType.LengthDelimited).string(message.payload.jsonPayload);
-        /* string jspb_payload = 7; */
-        if (message.payload.oneofKind === "jspbPayload")
-            writer.tag(7, WireType.LengthDelimited).string(message.payload.jspbPayload);
-        /* string text_payload = 8; */
-        if (message.payload.oneofKind === "textPayload")
-            writer.tag(8, WireType.LengthDelimited).string(message.payload.textPayload);
         /* conformance.WireFormat requested_output_format = 3; */
         if (message.requestedOutputFormat !== 0)
             writer.tag(3, WireType.Varint).int32(message.requestedOutputFormat);
@@ -557,6 +551,12 @@ class ConformanceRequest$Type extends MessageType<ConformanceRequest> {
         /* conformance.JspbEncodingConfig jspb_encoding_options = 6; */
         if (message.jspbEncodingOptions)
             JspbEncodingConfig.internalBinaryWrite(message.jspbEncodingOptions, writer.tag(6, WireType.LengthDelimited).fork(), options).join();
+        /* string jspb_payload = 7; */
+        if (message.payload.oneofKind === "jspbPayload")
+            writer.tag(7, WireType.LengthDelimited).string(message.payload.jspbPayload);
+        /* string text_payload = 8; */
+        if (message.payload.oneofKind === "textPayload")
+            writer.tag(8, WireType.LengthDelimited).string(message.payload.textPayload);
         /* bool print_unknown_fields = 9; */
         if (message.printUnknownFields !== false)
             writer.tag(9, WireType.Varint).bool(message.printUnknownFields);
@@ -666,12 +666,6 @@ class ConformanceResponse$Type extends MessageType<ConformanceResponse> {
         /* string parse_error = 1; */
         if (message.result.oneofKind === "parseError")
             writer.tag(1, WireType.LengthDelimited).string(message.result.parseError);
-        /* string serialize_error = 6; */
-        if (message.result.oneofKind === "serializeError")
-            writer.tag(6, WireType.LengthDelimited).string(message.result.serializeError);
-        /* string timeout_error = 9; */
-        if (message.result.oneofKind === "timeoutError")
-            writer.tag(9, WireType.LengthDelimited).string(message.result.timeoutError);
         /* string runtime_error = 2; */
         if (message.result.oneofKind === "runtimeError")
             writer.tag(2, WireType.LengthDelimited).string(message.result.runtimeError);
@@ -684,12 +678,18 @@ class ConformanceResponse$Type extends MessageType<ConformanceResponse> {
         /* string skipped = 5; */
         if (message.result.oneofKind === "skipped")
             writer.tag(5, WireType.LengthDelimited).string(message.result.skipped);
+        /* string serialize_error = 6; */
+        if (message.result.oneofKind === "serializeError")
+            writer.tag(6, WireType.LengthDelimited).string(message.result.serializeError);
         /* string jspb_payload = 7; */
         if (message.result.oneofKind === "jspbPayload")
             writer.tag(7, WireType.LengthDelimited).string(message.result.jspbPayload);
         /* string text_payload = 8; */
         if (message.result.oneofKind === "textPayload")
             writer.tag(8, WireType.LengthDelimited).string(message.result.textPayload);
+        /* string timeout_error = 9; */
+        if (message.result.oneofKind === "timeoutError")
+            writer.tag(9, WireType.LengthDelimited).string(message.result.timeoutError);
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);

--- a/packages/test-force_optimize_speed/gen/google/api/http.ts
+++ b/packages/test-force_optimize_speed/gen/google/api/http.ts
@@ -608,18 +608,18 @@ class HttpRule$Type extends MessageType<HttpRule> {
         /* string patch = 6; */
         if (message.pattern.oneofKind === "patch")
             writer.tag(6, WireType.LengthDelimited).string(message.pattern.patch);
-        /* google.api.CustomHttpPattern custom = 8; */
-        if (message.pattern.oneofKind === "custom")
-            CustomHttpPattern.internalBinaryWrite(message.pattern.custom, writer.tag(8, WireType.LengthDelimited).fork(), options).join();
         /* string body = 7; */
         if (message.body !== "")
             writer.tag(7, WireType.LengthDelimited).string(message.body);
-        /* string response_body = 12; */
-        if (message.responseBody !== "")
-            writer.tag(12, WireType.LengthDelimited).string(message.responseBody);
+        /* google.api.CustomHttpPattern custom = 8; */
+        if (message.pattern.oneofKind === "custom")
+            CustomHttpPattern.internalBinaryWrite(message.pattern.custom, writer.tag(8, WireType.LengthDelimited).fork(), options).join();
         /* repeated google.api.HttpRule additional_bindings = 11; */
         for (let i = 0; i < message.additionalBindings.length; i++)
             HttpRule.internalBinaryWrite(message.additionalBindings[i], writer.tag(11, WireType.LengthDelimited).fork(), options).join();
+        /* string response_body = 12; */
+        if (message.responseBody !== "")
+            writer.tag(12, WireType.LengthDelimited).string(message.responseBody);
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);

--- a/packages/test-force_optimize_speed/gen/google/protobuf/compiler/plugin.ts
+++ b/packages/test-force_optimize_speed/gen/google/protobuf/compiler/plugin.ts
@@ -391,15 +391,15 @@ class CodeGeneratorRequest$Type extends MessageType<CodeGeneratorRequest> {
         /* optional string parameter = 2; */
         if (message.parameter !== undefined)
             writer.tag(2, WireType.LengthDelimited).string(message.parameter);
+        /* optional google.protobuf.compiler.Version compiler_version = 3; */
+        if (message.compilerVersion)
+            Version.internalBinaryWrite(message.compilerVersion, writer.tag(3, WireType.LengthDelimited).fork(), options).join();
         /* repeated google.protobuf.FileDescriptorProto proto_file = 15; */
         for (let i = 0; i < message.protoFile.length; i++)
             FileDescriptorProto.internalBinaryWrite(message.protoFile[i], writer.tag(15, WireType.LengthDelimited).fork(), options).join();
         /* repeated google.protobuf.FileDescriptorProto source_file_descriptors = 17; */
         for (let i = 0; i < message.sourceFileDescriptors.length; i++)
             FileDescriptorProto.internalBinaryWrite(message.sourceFileDescriptors[i], writer.tag(17, WireType.LengthDelimited).fork(), options).join();
-        /* optional google.protobuf.compiler.Version compiler_version = 3; */
-        if (message.compilerVersion)
-            Version.internalBinaryWrite(message.compilerVersion, writer.tag(3, WireType.LengthDelimited).fork(), options).join();
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);

--- a/packages/test-force_optimize_speed/gen/google/protobuf/descriptor.ts
+++ b/packages/test-force_optimize_speed/gen/google/protobuf/descriptor.ts
@@ -2249,12 +2249,6 @@ class FileDescriptorProto$Type extends MessageType<FileDescriptorProto> {
         /* repeated string dependency = 3; */
         for (let i = 0; i < message.dependency.length; i++)
             writer.tag(3, WireType.LengthDelimited).string(message.dependency[i]);
-        /* repeated int32 public_dependency = 10; */
-        for (let i = 0; i < message.publicDependency.length; i++)
-            writer.tag(10, WireType.Varint).int32(message.publicDependency[i]);
-        /* repeated int32 weak_dependency = 11; */
-        for (let i = 0; i < message.weakDependency.length; i++)
-            writer.tag(11, WireType.Varint).int32(message.weakDependency[i]);
         /* repeated google.protobuf.DescriptorProto message_type = 4; */
         for (let i = 0; i < message.messageType.length; i++)
             DescriptorProto.internalBinaryWrite(message.messageType[i], writer.tag(4, WireType.LengthDelimited).fork(), options).join();
@@ -2273,6 +2267,12 @@ class FileDescriptorProto$Type extends MessageType<FileDescriptorProto> {
         /* optional google.protobuf.SourceCodeInfo source_code_info = 9; */
         if (message.sourceCodeInfo)
             SourceCodeInfo.internalBinaryWrite(message.sourceCodeInfo, writer.tag(9, WireType.LengthDelimited).fork(), options).join();
+        /* repeated int32 public_dependency = 10; */
+        for (let i = 0; i < message.publicDependency.length; i++)
+            writer.tag(10, WireType.Varint).int32(message.publicDependency[i]);
+        /* repeated int32 weak_dependency = 11; */
+        for (let i = 0; i < message.weakDependency.length; i++)
+            writer.tag(11, WireType.Varint).int32(message.weakDependency[i]);
         /* optional string syntax = 12; */
         if (message.syntax !== undefined)
             writer.tag(12, WireType.LengthDelimited).string(message.syntax);
@@ -2372,9 +2372,6 @@ class DescriptorProto$Type extends MessageType<DescriptorProto> {
         /* repeated google.protobuf.FieldDescriptorProto field = 2; */
         for (let i = 0; i < message.field.length; i++)
             FieldDescriptorProto.internalBinaryWrite(message.field[i], writer.tag(2, WireType.LengthDelimited).fork(), options).join();
-        /* repeated google.protobuf.FieldDescriptorProto extension = 6; */
-        for (let i = 0; i < message.extension.length; i++)
-            FieldDescriptorProto.internalBinaryWrite(message.extension[i], writer.tag(6, WireType.LengthDelimited).fork(), options).join();
         /* repeated google.protobuf.DescriptorProto nested_type = 3; */
         for (let i = 0; i < message.nestedType.length; i++)
             DescriptorProto.internalBinaryWrite(message.nestedType[i], writer.tag(3, WireType.LengthDelimited).fork(), options).join();
@@ -2384,12 +2381,15 @@ class DescriptorProto$Type extends MessageType<DescriptorProto> {
         /* repeated google.protobuf.DescriptorProto.ExtensionRange extension_range = 5; */
         for (let i = 0; i < message.extensionRange.length; i++)
             DescriptorProto_ExtensionRange.internalBinaryWrite(message.extensionRange[i], writer.tag(5, WireType.LengthDelimited).fork(), options).join();
-        /* repeated google.protobuf.OneofDescriptorProto oneof_decl = 8; */
-        for (let i = 0; i < message.oneofDecl.length; i++)
-            OneofDescriptorProto.internalBinaryWrite(message.oneofDecl[i], writer.tag(8, WireType.LengthDelimited).fork(), options).join();
+        /* repeated google.protobuf.FieldDescriptorProto extension = 6; */
+        for (let i = 0; i < message.extension.length; i++)
+            FieldDescriptorProto.internalBinaryWrite(message.extension[i], writer.tag(6, WireType.LengthDelimited).fork(), options).join();
         /* optional google.protobuf.MessageOptions options = 7; */
         if (message.options)
             MessageOptions.internalBinaryWrite(message.options, writer.tag(7, WireType.LengthDelimited).fork(), options).join();
+        /* repeated google.protobuf.OneofDescriptorProto oneof_decl = 8; */
+        for (let i = 0; i < message.oneofDecl.length; i++)
+            OneofDescriptorProto.internalBinaryWrite(message.oneofDecl[i], writer.tag(8, WireType.LengthDelimited).fork(), options).join();
         /* repeated google.protobuf.DescriptorProto.ReservedRange reserved_range = 9; */
         for (let i = 0; i < message.reservedRange.length; i++)
             DescriptorProto_ReservedRange.internalBinaryWrite(message.reservedRange[i], writer.tag(9, WireType.LengthDelimited).fork(), options).join();
@@ -2566,18 +2566,18 @@ class ExtensionRangeOptions$Type extends MessageType<ExtensionRangeOptions> {
         return message;
     }
     internalBinaryWrite(message: ExtensionRangeOptions, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
-        /* repeated google.protobuf.UninterpretedOption uninterpreted_option = 999; */
-        for (let i = 0; i < message.uninterpretedOption.length; i++)
-            UninterpretedOption.internalBinaryWrite(message.uninterpretedOption[i], writer.tag(999, WireType.LengthDelimited).fork(), options).join();
         /* repeated google.protobuf.ExtensionRangeOptions.Declaration declaration = 2; */
         for (let i = 0; i < message.declaration.length; i++)
             ExtensionRangeOptions_Declaration.internalBinaryWrite(message.declaration[i], writer.tag(2, WireType.LengthDelimited).fork(), options).join();
-        /* optional google.protobuf.FeatureSet features = 50; */
-        if (message.features)
-            FeatureSet.internalBinaryWrite(message.features, writer.tag(50, WireType.LengthDelimited).fork(), options).join();
         /* optional google.protobuf.ExtensionRangeOptions.VerificationState verification = 3; */
         if (message.verification !== undefined)
             writer.tag(3, WireType.Varint).int32(message.verification);
+        /* optional google.protobuf.FeatureSet features = 50; */
+        if (message.features)
+            FeatureSet.internalBinaryWrite(message.features, writer.tag(50, WireType.LengthDelimited).fork(), options).join();
+        /* repeated google.protobuf.UninterpretedOption uninterpreted_option = 999; */
+        for (let i = 0; i < message.uninterpretedOption.length; i++)
+            UninterpretedOption.internalBinaryWrite(message.uninterpretedOption[i], writer.tag(999, WireType.LengthDelimited).fork(), options).join();
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
@@ -2738,6 +2738,9 @@ class FieldDescriptorProto$Type extends MessageType<FieldDescriptorProto> {
         /* optional string name = 1; */
         if (message.name !== undefined)
             writer.tag(1, WireType.LengthDelimited).string(message.name);
+        /* optional string extendee = 2; */
+        if (message.extendee !== undefined)
+            writer.tag(2, WireType.LengthDelimited).string(message.extendee);
         /* optional int32 number = 3; */
         if (message.number !== undefined)
             writer.tag(3, WireType.Varint).int32(message.number);
@@ -2750,21 +2753,18 @@ class FieldDescriptorProto$Type extends MessageType<FieldDescriptorProto> {
         /* optional string type_name = 6; */
         if (message.typeName !== undefined)
             writer.tag(6, WireType.LengthDelimited).string(message.typeName);
-        /* optional string extendee = 2; */
-        if (message.extendee !== undefined)
-            writer.tag(2, WireType.LengthDelimited).string(message.extendee);
         /* optional string default_value = 7; */
         if (message.defaultValue !== undefined)
             writer.tag(7, WireType.LengthDelimited).string(message.defaultValue);
+        /* optional google.protobuf.FieldOptions options = 8; */
+        if (message.options)
+            FieldOptions.internalBinaryWrite(message.options, writer.tag(8, WireType.LengthDelimited).fork(), options).join();
         /* optional int32 oneof_index = 9; */
         if (message.oneofIndex !== undefined)
             writer.tag(9, WireType.Varint).int32(message.oneofIndex);
         /* optional string json_name = 10; */
         if (message.jsonName !== undefined)
             writer.tag(10, WireType.LengthDelimited).string(message.jsonName);
-        /* optional google.protobuf.FieldOptions options = 8; */
-        if (message.options)
-            FieldOptions.internalBinaryWrite(message.options, writer.tag(8, WireType.LengthDelimited).fork(), options).join();
         /* optional bool proto3_optional = 17; */
         if (message.proto3Optional !== undefined)
             writer.tag(17, WireType.Varint).bool(message.proto3Optional);
@@ -3283,18 +3283,12 @@ class FileOptions$Type extends MessageType<FileOptions> {
         /* optional string java_outer_classname = 8; */
         if (message.javaOuterClassname !== undefined)
             writer.tag(8, WireType.LengthDelimited).string(message.javaOuterClassname);
-        /* optional bool java_multiple_files = 10; */
-        if (message.javaMultipleFiles !== undefined)
-            writer.tag(10, WireType.Varint).bool(message.javaMultipleFiles);
-        /* optional bool java_generate_equals_and_hash = 20 [deprecated = true]; */
-        if (message.javaGenerateEqualsAndHash !== undefined)
-            writer.tag(20, WireType.Varint).bool(message.javaGenerateEqualsAndHash);
-        /* optional bool java_string_check_utf8 = 27; */
-        if (message.javaStringCheckUtf8 !== undefined)
-            writer.tag(27, WireType.Varint).bool(message.javaStringCheckUtf8);
         /* optional google.protobuf.FileOptions.OptimizeMode optimize_for = 9; */
         if (message.optimizeFor !== undefined)
             writer.tag(9, WireType.Varint).int32(message.optimizeFor);
+        /* optional bool java_multiple_files = 10; */
+        if (message.javaMultipleFiles !== undefined)
+            writer.tag(10, WireType.Varint).bool(message.javaMultipleFiles);
         /* optional string go_package = 11; */
         if (message.goPackage !== undefined)
             writer.tag(11, WireType.LengthDelimited).string(message.goPackage);
@@ -3307,9 +3301,15 @@ class FileOptions$Type extends MessageType<FileOptions> {
         /* optional bool py_generic_services = 18; */
         if (message.pyGenericServices !== undefined)
             writer.tag(18, WireType.Varint).bool(message.pyGenericServices);
+        /* optional bool java_generate_equals_and_hash = 20 [deprecated = true]; */
+        if (message.javaGenerateEqualsAndHash !== undefined)
+            writer.tag(20, WireType.Varint).bool(message.javaGenerateEqualsAndHash);
         /* optional bool deprecated = 23; */
         if (message.deprecated !== undefined)
             writer.tag(23, WireType.Varint).bool(message.deprecated);
+        /* optional bool java_string_check_utf8 = 27; */
+        if (message.javaStringCheckUtf8 !== undefined)
+            writer.tag(27, WireType.Varint).bool(message.javaStringCheckUtf8);
         /* optional bool cc_enable_arenas = 31; */
         if (message.ccEnableArenas !== undefined)
             writer.tag(31, WireType.Varint).bool(message.ccEnableArenas);
@@ -3537,21 +3537,21 @@ class FieldOptions$Type extends MessageType<FieldOptions> {
         /* optional bool packed = 2; */
         if (message.packed !== undefined)
             writer.tag(2, WireType.Varint).bool(message.packed);
-        /* optional google.protobuf.FieldOptions.JSType jstype = 6; */
-        if (message.jstype !== undefined)
-            writer.tag(6, WireType.Varint).int32(message.jstype);
-        /* optional bool lazy = 5; */
-        if (message.lazy !== undefined)
-            writer.tag(5, WireType.Varint).bool(message.lazy);
-        /* optional bool unverified_lazy = 15; */
-        if (message.unverifiedLazy !== undefined)
-            writer.tag(15, WireType.Varint).bool(message.unverifiedLazy);
         /* optional bool deprecated = 3; */
         if (message.deprecated !== undefined)
             writer.tag(3, WireType.Varint).bool(message.deprecated);
+        /* optional bool lazy = 5; */
+        if (message.lazy !== undefined)
+            writer.tag(5, WireType.Varint).bool(message.lazy);
+        /* optional google.protobuf.FieldOptions.JSType jstype = 6; */
+        if (message.jstype !== undefined)
+            writer.tag(6, WireType.Varint).int32(message.jstype);
         /* optional bool weak = 10; */
         if (message.weak !== undefined)
             writer.tag(10, WireType.Varint).bool(message.weak);
+        /* optional bool unverified_lazy = 15; */
+        if (message.unverifiedLazy !== undefined)
+            writer.tag(15, WireType.Varint).bool(message.unverifiedLazy);
         /* optional bool debug_redact = 16; */
         if (message.debugRedact !== undefined)
             writer.tag(16, WireType.Varint).bool(message.debugRedact);
@@ -3620,12 +3620,12 @@ class FieldOptions_EditionDefault$Type extends MessageType<FieldOptions_EditionD
         return message;
     }
     internalBinaryWrite(message: FieldOptions_EditionDefault, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
-        /* optional google.protobuf.Edition edition = 3; */
-        if (message.edition !== undefined)
-            writer.tag(3, WireType.Varint).int32(message.edition);
         /* optional string value = 2; */
         if (message.value !== undefined)
             writer.tag(2, WireType.LengthDelimited).string(message.value);
+        /* optional google.protobuf.Edition edition = 3; */
+        if (message.edition !== undefined)
+            writer.tag(3, WireType.Varint).int32(message.edition);
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
@@ -3949,12 +3949,12 @@ class ServiceOptions$Type extends MessageType<ServiceOptions> {
         return message;
     }
     internalBinaryWrite(message: ServiceOptions, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
-        /* optional google.protobuf.FeatureSet features = 34; */
-        if (message.features)
-            FeatureSet.internalBinaryWrite(message.features, writer.tag(34, WireType.LengthDelimited).fork(), options).join();
         /* optional bool deprecated = 33; */
         if (message.deprecated !== undefined)
             writer.tag(33, WireType.Varint).bool(message.deprecated);
+        /* optional google.protobuf.FeatureSet features = 34; */
+        if (message.features)
+            FeatureSet.internalBinaryWrite(message.features, writer.tag(34, WireType.LengthDelimited).fork(), options).join();
         /* repeated google.protobuf.UninterpretedOption uninterpreted_option = 999; */
         for (let i = 0; i < message.uninterpretedOption.length; i++)
             UninterpretedOption.internalBinaryWrite(message.uninterpretedOption[i], writer.tag(999, WireType.LengthDelimited).fork(), options).join();

--- a/packages/test-force_optimize_speed/gen/google/protobuf/test_messages_proto2.ts
+++ b/packages/test-force_optimize_speed/gen/google/protobuf/test_messages_proto2.ts
@@ -2354,6 +2354,71 @@ class TestAllTypesProto2$Type extends MessageType<TestAllTypesProto2> {
         /* repeated string repeated_cord = 55; */
         for (let i = 0; i < message.repeatedCord.length; i++)
             writer.tag(55, WireType.LengthDelimited).string(message.repeatedCord[i]);
+        /* map<int32, int32> map_int32_int32 = 56; */
+        for (let k of globalThis.Object.keys(message.mapInt32Int32))
+            writer.tag(56, WireType.LengthDelimited).fork().tag(1, WireType.Varint).int32(parseInt(k)).tag(2, WireType.Varint).int32(message.mapInt32Int32[k as any]).join();
+        /* map<int64, int64> map_int64_int64 = 57; */
+        for (let k of globalThis.Object.keys(message.mapInt64Int64))
+            writer.tag(57, WireType.LengthDelimited).fork().tag(1, WireType.Varint).int64(k).tag(2, WireType.Varint).int64(message.mapInt64Int64[k]).join();
+        /* map<uint32, uint32> map_uint32_uint32 = 58; */
+        for (let k of globalThis.Object.keys(message.mapUint32Uint32))
+            writer.tag(58, WireType.LengthDelimited).fork().tag(1, WireType.Varint).uint32(parseInt(k)).tag(2, WireType.Varint).uint32(message.mapUint32Uint32[k as any]).join();
+        /* map<uint64, uint64> map_uint64_uint64 = 59; */
+        for (let k of globalThis.Object.keys(message.mapUint64Uint64))
+            writer.tag(59, WireType.LengthDelimited).fork().tag(1, WireType.Varint).uint64(k).tag(2, WireType.Varint).uint64(message.mapUint64Uint64[k]).join();
+        /* map<sint32, sint32> map_sint32_sint32 = 60; */
+        for (let k of globalThis.Object.keys(message.mapSint32Sint32))
+            writer.tag(60, WireType.LengthDelimited).fork().tag(1, WireType.Varint).sint32(parseInt(k)).tag(2, WireType.Varint).sint32(message.mapSint32Sint32[k as any]).join();
+        /* map<sint64, sint64> map_sint64_sint64 = 61; */
+        for (let k of globalThis.Object.keys(message.mapSint64Sint64))
+            writer.tag(61, WireType.LengthDelimited).fork().tag(1, WireType.Varint).sint64(k).tag(2, WireType.Varint).sint64(message.mapSint64Sint64[k]).join();
+        /* map<fixed32, fixed32> map_fixed32_fixed32 = 62; */
+        for (let k of globalThis.Object.keys(message.mapFixed32Fixed32))
+            writer.tag(62, WireType.LengthDelimited).fork().tag(1, WireType.Bit32).fixed32(parseInt(k)).tag(2, WireType.Bit32).fixed32(message.mapFixed32Fixed32[k as any]).join();
+        /* map<fixed64, fixed64> map_fixed64_fixed64 = 63; */
+        for (let k of globalThis.Object.keys(message.mapFixed64Fixed64))
+            writer.tag(63, WireType.LengthDelimited).fork().tag(1, WireType.Bit64).fixed64(k).tag(2, WireType.Bit64).fixed64(message.mapFixed64Fixed64[k]).join();
+        /* map<sfixed32, sfixed32> map_sfixed32_sfixed32 = 64; */
+        for (let k of globalThis.Object.keys(message.mapSfixed32Sfixed32))
+            writer.tag(64, WireType.LengthDelimited).fork().tag(1, WireType.Bit32).sfixed32(parseInt(k)).tag(2, WireType.Bit32).sfixed32(message.mapSfixed32Sfixed32[k as any]).join();
+        /* map<sfixed64, sfixed64> map_sfixed64_sfixed64 = 65; */
+        for (let k of globalThis.Object.keys(message.mapSfixed64Sfixed64))
+            writer.tag(65, WireType.LengthDelimited).fork().tag(1, WireType.Bit64).sfixed64(k).tag(2, WireType.Bit64).sfixed64(message.mapSfixed64Sfixed64[k]).join();
+        /* map<int32, float> map_int32_float = 66; */
+        for (let k of globalThis.Object.keys(message.mapInt32Float))
+            writer.tag(66, WireType.LengthDelimited).fork().tag(1, WireType.Varint).int32(parseInt(k)).tag(2, WireType.Bit32).float(message.mapInt32Float[k as any]).join();
+        /* map<int32, double> map_int32_double = 67; */
+        for (let k of globalThis.Object.keys(message.mapInt32Double))
+            writer.tag(67, WireType.LengthDelimited).fork().tag(1, WireType.Varint).int32(parseInt(k)).tag(2, WireType.Bit64).double(message.mapInt32Double[k as any]).join();
+        /* map<bool, bool> map_bool_bool = 68; */
+        for (let k of globalThis.Object.keys(message.mapBoolBool))
+            writer.tag(68, WireType.LengthDelimited).fork().tag(1, WireType.Varint).bool(k === "true").tag(2, WireType.Varint).bool(message.mapBoolBool[k]).join();
+        /* map<string, string> map_string_string = 69; */
+        for (let k of globalThis.Object.keys(message.mapStringString))
+            writer.tag(69, WireType.LengthDelimited).fork().tag(1, WireType.LengthDelimited).string(k).tag(2, WireType.LengthDelimited).string(message.mapStringString[k]).join();
+        /* map<string, bytes> map_string_bytes = 70; */
+        for (let k of globalThis.Object.keys(message.mapStringBytes))
+            writer.tag(70, WireType.LengthDelimited).fork().tag(1, WireType.LengthDelimited).string(k).tag(2, WireType.LengthDelimited).bytes(message.mapStringBytes[k]).join();
+        /* map<string, protobuf_test_messages.proto2.TestAllTypesProto2.NestedMessage> map_string_nested_message = 71; */
+        for (let k of globalThis.Object.keys(message.mapStringNestedMessage)) {
+            writer.tag(71, WireType.LengthDelimited).fork().tag(1, WireType.LengthDelimited).string(k);
+            writer.tag(2, WireType.LengthDelimited).fork();
+            TestAllTypesProto2_NestedMessage.internalBinaryWrite(message.mapStringNestedMessage[k], writer, options);
+            writer.join().join();
+        }
+        /* map<string, protobuf_test_messages.proto2.ForeignMessageProto2> map_string_foreign_message = 72; */
+        for (let k of globalThis.Object.keys(message.mapStringForeignMessage)) {
+            writer.tag(72, WireType.LengthDelimited).fork().tag(1, WireType.LengthDelimited).string(k);
+            writer.tag(2, WireType.LengthDelimited).fork();
+            ForeignMessageProto2.internalBinaryWrite(message.mapStringForeignMessage[k], writer, options);
+            writer.join().join();
+        }
+        /* map<string, protobuf_test_messages.proto2.TestAllTypesProto2.NestedEnum> map_string_nested_enum = 73; */
+        for (let k of globalThis.Object.keys(message.mapStringNestedEnum))
+            writer.tag(73, WireType.LengthDelimited).fork().tag(1, WireType.LengthDelimited).string(k).tag(2, WireType.Varint).int32(message.mapStringNestedEnum[k]).join();
+        /* map<string, protobuf_test_messages.proto2.ForeignEnumProto2> map_string_foreign_enum = 74; */
+        for (let k of globalThis.Object.keys(message.mapStringForeignEnum))
+            writer.tag(74, WireType.LengthDelimited).fork().tag(1, WireType.LengthDelimited).string(k).tag(2, WireType.Varint).int32(message.mapStringForeignEnum[k]).join();
         /* repeated int32 packed_int32 = 75 [packed = true]; */
         if (message.packedInt32.length) {
             writer.tag(75, WireType.LengthDelimited).fork();
@@ -2494,71 +2559,6 @@ class TestAllTypesProto2$Type extends MessageType<TestAllTypesProto2> {
         /* repeated protobuf_test_messages.proto2.TestAllTypesProto2.NestedEnum unpacked_nested_enum = 102 [packed = false]; */
         for (let i = 0; i < message.unpackedNestedEnum.length; i++)
             writer.tag(102, WireType.Varint).int32(message.unpackedNestedEnum[i]);
-        /* map<int32, int32> map_int32_int32 = 56; */
-        for (let k of globalThis.Object.keys(message.mapInt32Int32))
-            writer.tag(56, WireType.LengthDelimited).fork().tag(1, WireType.Varint).int32(parseInt(k)).tag(2, WireType.Varint).int32(message.mapInt32Int32[k as any]).join();
-        /* map<int64, int64> map_int64_int64 = 57; */
-        for (let k of globalThis.Object.keys(message.mapInt64Int64))
-            writer.tag(57, WireType.LengthDelimited).fork().tag(1, WireType.Varint).int64(k).tag(2, WireType.Varint).int64(message.mapInt64Int64[k]).join();
-        /* map<uint32, uint32> map_uint32_uint32 = 58; */
-        for (let k of globalThis.Object.keys(message.mapUint32Uint32))
-            writer.tag(58, WireType.LengthDelimited).fork().tag(1, WireType.Varint).uint32(parseInt(k)).tag(2, WireType.Varint).uint32(message.mapUint32Uint32[k as any]).join();
-        /* map<uint64, uint64> map_uint64_uint64 = 59; */
-        for (let k of globalThis.Object.keys(message.mapUint64Uint64))
-            writer.tag(59, WireType.LengthDelimited).fork().tag(1, WireType.Varint).uint64(k).tag(2, WireType.Varint).uint64(message.mapUint64Uint64[k]).join();
-        /* map<sint32, sint32> map_sint32_sint32 = 60; */
-        for (let k of globalThis.Object.keys(message.mapSint32Sint32))
-            writer.tag(60, WireType.LengthDelimited).fork().tag(1, WireType.Varint).sint32(parseInt(k)).tag(2, WireType.Varint).sint32(message.mapSint32Sint32[k as any]).join();
-        /* map<sint64, sint64> map_sint64_sint64 = 61; */
-        for (let k of globalThis.Object.keys(message.mapSint64Sint64))
-            writer.tag(61, WireType.LengthDelimited).fork().tag(1, WireType.Varint).sint64(k).tag(2, WireType.Varint).sint64(message.mapSint64Sint64[k]).join();
-        /* map<fixed32, fixed32> map_fixed32_fixed32 = 62; */
-        for (let k of globalThis.Object.keys(message.mapFixed32Fixed32))
-            writer.tag(62, WireType.LengthDelimited).fork().tag(1, WireType.Bit32).fixed32(parseInt(k)).tag(2, WireType.Bit32).fixed32(message.mapFixed32Fixed32[k as any]).join();
-        /* map<fixed64, fixed64> map_fixed64_fixed64 = 63; */
-        for (let k of globalThis.Object.keys(message.mapFixed64Fixed64))
-            writer.tag(63, WireType.LengthDelimited).fork().tag(1, WireType.Bit64).fixed64(k).tag(2, WireType.Bit64).fixed64(message.mapFixed64Fixed64[k]).join();
-        /* map<sfixed32, sfixed32> map_sfixed32_sfixed32 = 64; */
-        for (let k of globalThis.Object.keys(message.mapSfixed32Sfixed32))
-            writer.tag(64, WireType.LengthDelimited).fork().tag(1, WireType.Bit32).sfixed32(parseInt(k)).tag(2, WireType.Bit32).sfixed32(message.mapSfixed32Sfixed32[k as any]).join();
-        /* map<sfixed64, sfixed64> map_sfixed64_sfixed64 = 65; */
-        for (let k of globalThis.Object.keys(message.mapSfixed64Sfixed64))
-            writer.tag(65, WireType.LengthDelimited).fork().tag(1, WireType.Bit64).sfixed64(k).tag(2, WireType.Bit64).sfixed64(message.mapSfixed64Sfixed64[k]).join();
-        /* map<int32, float> map_int32_float = 66; */
-        for (let k of globalThis.Object.keys(message.mapInt32Float))
-            writer.tag(66, WireType.LengthDelimited).fork().tag(1, WireType.Varint).int32(parseInt(k)).tag(2, WireType.Bit32).float(message.mapInt32Float[k as any]).join();
-        /* map<int32, double> map_int32_double = 67; */
-        for (let k of globalThis.Object.keys(message.mapInt32Double))
-            writer.tag(67, WireType.LengthDelimited).fork().tag(1, WireType.Varint).int32(parseInt(k)).tag(2, WireType.Bit64).double(message.mapInt32Double[k as any]).join();
-        /* map<bool, bool> map_bool_bool = 68; */
-        for (let k of globalThis.Object.keys(message.mapBoolBool))
-            writer.tag(68, WireType.LengthDelimited).fork().tag(1, WireType.Varint).bool(k === "true").tag(2, WireType.Varint).bool(message.mapBoolBool[k]).join();
-        /* map<string, string> map_string_string = 69; */
-        for (let k of globalThis.Object.keys(message.mapStringString))
-            writer.tag(69, WireType.LengthDelimited).fork().tag(1, WireType.LengthDelimited).string(k).tag(2, WireType.LengthDelimited).string(message.mapStringString[k]).join();
-        /* map<string, bytes> map_string_bytes = 70; */
-        for (let k of globalThis.Object.keys(message.mapStringBytes))
-            writer.tag(70, WireType.LengthDelimited).fork().tag(1, WireType.LengthDelimited).string(k).tag(2, WireType.LengthDelimited).bytes(message.mapStringBytes[k]).join();
-        /* map<string, protobuf_test_messages.proto2.TestAllTypesProto2.NestedMessage> map_string_nested_message = 71; */
-        for (let k of globalThis.Object.keys(message.mapStringNestedMessage)) {
-            writer.tag(71, WireType.LengthDelimited).fork().tag(1, WireType.LengthDelimited).string(k);
-            writer.tag(2, WireType.LengthDelimited).fork();
-            TestAllTypesProto2_NestedMessage.internalBinaryWrite(message.mapStringNestedMessage[k], writer, options);
-            writer.join().join();
-        }
-        /* map<string, protobuf_test_messages.proto2.ForeignMessageProto2> map_string_foreign_message = 72; */
-        for (let k of globalThis.Object.keys(message.mapStringForeignMessage)) {
-            writer.tag(72, WireType.LengthDelimited).fork().tag(1, WireType.LengthDelimited).string(k);
-            writer.tag(2, WireType.LengthDelimited).fork();
-            ForeignMessageProto2.internalBinaryWrite(message.mapStringForeignMessage[k], writer, options);
-            writer.join().join();
-        }
-        /* map<string, protobuf_test_messages.proto2.TestAllTypesProto2.NestedEnum> map_string_nested_enum = 73; */
-        for (let k of globalThis.Object.keys(message.mapStringNestedEnum))
-            writer.tag(73, WireType.LengthDelimited).fork().tag(1, WireType.LengthDelimited).string(k).tag(2, WireType.Varint).int32(message.mapStringNestedEnum[k]).join();
-        /* map<string, protobuf_test_messages.proto2.ForeignEnumProto2> map_string_foreign_enum = 74; */
-        for (let k of globalThis.Object.keys(message.mapStringForeignEnum))
-            writer.tag(74, WireType.LengthDelimited).fork().tag(1, WireType.LengthDelimited).string(k).tag(2, WireType.Varint).int32(message.mapStringForeignEnum[k]).join();
         /* uint32 oneof_uint32 = 111; */
         if (message.oneofField.oneofKind === "oneofUint32")
             writer.tag(111, WireType.Varint).uint32(message.oneofField.oneofUint32);

--- a/packages/test-force_optimize_speed/gen/google/protobuf/test_messages_proto3.ts
+++ b/packages/test-force_optimize_speed/gen/google/protobuf/test_messages_proto3.ts
@@ -2307,6 +2307,71 @@ class TestAllTypesProto3$Type extends MessageType<TestAllTypesProto3> {
         /* repeated string repeated_cord = 55; */
         for (let i = 0; i < message.repeatedCord.length; i++)
             writer.tag(55, WireType.LengthDelimited).string(message.repeatedCord[i]);
+        /* map<int32, int32> map_int32_int32 = 56; */
+        for (let k of globalThis.Object.keys(message.mapInt32Int32))
+            writer.tag(56, WireType.LengthDelimited).fork().tag(1, WireType.Varint).int32(parseInt(k)).tag(2, WireType.Varint).int32(message.mapInt32Int32[k as any]).join();
+        /* map<int64, int64> map_int64_int64 = 57; */
+        for (let k of globalThis.Object.keys(message.mapInt64Int64))
+            writer.tag(57, WireType.LengthDelimited).fork().tag(1, WireType.Varint).int64(k).tag(2, WireType.Varint).int64(message.mapInt64Int64[k]).join();
+        /* map<uint32, uint32> map_uint32_uint32 = 58; */
+        for (let k of globalThis.Object.keys(message.mapUint32Uint32))
+            writer.tag(58, WireType.LengthDelimited).fork().tag(1, WireType.Varint).uint32(parseInt(k)).tag(2, WireType.Varint).uint32(message.mapUint32Uint32[k as any]).join();
+        /* map<uint64, uint64> map_uint64_uint64 = 59; */
+        for (let k of globalThis.Object.keys(message.mapUint64Uint64))
+            writer.tag(59, WireType.LengthDelimited).fork().tag(1, WireType.Varint).uint64(k).tag(2, WireType.Varint).uint64(message.mapUint64Uint64[k]).join();
+        /* map<sint32, sint32> map_sint32_sint32 = 60; */
+        for (let k of globalThis.Object.keys(message.mapSint32Sint32))
+            writer.tag(60, WireType.LengthDelimited).fork().tag(1, WireType.Varint).sint32(parseInt(k)).tag(2, WireType.Varint).sint32(message.mapSint32Sint32[k as any]).join();
+        /* map<sint64, sint64> map_sint64_sint64 = 61; */
+        for (let k of globalThis.Object.keys(message.mapSint64Sint64))
+            writer.tag(61, WireType.LengthDelimited).fork().tag(1, WireType.Varint).sint64(k).tag(2, WireType.Varint).sint64(message.mapSint64Sint64[k]).join();
+        /* map<fixed32, fixed32> map_fixed32_fixed32 = 62; */
+        for (let k of globalThis.Object.keys(message.mapFixed32Fixed32))
+            writer.tag(62, WireType.LengthDelimited).fork().tag(1, WireType.Bit32).fixed32(parseInt(k)).tag(2, WireType.Bit32).fixed32(message.mapFixed32Fixed32[k as any]).join();
+        /* map<fixed64, fixed64> map_fixed64_fixed64 = 63; */
+        for (let k of globalThis.Object.keys(message.mapFixed64Fixed64))
+            writer.tag(63, WireType.LengthDelimited).fork().tag(1, WireType.Bit64).fixed64(k).tag(2, WireType.Bit64).fixed64(message.mapFixed64Fixed64[k]).join();
+        /* map<sfixed32, sfixed32> map_sfixed32_sfixed32 = 64; */
+        for (let k of globalThis.Object.keys(message.mapSfixed32Sfixed32))
+            writer.tag(64, WireType.LengthDelimited).fork().tag(1, WireType.Bit32).sfixed32(parseInt(k)).tag(2, WireType.Bit32).sfixed32(message.mapSfixed32Sfixed32[k as any]).join();
+        /* map<sfixed64, sfixed64> map_sfixed64_sfixed64 = 65; */
+        for (let k of globalThis.Object.keys(message.mapSfixed64Sfixed64))
+            writer.tag(65, WireType.LengthDelimited).fork().tag(1, WireType.Bit64).sfixed64(k).tag(2, WireType.Bit64).sfixed64(message.mapSfixed64Sfixed64[k]).join();
+        /* map<int32, float> map_int32_float = 66; */
+        for (let k of globalThis.Object.keys(message.mapInt32Float))
+            writer.tag(66, WireType.LengthDelimited).fork().tag(1, WireType.Varint).int32(parseInt(k)).tag(2, WireType.Bit32).float(message.mapInt32Float[k as any]).join();
+        /* map<int32, double> map_int32_double = 67; */
+        for (let k of globalThis.Object.keys(message.mapInt32Double))
+            writer.tag(67, WireType.LengthDelimited).fork().tag(1, WireType.Varint).int32(parseInt(k)).tag(2, WireType.Bit64).double(message.mapInt32Double[k as any]).join();
+        /* map<bool, bool> map_bool_bool = 68; */
+        for (let k of globalThis.Object.keys(message.mapBoolBool))
+            writer.tag(68, WireType.LengthDelimited).fork().tag(1, WireType.Varint).bool(k === "true").tag(2, WireType.Varint).bool(message.mapBoolBool[k]).join();
+        /* map<string, string> map_string_string = 69; */
+        for (let k of globalThis.Object.keys(message.mapStringString))
+            writer.tag(69, WireType.LengthDelimited).fork().tag(1, WireType.LengthDelimited).string(k).tag(2, WireType.LengthDelimited).string(message.mapStringString[k]).join();
+        /* map<string, bytes> map_string_bytes = 70; */
+        for (let k of globalThis.Object.keys(message.mapStringBytes))
+            writer.tag(70, WireType.LengthDelimited).fork().tag(1, WireType.LengthDelimited).string(k).tag(2, WireType.LengthDelimited).bytes(message.mapStringBytes[k]).join();
+        /* map<string, protobuf_test_messages.proto3.TestAllTypesProto3.NestedMessage> map_string_nested_message = 71; */
+        for (let k of globalThis.Object.keys(message.mapStringNestedMessage)) {
+            writer.tag(71, WireType.LengthDelimited).fork().tag(1, WireType.LengthDelimited).string(k);
+            writer.tag(2, WireType.LengthDelimited).fork();
+            TestAllTypesProto3_NestedMessage.internalBinaryWrite(message.mapStringNestedMessage[k], writer, options);
+            writer.join().join();
+        }
+        /* map<string, protobuf_test_messages.proto3.ForeignMessage> map_string_foreign_message = 72; */
+        for (let k of globalThis.Object.keys(message.mapStringForeignMessage)) {
+            writer.tag(72, WireType.LengthDelimited).fork().tag(1, WireType.LengthDelimited).string(k);
+            writer.tag(2, WireType.LengthDelimited).fork();
+            ForeignMessage.internalBinaryWrite(message.mapStringForeignMessage[k], writer, options);
+            writer.join().join();
+        }
+        /* map<string, protobuf_test_messages.proto3.TestAllTypesProto3.NestedEnum> map_string_nested_enum = 73; */
+        for (let k of globalThis.Object.keys(message.mapStringNestedEnum))
+            writer.tag(73, WireType.LengthDelimited).fork().tag(1, WireType.LengthDelimited).string(k).tag(2, WireType.Varint).int32(message.mapStringNestedEnum[k]).join();
+        /* map<string, protobuf_test_messages.proto3.ForeignEnum> map_string_foreign_enum = 74; */
+        for (let k of globalThis.Object.keys(message.mapStringForeignEnum))
+            writer.tag(74, WireType.LengthDelimited).fork().tag(1, WireType.LengthDelimited).string(k).tag(2, WireType.Varint).int32(message.mapStringForeignEnum[k]).join();
         /* repeated int32 packed_int32 = 75 [packed = true]; */
         if (message.packedInt32.length) {
             writer.tag(75, WireType.LengthDelimited).fork();
@@ -2447,71 +2512,6 @@ class TestAllTypesProto3$Type extends MessageType<TestAllTypesProto3> {
         /* repeated protobuf_test_messages.proto3.TestAllTypesProto3.NestedEnum unpacked_nested_enum = 102 [packed = false]; */
         for (let i = 0; i < message.unpackedNestedEnum.length; i++)
             writer.tag(102, WireType.Varint).int32(message.unpackedNestedEnum[i]);
-        /* map<int32, int32> map_int32_int32 = 56; */
-        for (let k of globalThis.Object.keys(message.mapInt32Int32))
-            writer.tag(56, WireType.LengthDelimited).fork().tag(1, WireType.Varint).int32(parseInt(k)).tag(2, WireType.Varint).int32(message.mapInt32Int32[k as any]).join();
-        /* map<int64, int64> map_int64_int64 = 57; */
-        for (let k of globalThis.Object.keys(message.mapInt64Int64))
-            writer.tag(57, WireType.LengthDelimited).fork().tag(1, WireType.Varint).int64(k).tag(2, WireType.Varint).int64(message.mapInt64Int64[k]).join();
-        /* map<uint32, uint32> map_uint32_uint32 = 58; */
-        for (let k of globalThis.Object.keys(message.mapUint32Uint32))
-            writer.tag(58, WireType.LengthDelimited).fork().tag(1, WireType.Varint).uint32(parseInt(k)).tag(2, WireType.Varint).uint32(message.mapUint32Uint32[k as any]).join();
-        /* map<uint64, uint64> map_uint64_uint64 = 59; */
-        for (let k of globalThis.Object.keys(message.mapUint64Uint64))
-            writer.tag(59, WireType.LengthDelimited).fork().tag(1, WireType.Varint).uint64(k).tag(2, WireType.Varint).uint64(message.mapUint64Uint64[k]).join();
-        /* map<sint32, sint32> map_sint32_sint32 = 60; */
-        for (let k of globalThis.Object.keys(message.mapSint32Sint32))
-            writer.tag(60, WireType.LengthDelimited).fork().tag(1, WireType.Varint).sint32(parseInt(k)).tag(2, WireType.Varint).sint32(message.mapSint32Sint32[k as any]).join();
-        /* map<sint64, sint64> map_sint64_sint64 = 61; */
-        for (let k of globalThis.Object.keys(message.mapSint64Sint64))
-            writer.tag(61, WireType.LengthDelimited).fork().tag(1, WireType.Varint).sint64(k).tag(2, WireType.Varint).sint64(message.mapSint64Sint64[k]).join();
-        /* map<fixed32, fixed32> map_fixed32_fixed32 = 62; */
-        for (let k of globalThis.Object.keys(message.mapFixed32Fixed32))
-            writer.tag(62, WireType.LengthDelimited).fork().tag(1, WireType.Bit32).fixed32(parseInt(k)).tag(2, WireType.Bit32).fixed32(message.mapFixed32Fixed32[k as any]).join();
-        /* map<fixed64, fixed64> map_fixed64_fixed64 = 63; */
-        for (let k of globalThis.Object.keys(message.mapFixed64Fixed64))
-            writer.tag(63, WireType.LengthDelimited).fork().tag(1, WireType.Bit64).fixed64(k).tag(2, WireType.Bit64).fixed64(message.mapFixed64Fixed64[k]).join();
-        /* map<sfixed32, sfixed32> map_sfixed32_sfixed32 = 64; */
-        for (let k of globalThis.Object.keys(message.mapSfixed32Sfixed32))
-            writer.tag(64, WireType.LengthDelimited).fork().tag(1, WireType.Bit32).sfixed32(parseInt(k)).tag(2, WireType.Bit32).sfixed32(message.mapSfixed32Sfixed32[k as any]).join();
-        /* map<sfixed64, sfixed64> map_sfixed64_sfixed64 = 65; */
-        for (let k of globalThis.Object.keys(message.mapSfixed64Sfixed64))
-            writer.tag(65, WireType.LengthDelimited).fork().tag(1, WireType.Bit64).sfixed64(k).tag(2, WireType.Bit64).sfixed64(message.mapSfixed64Sfixed64[k]).join();
-        /* map<int32, float> map_int32_float = 66; */
-        for (let k of globalThis.Object.keys(message.mapInt32Float))
-            writer.tag(66, WireType.LengthDelimited).fork().tag(1, WireType.Varint).int32(parseInt(k)).tag(2, WireType.Bit32).float(message.mapInt32Float[k as any]).join();
-        /* map<int32, double> map_int32_double = 67; */
-        for (let k of globalThis.Object.keys(message.mapInt32Double))
-            writer.tag(67, WireType.LengthDelimited).fork().tag(1, WireType.Varint).int32(parseInt(k)).tag(2, WireType.Bit64).double(message.mapInt32Double[k as any]).join();
-        /* map<bool, bool> map_bool_bool = 68; */
-        for (let k of globalThis.Object.keys(message.mapBoolBool))
-            writer.tag(68, WireType.LengthDelimited).fork().tag(1, WireType.Varint).bool(k === "true").tag(2, WireType.Varint).bool(message.mapBoolBool[k]).join();
-        /* map<string, string> map_string_string = 69; */
-        for (let k of globalThis.Object.keys(message.mapStringString))
-            writer.tag(69, WireType.LengthDelimited).fork().tag(1, WireType.LengthDelimited).string(k).tag(2, WireType.LengthDelimited).string(message.mapStringString[k]).join();
-        /* map<string, bytes> map_string_bytes = 70; */
-        for (let k of globalThis.Object.keys(message.mapStringBytes))
-            writer.tag(70, WireType.LengthDelimited).fork().tag(1, WireType.LengthDelimited).string(k).tag(2, WireType.LengthDelimited).bytes(message.mapStringBytes[k]).join();
-        /* map<string, protobuf_test_messages.proto3.TestAllTypesProto3.NestedMessage> map_string_nested_message = 71; */
-        for (let k of globalThis.Object.keys(message.mapStringNestedMessage)) {
-            writer.tag(71, WireType.LengthDelimited).fork().tag(1, WireType.LengthDelimited).string(k);
-            writer.tag(2, WireType.LengthDelimited).fork();
-            TestAllTypesProto3_NestedMessage.internalBinaryWrite(message.mapStringNestedMessage[k], writer, options);
-            writer.join().join();
-        }
-        /* map<string, protobuf_test_messages.proto3.ForeignMessage> map_string_foreign_message = 72; */
-        for (let k of globalThis.Object.keys(message.mapStringForeignMessage)) {
-            writer.tag(72, WireType.LengthDelimited).fork().tag(1, WireType.LengthDelimited).string(k);
-            writer.tag(2, WireType.LengthDelimited).fork();
-            ForeignMessage.internalBinaryWrite(message.mapStringForeignMessage[k], writer, options);
-            writer.join().join();
-        }
-        /* map<string, protobuf_test_messages.proto3.TestAllTypesProto3.NestedEnum> map_string_nested_enum = 73; */
-        for (let k of globalThis.Object.keys(message.mapStringNestedEnum))
-            writer.tag(73, WireType.LengthDelimited).fork().tag(1, WireType.LengthDelimited).string(k).tag(2, WireType.Varint).int32(message.mapStringNestedEnum[k]).join();
-        /* map<string, protobuf_test_messages.proto3.ForeignEnum> map_string_foreign_enum = 74; */
-        for (let k of globalThis.Object.keys(message.mapStringForeignEnum))
-            writer.tag(74, WireType.LengthDelimited).fork().tag(1, WireType.LengthDelimited).string(k).tag(2, WireType.Varint).int32(message.mapStringForeignEnum[k]).join();
         /* uint32 oneof_uint32 = 111; */
         if (message.oneofField.oneofKind === "oneofUint32")
             writer.tag(111, WireType.Varint).uint32(message.oneofField.oneofUint32);
@@ -2626,9 +2626,6 @@ class TestAllTypesProto3$Type extends MessageType<TestAllTypesProto3> {
         /* repeated google.protobuf.FieldMask repeated_fieldmask = 313; */
         for (let i = 0; i < message.repeatedFieldmask.length; i++)
             FieldMask.internalBinaryWrite(message.repeatedFieldmask[i], writer.tag(313, WireType.LengthDelimited).fork(), options).join();
-        /* repeated google.protobuf.Struct repeated_struct = 324; */
-        for (let i = 0; i < message.repeatedStruct.length; i++)
-            Struct.internalBinaryWrite(message.repeatedStruct[i], writer.tag(324, WireType.LengthDelimited).fork(), options).join();
         /* repeated google.protobuf.Any repeated_any = 315; */
         for (let i = 0; i < message.repeatedAny.length; i++)
             Any.internalBinaryWrite(message.repeatedAny[i], writer.tag(315, WireType.LengthDelimited).fork(), options).join();
@@ -2638,6 +2635,9 @@ class TestAllTypesProto3$Type extends MessageType<TestAllTypesProto3> {
         /* repeated google.protobuf.ListValue repeated_list_value = 317; */
         for (let i = 0; i < message.repeatedListValue.length; i++)
             ListValue.internalBinaryWrite(message.repeatedListValue[i], writer.tag(317, WireType.LengthDelimited).fork(), options).join();
+        /* repeated google.protobuf.Struct repeated_struct = 324; */
+        for (let i = 0; i < message.repeatedStruct.length; i++)
+            Struct.internalBinaryWrite(message.repeatedStruct[i], writer.tag(324, WireType.LengthDelimited).fork(), options).join();
         /* int32 fieldname1 = 401; */
         if (message.fieldname1 !== 0)
             writer.tag(401, WireType.Varint).int32(message.fieldname1);

--- a/packages/test-force_optimize_speed/gen/google/protobuf/unittest_mset.ts
+++ b/packages/test-force_optimize_speed/gen/google/protobuf/unittest_mset.ts
@@ -290,12 +290,12 @@ class NestedTestInt$Type extends MessageType<NestedTestInt> {
         /* optional fixed32 a = 1; */
         if (message.a !== undefined)
             writer.tag(1, WireType.Bit32).fixed32(message.a);
-        /* optional int32 b = 3; */
-        if (message.b !== undefined)
-            writer.tag(3, WireType.Varint).int32(message.b);
         /* optional protobuf_unittest.NestedTestInt child = 2; */
         if (message.child)
             NestedTestInt.internalBinaryWrite(message.child, writer.tag(2, WireType.LengthDelimited).fork(), options).join();
+        /* optional int32 b = 3; */
+        if (message.b !== undefined)
+            writer.tag(3, WireType.Varint).int32(message.b);
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);

--- a/packages/test-force_optimize_speed/gen/google/protobuf/unittest_proto3.ts
+++ b/packages/test-force_optimize_speed/gen/google/protobuf/unittest_proto3.ts
@@ -1282,9 +1282,6 @@ class TestAllTypes$Type extends MessageType<TestAllTypes> {
         /* proto3_unittest.TestAllTypes.NestedMessage optional_unverified_lazy_message = 28; */
         if (message.optionalUnverifiedLazyMessage)
             TestAllTypes_NestedMessage.internalBinaryWrite(message.optionalUnverifiedLazyMessage, writer.tag(28, WireType.LengthDelimited).fork(), options).join();
-        /* protobuf_unittest_import.ImportMessage optional_lazy_import_message = 115; */
-        if (message.optionalLazyImportMessage)
-            ImportMessage.internalBinaryWrite(message.optionalLazyImportMessage, writer.tag(115, WireType.LengthDelimited).fork(), options).join();
         /* repeated int32 repeated_int32 = 31; */
         if (message.repeatedInt32.length) {
             writer.tag(31, WireType.LengthDelimited).fork();
@@ -1426,6 +1423,9 @@ class TestAllTypes$Type extends MessageType<TestAllTypes> {
         /* bytes oneof_bytes = 114; */
         if (message.oneofField.oneofKind === "oneofBytes")
             writer.tag(114, WireType.LengthDelimited).bytes(message.oneofField.oneofBytes);
+        /* protobuf_unittest_import.ImportMessage optional_lazy_import_message = 115; */
+        if (message.optionalLazyImportMessage)
+            ImportMessage.internalBinaryWrite(message.optionalLazyImportMessage, writer.tag(115, WireType.LengthDelimited).fork(), options).join();
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);

--- a/packages/test-force_optimize_speed/gen/google/protobuf/unittest_proto3_arena.ts
+++ b/packages/test-force_optimize_speed/gen/google/protobuf/unittest_proto3_arena.ts
@@ -973,9 +973,6 @@ class TestAllTypes$Type extends MessageType<TestAllTypes> {
         /* proto3_arena_unittest.TestAllTypes.NestedMessage optional_lazy_message = 27; */
         if (message.optionalLazyMessage)
             TestAllTypes_NestedMessage.internalBinaryWrite(message.optionalLazyMessage, writer.tag(27, WireType.LengthDelimited).fork(), options).join();
-        /* protobuf_unittest_import.ImportMessage optional_lazy_import_message = 115; */
-        if (message.optionalLazyImportMessage)
-            ImportMessage.internalBinaryWrite(message.optionalLazyImportMessage, writer.tag(115, WireType.LengthDelimited).fork(), options).join();
         /* repeated int32 repeated_int32 = 31; */
         if (message.repeatedInt32.length) {
             writer.tag(31, WireType.LengthDelimited).fork();
@@ -1117,6 +1114,9 @@ class TestAllTypes$Type extends MessageType<TestAllTypes> {
         /* bytes oneof_bytes = 114; */
         if (message.oneofField.oneofKind === "oneofBytes")
             writer.tag(114, WireType.LengthDelimited).bytes(message.oneofField.oneofBytes);
+        /* protobuf_unittest_import.ImportMessage optional_lazy_import_message = 115; */
+        if (message.optionalLazyImportMessage)
+            ImportMessage.internalBinaryWrite(message.optionalLazyImportMessage, writer.tag(115, WireType.LengthDelimited).fork(), options).join();
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);

--- a/packages/test-force_optimize_speed/gen/google/rpc/context/attribute_context.ts
+++ b/packages/test-force_optimize_speed/gen/google/rpc/context/attribute_context.ts
@@ -504,9 +504,6 @@ class AttributeContext$Type extends MessageType<AttributeContext> {
         return message;
     }
     internalBinaryWrite(message: AttributeContext, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
-        /* google.rpc.context.AttributeContext.Peer origin = 7; */
-        if (message.origin)
-            AttributeContext_Peer.internalBinaryWrite(message.origin, writer.tag(7, WireType.LengthDelimited).fork(), options).join();
         /* google.rpc.context.AttributeContext.Peer source = 1; */
         if (message.source)
             AttributeContext_Peer.internalBinaryWrite(message.source, writer.tag(1, WireType.LengthDelimited).fork(), options).join();
@@ -525,6 +522,9 @@ class AttributeContext$Type extends MessageType<AttributeContext> {
         /* google.rpc.context.AttributeContext.Api api = 6; */
         if (message.api)
             AttributeContext_Api.internalBinaryWrite(message.api, writer.tag(6, WireType.LengthDelimited).fork(), options).join();
+        /* google.rpc.context.AttributeContext.Peer origin = 7; */
+        if (message.origin)
+            AttributeContext_Peer.internalBinaryWrite(message.origin, writer.tag(7, WireType.LengthDelimited).fork(), options).join();
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);

--- a/packages/test-force_optimize_speed/spec/generated-binary-read-compat.spec.ts
+++ b/packages/test-force_optimize_speed/spec/generated-binary-read-compat.spec.ts
@@ -1,4 +1,4 @@
-import {IMessageType, MessageType} from "@protobuf-ts/runtime";
+import {IMessageType, MessageType, base64encode} from "@protobuf-ts/runtime";
 import {EnumFieldMessage} from "../gen/msg-enum";
 import {JsonNamesMessage} from "../gen/msg-json-names";
 import {MessageFieldMessage} from "../gen/msg-message";
@@ -6,6 +6,7 @@ import {OneofMessageMemberMessage, OneofScalarMemberMessage} from "../gen/msg-on
 import {Proto2OptionalsMessage} from "../gen/msg-proto2-optionals";
 import {Proto3OptionalsMessage} from "../gen/msg-proto3-optionals";
 import {RepeatedScalarValuesMessage, ScalarValuesMessage} from "../gen/msg-scalar";
+import {TestAllTypesProto3} from "../gen/google/protobuf/test_messages_proto3";
 
 // Copied from test-default/generated-binary-read-compat.spec.ts. Do not edit.
 let generatedRegistry: IMessageType<any>[] = [
@@ -39,6 +40,20 @@ describe('generated code compatibility', () => {
             });
         }
     });
+
+    it('should have same serialization order regardless of optimization options', function () {
+        const reflectionType = new MessageType<TestAllTypesProto3>(TestAllTypesProto3.typeName, [...TestAllTypesProto3.fields].reverse());
+        const message = TestAllTypesProto3.fromJson({
+            optionalInt32: 123,
+            optionalInt64: "1",
+            optionalString: "1",
+            optionalNestedMessage: {
+                a: 2,
+            }
+        });
+        expect(base64encode(TestAllTypesProto3.toBinary(message)))
+            .toBe(base64encode(reflectionType.toBinary(message)));
+    })
 
 });
 

--- a/packages/test-long_type_string/gen/conformance/conformance.ts
+++ b/packages/test-long_type_string/gen/conformance/conformance.ts
@@ -539,12 +539,6 @@ class ConformanceRequest$Type extends MessageType<ConformanceRequest> {
         /* string json_payload = 2; */
         if (message.payload.oneofKind === "jsonPayload")
             writer.tag(2, WireType.LengthDelimited).string(message.payload.jsonPayload);
-        /* string jspb_payload = 7; */
-        if (message.payload.oneofKind === "jspbPayload")
-            writer.tag(7, WireType.LengthDelimited).string(message.payload.jspbPayload);
-        /* string text_payload = 8; */
-        if (message.payload.oneofKind === "textPayload")
-            writer.tag(8, WireType.LengthDelimited).string(message.payload.textPayload);
         /* conformance.WireFormat requested_output_format = 3; */
         if (message.requestedOutputFormat !== 0)
             writer.tag(3, WireType.Varint).int32(message.requestedOutputFormat);
@@ -557,6 +551,12 @@ class ConformanceRequest$Type extends MessageType<ConformanceRequest> {
         /* conformance.JspbEncodingConfig jspb_encoding_options = 6; */
         if (message.jspbEncodingOptions)
             JspbEncodingConfig.internalBinaryWrite(message.jspbEncodingOptions, writer.tag(6, WireType.LengthDelimited).fork(), options).join();
+        /* string jspb_payload = 7; */
+        if (message.payload.oneofKind === "jspbPayload")
+            writer.tag(7, WireType.LengthDelimited).string(message.payload.jspbPayload);
+        /* string text_payload = 8; */
+        if (message.payload.oneofKind === "textPayload")
+            writer.tag(8, WireType.LengthDelimited).string(message.payload.textPayload);
         /* bool print_unknown_fields = 9; */
         if (message.printUnknownFields !== false)
             writer.tag(9, WireType.Varint).bool(message.printUnknownFields);
@@ -666,12 +666,6 @@ class ConformanceResponse$Type extends MessageType<ConformanceResponse> {
         /* string parse_error = 1; */
         if (message.result.oneofKind === "parseError")
             writer.tag(1, WireType.LengthDelimited).string(message.result.parseError);
-        /* string serialize_error = 6; */
-        if (message.result.oneofKind === "serializeError")
-            writer.tag(6, WireType.LengthDelimited).string(message.result.serializeError);
-        /* string timeout_error = 9; */
-        if (message.result.oneofKind === "timeoutError")
-            writer.tag(9, WireType.LengthDelimited).string(message.result.timeoutError);
         /* string runtime_error = 2; */
         if (message.result.oneofKind === "runtimeError")
             writer.tag(2, WireType.LengthDelimited).string(message.result.runtimeError);
@@ -684,12 +678,18 @@ class ConformanceResponse$Type extends MessageType<ConformanceResponse> {
         /* string skipped = 5; */
         if (message.result.oneofKind === "skipped")
             writer.tag(5, WireType.LengthDelimited).string(message.result.skipped);
+        /* string serialize_error = 6; */
+        if (message.result.oneofKind === "serializeError")
+            writer.tag(6, WireType.LengthDelimited).string(message.result.serializeError);
         /* string jspb_payload = 7; */
         if (message.result.oneofKind === "jspbPayload")
             writer.tag(7, WireType.LengthDelimited).string(message.result.jspbPayload);
         /* string text_payload = 8; */
         if (message.result.oneofKind === "textPayload")
             writer.tag(8, WireType.LengthDelimited).string(message.result.textPayload);
+        /* string timeout_error = 9; */
+        if (message.result.oneofKind === "timeoutError")
+            writer.tag(9, WireType.LengthDelimited).string(message.result.timeoutError);
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);

--- a/packages/test-long_type_string/gen/google/api/http.ts
+++ b/packages/test-long_type_string/gen/google/api/http.ts
@@ -608,18 +608,18 @@ class HttpRule$Type extends MessageType<HttpRule> {
         /* string patch = 6; */
         if (message.pattern.oneofKind === "patch")
             writer.tag(6, WireType.LengthDelimited).string(message.pattern.patch);
-        /* google.api.CustomHttpPattern custom = 8; */
-        if (message.pattern.oneofKind === "custom")
-            CustomHttpPattern.internalBinaryWrite(message.pattern.custom, writer.tag(8, WireType.LengthDelimited).fork(), options).join();
         /* string body = 7; */
         if (message.body !== "")
             writer.tag(7, WireType.LengthDelimited).string(message.body);
-        /* string response_body = 12; */
-        if (message.responseBody !== "")
-            writer.tag(12, WireType.LengthDelimited).string(message.responseBody);
+        /* google.api.CustomHttpPattern custom = 8; */
+        if (message.pattern.oneofKind === "custom")
+            CustomHttpPattern.internalBinaryWrite(message.pattern.custom, writer.tag(8, WireType.LengthDelimited).fork(), options).join();
         /* repeated google.api.HttpRule additional_bindings = 11; */
         for (let i = 0; i < message.additionalBindings.length; i++)
             HttpRule.internalBinaryWrite(message.additionalBindings[i], writer.tag(11, WireType.LengthDelimited).fork(), options).join();
+        /* string response_body = 12; */
+        if (message.responseBody !== "")
+            writer.tag(12, WireType.LengthDelimited).string(message.responseBody);
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);

--- a/packages/test-long_type_string/gen/google/protobuf/compiler/plugin.ts
+++ b/packages/test-long_type_string/gen/google/protobuf/compiler/plugin.ts
@@ -391,15 +391,15 @@ class CodeGeneratorRequest$Type extends MessageType<CodeGeneratorRequest> {
         /* optional string parameter = 2; */
         if (message.parameter !== undefined)
             writer.tag(2, WireType.LengthDelimited).string(message.parameter);
+        /* optional google.protobuf.compiler.Version compiler_version = 3; */
+        if (message.compilerVersion)
+            Version.internalBinaryWrite(message.compilerVersion, writer.tag(3, WireType.LengthDelimited).fork(), options).join();
         /* repeated google.protobuf.FileDescriptorProto proto_file = 15; */
         for (let i = 0; i < message.protoFile.length; i++)
             FileDescriptorProto.internalBinaryWrite(message.protoFile[i], writer.tag(15, WireType.LengthDelimited).fork(), options).join();
         /* repeated google.protobuf.FileDescriptorProto source_file_descriptors = 17; */
         for (let i = 0; i < message.sourceFileDescriptors.length; i++)
             FileDescriptorProto.internalBinaryWrite(message.sourceFileDescriptors[i], writer.tag(17, WireType.LengthDelimited).fork(), options).join();
-        /* optional google.protobuf.compiler.Version compiler_version = 3; */
-        if (message.compilerVersion)
-            Version.internalBinaryWrite(message.compilerVersion, writer.tag(3, WireType.LengthDelimited).fork(), options).join();
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);

--- a/packages/test-long_type_string/gen/google/protobuf/descriptor.ts
+++ b/packages/test-long_type_string/gen/google/protobuf/descriptor.ts
@@ -2249,12 +2249,6 @@ class FileDescriptorProto$Type extends MessageType<FileDescriptorProto> {
         /* repeated string dependency = 3; */
         for (let i = 0; i < message.dependency.length; i++)
             writer.tag(3, WireType.LengthDelimited).string(message.dependency[i]);
-        /* repeated int32 public_dependency = 10; */
-        for (let i = 0; i < message.publicDependency.length; i++)
-            writer.tag(10, WireType.Varint).int32(message.publicDependency[i]);
-        /* repeated int32 weak_dependency = 11; */
-        for (let i = 0; i < message.weakDependency.length; i++)
-            writer.tag(11, WireType.Varint).int32(message.weakDependency[i]);
         /* repeated google.protobuf.DescriptorProto message_type = 4; */
         for (let i = 0; i < message.messageType.length; i++)
             DescriptorProto.internalBinaryWrite(message.messageType[i], writer.tag(4, WireType.LengthDelimited).fork(), options).join();
@@ -2273,6 +2267,12 @@ class FileDescriptorProto$Type extends MessageType<FileDescriptorProto> {
         /* optional google.protobuf.SourceCodeInfo source_code_info = 9; */
         if (message.sourceCodeInfo)
             SourceCodeInfo.internalBinaryWrite(message.sourceCodeInfo, writer.tag(9, WireType.LengthDelimited).fork(), options).join();
+        /* repeated int32 public_dependency = 10; */
+        for (let i = 0; i < message.publicDependency.length; i++)
+            writer.tag(10, WireType.Varint).int32(message.publicDependency[i]);
+        /* repeated int32 weak_dependency = 11; */
+        for (let i = 0; i < message.weakDependency.length; i++)
+            writer.tag(11, WireType.Varint).int32(message.weakDependency[i]);
         /* optional string syntax = 12; */
         if (message.syntax !== undefined)
             writer.tag(12, WireType.LengthDelimited).string(message.syntax);
@@ -2372,9 +2372,6 @@ class DescriptorProto$Type extends MessageType<DescriptorProto> {
         /* repeated google.protobuf.FieldDescriptorProto field = 2; */
         for (let i = 0; i < message.field.length; i++)
             FieldDescriptorProto.internalBinaryWrite(message.field[i], writer.tag(2, WireType.LengthDelimited).fork(), options).join();
-        /* repeated google.protobuf.FieldDescriptorProto extension = 6; */
-        for (let i = 0; i < message.extension.length; i++)
-            FieldDescriptorProto.internalBinaryWrite(message.extension[i], writer.tag(6, WireType.LengthDelimited).fork(), options).join();
         /* repeated google.protobuf.DescriptorProto nested_type = 3; */
         for (let i = 0; i < message.nestedType.length; i++)
             DescriptorProto.internalBinaryWrite(message.nestedType[i], writer.tag(3, WireType.LengthDelimited).fork(), options).join();
@@ -2384,12 +2381,15 @@ class DescriptorProto$Type extends MessageType<DescriptorProto> {
         /* repeated google.protobuf.DescriptorProto.ExtensionRange extension_range = 5; */
         for (let i = 0; i < message.extensionRange.length; i++)
             DescriptorProto_ExtensionRange.internalBinaryWrite(message.extensionRange[i], writer.tag(5, WireType.LengthDelimited).fork(), options).join();
-        /* repeated google.protobuf.OneofDescriptorProto oneof_decl = 8; */
-        for (let i = 0; i < message.oneofDecl.length; i++)
-            OneofDescriptorProto.internalBinaryWrite(message.oneofDecl[i], writer.tag(8, WireType.LengthDelimited).fork(), options).join();
+        /* repeated google.protobuf.FieldDescriptorProto extension = 6; */
+        for (let i = 0; i < message.extension.length; i++)
+            FieldDescriptorProto.internalBinaryWrite(message.extension[i], writer.tag(6, WireType.LengthDelimited).fork(), options).join();
         /* optional google.protobuf.MessageOptions options = 7; */
         if (message.options)
             MessageOptions.internalBinaryWrite(message.options, writer.tag(7, WireType.LengthDelimited).fork(), options).join();
+        /* repeated google.protobuf.OneofDescriptorProto oneof_decl = 8; */
+        for (let i = 0; i < message.oneofDecl.length; i++)
+            OneofDescriptorProto.internalBinaryWrite(message.oneofDecl[i], writer.tag(8, WireType.LengthDelimited).fork(), options).join();
         /* repeated google.protobuf.DescriptorProto.ReservedRange reserved_range = 9; */
         for (let i = 0; i < message.reservedRange.length; i++)
             DescriptorProto_ReservedRange.internalBinaryWrite(message.reservedRange[i], writer.tag(9, WireType.LengthDelimited).fork(), options).join();
@@ -2566,18 +2566,18 @@ class ExtensionRangeOptions$Type extends MessageType<ExtensionRangeOptions> {
         return message;
     }
     internalBinaryWrite(message: ExtensionRangeOptions, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
-        /* repeated google.protobuf.UninterpretedOption uninterpreted_option = 999; */
-        for (let i = 0; i < message.uninterpretedOption.length; i++)
-            UninterpretedOption.internalBinaryWrite(message.uninterpretedOption[i], writer.tag(999, WireType.LengthDelimited).fork(), options).join();
         /* repeated google.protobuf.ExtensionRangeOptions.Declaration declaration = 2; */
         for (let i = 0; i < message.declaration.length; i++)
             ExtensionRangeOptions_Declaration.internalBinaryWrite(message.declaration[i], writer.tag(2, WireType.LengthDelimited).fork(), options).join();
-        /* optional google.protobuf.FeatureSet features = 50; */
-        if (message.features)
-            FeatureSet.internalBinaryWrite(message.features, writer.tag(50, WireType.LengthDelimited).fork(), options).join();
         /* optional google.protobuf.ExtensionRangeOptions.VerificationState verification = 3; */
         if (message.verification !== undefined)
             writer.tag(3, WireType.Varint).int32(message.verification);
+        /* optional google.protobuf.FeatureSet features = 50; */
+        if (message.features)
+            FeatureSet.internalBinaryWrite(message.features, writer.tag(50, WireType.LengthDelimited).fork(), options).join();
+        /* repeated google.protobuf.UninterpretedOption uninterpreted_option = 999; */
+        for (let i = 0; i < message.uninterpretedOption.length; i++)
+            UninterpretedOption.internalBinaryWrite(message.uninterpretedOption[i], writer.tag(999, WireType.LengthDelimited).fork(), options).join();
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
@@ -2738,6 +2738,9 @@ class FieldDescriptorProto$Type extends MessageType<FieldDescriptorProto> {
         /* optional string name = 1; */
         if (message.name !== undefined)
             writer.tag(1, WireType.LengthDelimited).string(message.name);
+        /* optional string extendee = 2; */
+        if (message.extendee !== undefined)
+            writer.tag(2, WireType.LengthDelimited).string(message.extendee);
         /* optional int32 number = 3; */
         if (message.number !== undefined)
             writer.tag(3, WireType.Varint).int32(message.number);
@@ -2750,21 +2753,18 @@ class FieldDescriptorProto$Type extends MessageType<FieldDescriptorProto> {
         /* optional string type_name = 6; */
         if (message.typeName !== undefined)
             writer.tag(6, WireType.LengthDelimited).string(message.typeName);
-        /* optional string extendee = 2; */
-        if (message.extendee !== undefined)
-            writer.tag(2, WireType.LengthDelimited).string(message.extendee);
         /* optional string default_value = 7; */
         if (message.defaultValue !== undefined)
             writer.tag(7, WireType.LengthDelimited).string(message.defaultValue);
+        /* optional google.protobuf.FieldOptions options = 8; */
+        if (message.options)
+            FieldOptions.internalBinaryWrite(message.options, writer.tag(8, WireType.LengthDelimited).fork(), options).join();
         /* optional int32 oneof_index = 9; */
         if (message.oneofIndex !== undefined)
             writer.tag(9, WireType.Varint).int32(message.oneofIndex);
         /* optional string json_name = 10; */
         if (message.jsonName !== undefined)
             writer.tag(10, WireType.LengthDelimited).string(message.jsonName);
-        /* optional google.protobuf.FieldOptions options = 8; */
-        if (message.options)
-            FieldOptions.internalBinaryWrite(message.options, writer.tag(8, WireType.LengthDelimited).fork(), options).join();
         /* optional bool proto3_optional = 17; */
         if (message.proto3Optional !== undefined)
             writer.tag(17, WireType.Varint).bool(message.proto3Optional);
@@ -3283,18 +3283,12 @@ class FileOptions$Type extends MessageType<FileOptions> {
         /* optional string java_outer_classname = 8; */
         if (message.javaOuterClassname !== undefined)
             writer.tag(8, WireType.LengthDelimited).string(message.javaOuterClassname);
-        /* optional bool java_multiple_files = 10; */
-        if (message.javaMultipleFiles !== undefined)
-            writer.tag(10, WireType.Varint).bool(message.javaMultipleFiles);
-        /* optional bool java_generate_equals_and_hash = 20 [deprecated = true]; */
-        if (message.javaGenerateEqualsAndHash !== undefined)
-            writer.tag(20, WireType.Varint).bool(message.javaGenerateEqualsAndHash);
-        /* optional bool java_string_check_utf8 = 27; */
-        if (message.javaStringCheckUtf8 !== undefined)
-            writer.tag(27, WireType.Varint).bool(message.javaStringCheckUtf8);
         /* optional google.protobuf.FileOptions.OptimizeMode optimize_for = 9; */
         if (message.optimizeFor !== undefined)
             writer.tag(9, WireType.Varint).int32(message.optimizeFor);
+        /* optional bool java_multiple_files = 10; */
+        if (message.javaMultipleFiles !== undefined)
+            writer.tag(10, WireType.Varint).bool(message.javaMultipleFiles);
         /* optional string go_package = 11; */
         if (message.goPackage !== undefined)
             writer.tag(11, WireType.LengthDelimited).string(message.goPackage);
@@ -3307,9 +3301,15 @@ class FileOptions$Type extends MessageType<FileOptions> {
         /* optional bool py_generic_services = 18; */
         if (message.pyGenericServices !== undefined)
             writer.tag(18, WireType.Varint).bool(message.pyGenericServices);
+        /* optional bool java_generate_equals_and_hash = 20 [deprecated = true]; */
+        if (message.javaGenerateEqualsAndHash !== undefined)
+            writer.tag(20, WireType.Varint).bool(message.javaGenerateEqualsAndHash);
         /* optional bool deprecated = 23; */
         if (message.deprecated !== undefined)
             writer.tag(23, WireType.Varint).bool(message.deprecated);
+        /* optional bool java_string_check_utf8 = 27; */
+        if (message.javaStringCheckUtf8 !== undefined)
+            writer.tag(27, WireType.Varint).bool(message.javaStringCheckUtf8);
         /* optional bool cc_enable_arenas = 31; */
         if (message.ccEnableArenas !== undefined)
             writer.tag(31, WireType.Varint).bool(message.ccEnableArenas);
@@ -3537,21 +3537,21 @@ class FieldOptions$Type extends MessageType<FieldOptions> {
         /* optional bool packed = 2; */
         if (message.packed !== undefined)
             writer.tag(2, WireType.Varint).bool(message.packed);
-        /* optional google.protobuf.FieldOptions.JSType jstype = 6; */
-        if (message.jstype !== undefined)
-            writer.tag(6, WireType.Varint).int32(message.jstype);
-        /* optional bool lazy = 5; */
-        if (message.lazy !== undefined)
-            writer.tag(5, WireType.Varint).bool(message.lazy);
-        /* optional bool unverified_lazy = 15; */
-        if (message.unverifiedLazy !== undefined)
-            writer.tag(15, WireType.Varint).bool(message.unverifiedLazy);
         /* optional bool deprecated = 3; */
         if (message.deprecated !== undefined)
             writer.tag(3, WireType.Varint).bool(message.deprecated);
+        /* optional bool lazy = 5; */
+        if (message.lazy !== undefined)
+            writer.tag(5, WireType.Varint).bool(message.lazy);
+        /* optional google.protobuf.FieldOptions.JSType jstype = 6; */
+        if (message.jstype !== undefined)
+            writer.tag(6, WireType.Varint).int32(message.jstype);
         /* optional bool weak = 10; */
         if (message.weak !== undefined)
             writer.tag(10, WireType.Varint).bool(message.weak);
+        /* optional bool unverified_lazy = 15; */
+        if (message.unverifiedLazy !== undefined)
+            writer.tag(15, WireType.Varint).bool(message.unverifiedLazy);
         /* optional bool debug_redact = 16; */
         if (message.debugRedact !== undefined)
             writer.tag(16, WireType.Varint).bool(message.debugRedact);
@@ -3620,12 +3620,12 @@ class FieldOptions_EditionDefault$Type extends MessageType<FieldOptions_EditionD
         return message;
     }
     internalBinaryWrite(message: FieldOptions_EditionDefault, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
-        /* optional google.protobuf.Edition edition = 3; */
-        if (message.edition !== undefined)
-            writer.tag(3, WireType.Varint).int32(message.edition);
         /* optional string value = 2; */
         if (message.value !== undefined)
             writer.tag(2, WireType.LengthDelimited).string(message.value);
+        /* optional google.protobuf.Edition edition = 3; */
+        if (message.edition !== undefined)
+            writer.tag(3, WireType.Varint).int32(message.edition);
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
@@ -3949,12 +3949,12 @@ class ServiceOptions$Type extends MessageType<ServiceOptions> {
         return message;
     }
     internalBinaryWrite(message: ServiceOptions, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
-        /* optional google.protobuf.FeatureSet features = 34; */
-        if (message.features)
-            FeatureSet.internalBinaryWrite(message.features, writer.tag(34, WireType.LengthDelimited).fork(), options).join();
         /* optional bool deprecated = 33; */
         if (message.deprecated !== undefined)
             writer.tag(33, WireType.Varint).bool(message.deprecated);
+        /* optional google.protobuf.FeatureSet features = 34; */
+        if (message.features)
+            FeatureSet.internalBinaryWrite(message.features, writer.tag(34, WireType.LengthDelimited).fork(), options).join();
         /* repeated google.protobuf.UninterpretedOption uninterpreted_option = 999; */
         for (let i = 0; i < message.uninterpretedOption.length; i++)
             UninterpretedOption.internalBinaryWrite(message.uninterpretedOption[i], writer.tag(999, WireType.LengthDelimited).fork(), options).join();

--- a/packages/test-long_type_string/gen/google/protobuf/test_messages_proto2.ts
+++ b/packages/test-long_type_string/gen/google/protobuf/test_messages_proto2.ts
@@ -2354,6 +2354,71 @@ class TestAllTypesProto2$Type extends MessageType<TestAllTypesProto2> {
         /* repeated string repeated_cord = 55; */
         for (let i = 0; i < message.repeatedCord.length; i++)
             writer.tag(55, WireType.LengthDelimited).string(message.repeatedCord[i]);
+        /* map<int32, int32> map_int32_int32 = 56; */
+        for (let k of globalThis.Object.keys(message.mapInt32Int32))
+            writer.tag(56, WireType.LengthDelimited).fork().tag(1, WireType.Varint).int32(parseInt(k)).tag(2, WireType.Varint).int32(message.mapInt32Int32[k as any]).join();
+        /* map<int64, int64> map_int64_int64 = 57; */
+        for (let k of globalThis.Object.keys(message.mapInt64Int64))
+            writer.tag(57, WireType.LengthDelimited).fork().tag(1, WireType.Varint).int64(k).tag(2, WireType.Varint).int64(message.mapInt64Int64[k]).join();
+        /* map<uint32, uint32> map_uint32_uint32 = 58; */
+        for (let k of globalThis.Object.keys(message.mapUint32Uint32))
+            writer.tag(58, WireType.LengthDelimited).fork().tag(1, WireType.Varint).uint32(parseInt(k)).tag(2, WireType.Varint).uint32(message.mapUint32Uint32[k as any]).join();
+        /* map<uint64, uint64> map_uint64_uint64 = 59; */
+        for (let k of globalThis.Object.keys(message.mapUint64Uint64))
+            writer.tag(59, WireType.LengthDelimited).fork().tag(1, WireType.Varint).uint64(k).tag(2, WireType.Varint).uint64(message.mapUint64Uint64[k]).join();
+        /* map<sint32, sint32> map_sint32_sint32 = 60; */
+        for (let k of globalThis.Object.keys(message.mapSint32Sint32))
+            writer.tag(60, WireType.LengthDelimited).fork().tag(1, WireType.Varint).sint32(parseInt(k)).tag(2, WireType.Varint).sint32(message.mapSint32Sint32[k as any]).join();
+        /* map<sint64, sint64> map_sint64_sint64 = 61; */
+        for (let k of globalThis.Object.keys(message.mapSint64Sint64))
+            writer.tag(61, WireType.LengthDelimited).fork().tag(1, WireType.Varint).sint64(k).tag(2, WireType.Varint).sint64(message.mapSint64Sint64[k]).join();
+        /* map<fixed32, fixed32> map_fixed32_fixed32 = 62; */
+        for (let k of globalThis.Object.keys(message.mapFixed32Fixed32))
+            writer.tag(62, WireType.LengthDelimited).fork().tag(1, WireType.Bit32).fixed32(parseInt(k)).tag(2, WireType.Bit32).fixed32(message.mapFixed32Fixed32[k as any]).join();
+        /* map<fixed64, fixed64> map_fixed64_fixed64 = 63; */
+        for (let k of globalThis.Object.keys(message.mapFixed64Fixed64))
+            writer.tag(63, WireType.LengthDelimited).fork().tag(1, WireType.Bit64).fixed64(k).tag(2, WireType.Bit64).fixed64(message.mapFixed64Fixed64[k]).join();
+        /* map<sfixed32, sfixed32> map_sfixed32_sfixed32 = 64; */
+        for (let k of globalThis.Object.keys(message.mapSfixed32Sfixed32))
+            writer.tag(64, WireType.LengthDelimited).fork().tag(1, WireType.Bit32).sfixed32(parseInt(k)).tag(2, WireType.Bit32).sfixed32(message.mapSfixed32Sfixed32[k as any]).join();
+        /* map<sfixed64, sfixed64> map_sfixed64_sfixed64 = 65; */
+        for (let k of globalThis.Object.keys(message.mapSfixed64Sfixed64))
+            writer.tag(65, WireType.LengthDelimited).fork().tag(1, WireType.Bit64).sfixed64(k).tag(2, WireType.Bit64).sfixed64(message.mapSfixed64Sfixed64[k]).join();
+        /* map<int32, float> map_int32_float = 66; */
+        for (let k of globalThis.Object.keys(message.mapInt32Float))
+            writer.tag(66, WireType.LengthDelimited).fork().tag(1, WireType.Varint).int32(parseInt(k)).tag(2, WireType.Bit32).float(message.mapInt32Float[k as any]).join();
+        /* map<int32, double> map_int32_double = 67; */
+        for (let k of globalThis.Object.keys(message.mapInt32Double))
+            writer.tag(67, WireType.LengthDelimited).fork().tag(1, WireType.Varint).int32(parseInt(k)).tag(2, WireType.Bit64).double(message.mapInt32Double[k as any]).join();
+        /* map<bool, bool> map_bool_bool = 68; */
+        for (let k of globalThis.Object.keys(message.mapBoolBool))
+            writer.tag(68, WireType.LengthDelimited).fork().tag(1, WireType.Varint).bool(k === "true").tag(2, WireType.Varint).bool(message.mapBoolBool[k]).join();
+        /* map<string, string> map_string_string = 69; */
+        for (let k of globalThis.Object.keys(message.mapStringString))
+            writer.tag(69, WireType.LengthDelimited).fork().tag(1, WireType.LengthDelimited).string(k).tag(2, WireType.LengthDelimited).string(message.mapStringString[k]).join();
+        /* map<string, bytes> map_string_bytes = 70; */
+        for (let k of globalThis.Object.keys(message.mapStringBytes))
+            writer.tag(70, WireType.LengthDelimited).fork().tag(1, WireType.LengthDelimited).string(k).tag(2, WireType.LengthDelimited).bytes(message.mapStringBytes[k]).join();
+        /* map<string, protobuf_test_messages.proto2.TestAllTypesProto2.NestedMessage> map_string_nested_message = 71; */
+        for (let k of globalThis.Object.keys(message.mapStringNestedMessage)) {
+            writer.tag(71, WireType.LengthDelimited).fork().tag(1, WireType.LengthDelimited).string(k);
+            writer.tag(2, WireType.LengthDelimited).fork();
+            TestAllTypesProto2_NestedMessage.internalBinaryWrite(message.mapStringNestedMessage[k], writer, options);
+            writer.join().join();
+        }
+        /* map<string, protobuf_test_messages.proto2.ForeignMessageProto2> map_string_foreign_message = 72; */
+        for (let k of globalThis.Object.keys(message.mapStringForeignMessage)) {
+            writer.tag(72, WireType.LengthDelimited).fork().tag(1, WireType.LengthDelimited).string(k);
+            writer.tag(2, WireType.LengthDelimited).fork();
+            ForeignMessageProto2.internalBinaryWrite(message.mapStringForeignMessage[k], writer, options);
+            writer.join().join();
+        }
+        /* map<string, protobuf_test_messages.proto2.TestAllTypesProto2.NestedEnum> map_string_nested_enum = 73; */
+        for (let k of globalThis.Object.keys(message.mapStringNestedEnum))
+            writer.tag(73, WireType.LengthDelimited).fork().tag(1, WireType.LengthDelimited).string(k).tag(2, WireType.Varint).int32(message.mapStringNestedEnum[k]).join();
+        /* map<string, protobuf_test_messages.proto2.ForeignEnumProto2> map_string_foreign_enum = 74; */
+        for (let k of globalThis.Object.keys(message.mapStringForeignEnum))
+            writer.tag(74, WireType.LengthDelimited).fork().tag(1, WireType.LengthDelimited).string(k).tag(2, WireType.Varint).int32(message.mapStringForeignEnum[k]).join();
         /* repeated int32 packed_int32 = 75 [packed = true]; */
         if (message.packedInt32.length) {
             writer.tag(75, WireType.LengthDelimited).fork();
@@ -2494,71 +2559,6 @@ class TestAllTypesProto2$Type extends MessageType<TestAllTypesProto2> {
         /* repeated protobuf_test_messages.proto2.TestAllTypesProto2.NestedEnum unpacked_nested_enum = 102 [packed = false]; */
         for (let i = 0; i < message.unpackedNestedEnum.length; i++)
             writer.tag(102, WireType.Varint).int32(message.unpackedNestedEnum[i]);
-        /* map<int32, int32> map_int32_int32 = 56; */
-        for (let k of globalThis.Object.keys(message.mapInt32Int32))
-            writer.tag(56, WireType.LengthDelimited).fork().tag(1, WireType.Varint).int32(parseInt(k)).tag(2, WireType.Varint).int32(message.mapInt32Int32[k as any]).join();
-        /* map<int64, int64> map_int64_int64 = 57; */
-        for (let k of globalThis.Object.keys(message.mapInt64Int64))
-            writer.tag(57, WireType.LengthDelimited).fork().tag(1, WireType.Varint).int64(k).tag(2, WireType.Varint).int64(message.mapInt64Int64[k]).join();
-        /* map<uint32, uint32> map_uint32_uint32 = 58; */
-        for (let k of globalThis.Object.keys(message.mapUint32Uint32))
-            writer.tag(58, WireType.LengthDelimited).fork().tag(1, WireType.Varint).uint32(parseInt(k)).tag(2, WireType.Varint).uint32(message.mapUint32Uint32[k as any]).join();
-        /* map<uint64, uint64> map_uint64_uint64 = 59; */
-        for (let k of globalThis.Object.keys(message.mapUint64Uint64))
-            writer.tag(59, WireType.LengthDelimited).fork().tag(1, WireType.Varint).uint64(k).tag(2, WireType.Varint).uint64(message.mapUint64Uint64[k]).join();
-        /* map<sint32, sint32> map_sint32_sint32 = 60; */
-        for (let k of globalThis.Object.keys(message.mapSint32Sint32))
-            writer.tag(60, WireType.LengthDelimited).fork().tag(1, WireType.Varint).sint32(parseInt(k)).tag(2, WireType.Varint).sint32(message.mapSint32Sint32[k as any]).join();
-        /* map<sint64, sint64> map_sint64_sint64 = 61; */
-        for (let k of globalThis.Object.keys(message.mapSint64Sint64))
-            writer.tag(61, WireType.LengthDelimited).fork().tag(1, WireType.Varint).sint64(k).tag(2, WireType.Varint).sint64(message.mapSint64Sint64[k]).join();
-        /* map<fixed32, fixed32> map_fixed32_fixed32 = 62; */
-        for (let k of globalThis.Object.keys(message.mapFixed32Fixed32))
-            writer.tag(62, WireType.LengthDelimited).fork().tag(1, WireType.Bit32).fixed32(parseInt(k)).tag(2, WireType.Bit32).fixed32(message.mapFixed32Fixed32[k as any]).join();
-        /* map<fixed64, fixed64> map_fixed64_fixed64 = 63; */
-        for (let k of globalThis.Object.keys(message.mapFixed64Fixed64))
-            writer.tag(63, WireType.LengthDelimited).fork().tag(1, WireType.Bit64).fixed64(k).tag(2, WireType.Bit64).fixed64(message.mapFixed64Fixed64[k]).join();
-        /* map<sfixed32, sfixed32> map_sfixed32_sfixed32 = 64; */
-        for (let k of globalThis.Object.keys(message.mapSfixed32Sfixed32))
-            writer.tag(64, WireType.LengthDelimited).fork().tag(1, WireType.Bit32).sfixed32(parseInt(k)).tag(2, WireType.Bit32).sfixed32(message.mapSfixed32Sfixed32[k as any]).join();
-        /* map<sfixed64, sfixed64> map_sfixed64_sfixed64 = 65; */
-        for (let k of globalThis.Object.keys(message.mapSfixed64Sfixed64))
-            writer.tag(65, WireType.LengthDelimited).fork().tag(1, WireType.Bit64).sfixed64(k).tag(2, WireType.Bit64).sfixed64(message.mapSfixed64Sfixed64[k]).join();
-        /* map<int32, float> map_int32_float = 66; */
-        for (let k of globalThis.Object.keys(message.mapInt32Float))
-            writer.tag(66, WireType.LengthDelimited).fork().tag(1, WireType.Varint).int32(parseInt(k)).tag(2, WireType.Bit32).float(message.mapInt32Float[k as any]).join();
-        /* map<int32, double> map_int32_double = 67; */
-        for (let k of globalThis.Object.keys(message.mapInt32Double))
-            writer.tag(67, WireType.LengthDelimited).fork().tag(1, WireType.Varint).int32(parseInt(k)).tag(2, WireType.Bit64).double(message.mapInt32Double[k as any]).join();
-        /* map<bool, bool> map_bool_bool = 68; */
-        for (let k of globalThis.Object.keys(message.mapBoolBool))
-            writer.tag(68, WireType.LengthDelimited).fork().tag(1, WireType.Varint).bool(k === "true").tag(2, WireType.Varint).bool(message.mapBoolBool[k]).join();
-        /* map<string, string> map_string_string = 69; */
-        for (let k of globalThis.Object.keys(message.mapStringString))
-            writer.tag(69, WireType.LengthDelimited).fork().tag(1, WireType.LengthDelimited).string(k).tag(2, WireType.LengthDelimited).string(message.mapStringString[k]).join();
-        /* map<string, bytes> map_string_bytes = 70; */
-        for (let k of globalThis.Object.keys(message.mapStringBytes))
-            writer.tag(70, WireType.LengthDelimited).fork().tag(1, WireType.LengthDelimited).string(k).tag(2, WireType.LengthDelimited).bytes(message.mapStringBytes[k]).join();
-        /* map<string, protobuf_test_messages.proto2.TestAllTypesProto2.NestedMessage> map_string_nested_message = 71; */
-        for (let k of globalThis.Object.keys(message.mapStringNestedMessage)) {
-            writer.tag(71, WireType.LengthDelimited).fork().tag(1, WireType.LengthDelimited).string(k);
-            writer.tag(2, WireType.LengthDelimited).fork();
-            TestAllTypesProto2_NestedMessage.internalBinaryWrite(message.mapStringNestedMessage[k], writer, options);
-            writer.join().join();
-        }
-        /* map<string, protobuf_test_messages.proto2.ForeignMessageProto2> map_string_foreign_message = 72; */
-        for (let k of globalThis.Object.keys(message.mapStringForeignMessage)) {
-            writer.tag(72, WireType.LengthDelimited).fork().tag(1, WireType.LengthDelimited).string(k);
-            writer.tag(2, WireType.LengthDelimited).fork();
-            ForeignMessageProto2.internalBinaryWrite(message.mapStringForeignMessage[k], writer, options);
-            writer.join().join();
-        }
-        /* map<string, protobuf_test_messages.proto2.TestAllTypesProto2.NestedEnum> map_string_nested_enum = 73; */
-        for (let k of globalThis.Object.keys(message.mapStringNestedEnum))
-            writer.tag(73, WireType.LengthDelimited).fork().tag(1, WireType.LengthDelimited).string(k).tag(2, WireType.Varint).int32(message.mapStringNestedEnum[k]).join();
-        /* map<string, protobuf_test_messages.proto2.ForeignEnumProto2> map_string_foreign_enum = 74; */
-        for (let k of globalThis.Object.keys(message.mapStringForeignEnum))
-            writer.tag(74, WireType.LengthDelimited).fork().tag(1, WireType.LengthDelimited).string(k).tag(2, WireType.Varint).int32(message.mapStringForeignEnum[k]).join();
         /* uint32 oneof_uint32 = 111; */
         if (message.oneofField.oneofKind === "oneofUint32")
             writer.tag(111, WireType.Varint).uint32(message.oneofField.oneofUint32);

--- a/packages/test-long_type_string/gen/google/protobuf/test_messages_proto3.ts
+++ b/packages/test-long_type_string/gen/google/protobuf/test_messages_proto3.ts
@@ -2307,6 +2307,71 @@ class TestAllTypesProto3$Type extends MessageType<TestAllTypesProto3> {
         /* repeated string repeated_cord = 55; */
         for (let i = 0; i < message.repeatedCord.length; i++)
             writer.tag(55, WireType.LengthDelimited).string(message.repeatedCord[i]);
+        /* map<int32, int32> map_int32_int32 = 56; */
+        for (let k of globalThis.Object.keys(message.mapInt32Int32))
+            writer.tag(56, WireType.LengthDelimited).fork().tag(1, WireType.Varint).int32(parseInt(k)).tag(2, WireType.Varint).int32(message.mapInt32Int32[k as any]).join();
+        /* map<int64, int64> map_int64_int64 = 57; */
+        for (let k of globalThis.Object.keys(message.mapInt64Int64))
+            writer.tag(57, WireType.LengthDelimited).fork().tag(1, WireType.Varint).int64(k).tag(2, WireType.Varint).int64(message.mapInt64Int64[k]).join();
+        /* map<uint32, uint32> map_uint32_uint32 = 58; */
+        for (let k of globalThis.Object.keys(message.mapUint32Uint32))
+            writer.tag(58, WireType.LengthDelimited).fork().tag(1, WireType.Varint).uint32(parseInt(k)).tag(2, WireType.Varint).uint32(message.mapUint32Uint32[k as any]).join();
+        /* map<uint64, uint64> map_uint64_uint64 = 59; */
+        for (let k of globalThis.Object.keys(message.mapUint64Uint64))
+            writer.tag(59, WireType.LengthDelimited).fork().tag(1, WireType.Varint).uint64(k).tag(2, WireType.Varint).uint64(message.mapUint64Uint64[k]).join();
+        /* map<sint32, sint32> map_sint32_sint32 = 60; */
+        for (let k of globalThis.Object.keys(message.mapSint32Sint32))
+            writer.tag(60, WireType.LengthDelimited).fork().tag(1, WireType.Varint).sint32(parseInt(k)).tag(2, WireType.Varint).sint32(message.mapSint32Sint32[k as any]).join();
+        /* map<sint64, sint64> map_sint64_sint64 = 61; */
+        for (let k of globalThis.Object.keys(message.mapSint64Sint64))
+            writer.tag(61, WireType.LengthDelimited).fork().tag(1, WireType.Varint).sint64(k).tag(2, WireType.Varint).sint64(message.mapSint64Sint64[k]).join();
+        /* map<fixed32, fixed32> map_fixed32_fixed32 = 62; */
+        for (let k of globalThis.Object.keys(message.mapFixed32Fixed32))
+            writer.tag(62, WireType.LengthDelimited).fork().tag(1, WireType.Bit32).fixed32(parseInt(k)).tag(2, WireType.Bit32).fixed32(message.mapFixed32Fixed32[k as any]).join();
+        /* map<fixed64, fixed64> map_fixed64_fixed64 = 63; */
+        for (let k of globalThis.Object.keys(message.mapFixed64Fixed64))
+            writer.tag(63, WireType.LengthDelimited).fork().tag(1, WireType.Bit64).fixed64(k).tag(2, WireType.Bit64).fixed64(message.mapFixed64Fixed64[k]).join();
+        /* map<sfixed32, sfixed32> map_sfixed32_sfixed32 = 64; */
+        for (let k of globalThis.Object.keys(message.mapSfixed32Sfixed32))
+            writer.tag(64, WireType.LengthDelimited).fork().tag(1, WireType.Bit32).sfixed32(parseInt(k)).tag(2, WireType.Bit32).sfixed32(message.mapSfixed32Sfixed32[k as any]).join();
+        /* map<sfixed64, sfixed64> map_sfixed64_sfixed64 = 65; */
+        for (let k of globalThis.Object.keys(message.mapSfixed64Sfixed64))
+            writer.tag(65, WireType.LengthDelimited).fork().tag(1, WireType.Bit64).sfixed64(k).tag(2, WireType.Bit64).sfixed64(message.mapSfixed64Sfixed64[k]).join();
+        /* map<int32, float> map_int32_float = 66; */
+        for (let k of globalThis.Object.keys(message.mapInt32Float))
+            writer.tag(66, WireType.LengthDelimited).fork().tag(1, WireType.Varint).int32(parseInt(k)).tag(2, WireType.Bit32).float(message.mapInt32Float[k as any]).join();
+        /* map<int32, double> map_int32_double = 67; */
+        for (let k of globalThis.Object.keys(message.mapInt32Double))
+            writer.tag(67, WireType.LengthDelimited).fork().tag(1, WireType.Varint).int32(parseInt(k)).tag(2, WireType.Bit64).double(message.mapInt32Double[k as any]).join();
+        /* map<bool, bool> map_bool_bool = 68; */
+        for (let k of globalThis.Object.keys(message.mapBoolBool))
+            writer.tag(68, WireType.LengthDelimited).fork().tag(1, WireType.Varint).bool(k === "true").tag(2, WireType.Varint).bool(message.mapBoolBool[k]).join();
+        /* map<string, string> map_string_string = 69; */
+        for (let k of globalThis.Object.keys(message.mapStringString))
+            writer.tag(69, WireType.LengthDelimited).fork().tag(1, WireType.LengthDelimited).string(k).tag(2, WireType.LengthDelimited).string(message.mapStringString[k]).join();
+        /* map<string, bytes> map_string_bytes = 70; */
+        for (let k of globalThis.Object.keys(message.mapStringBytes))
+            writer.tag(70, WireType.LengthDelimited).fork().tag(1, WireType.LengthDelimited).string(k).tag(2, WireType.LengthDelimited).bytes(message.mapStringBytes[k]).join();
+        /* map<string, protobuf_test_messages.proto3.TestAllTypesProto3.NestedMessage> map_string_nested_message = 71; */
+        for (let k of globalThis.Object.keys(message.mapStringNestedMessage)) {
+            writer.tag(71, WireType.LengthDelimited).fork().tag(1, WireType.LengthDelimited).string(k);
+            writer.tag(2, WireType.LengthDelimited).fork();
+            TestAllTypesProto3_NestedMessage.internalBinaryWrite(message.mapStringNestedMessage[k], writer, options);
+            writer.join().join();
+        }
+        /* map<string, protobuf_test_messages.proto3.ForeignMessage> map_string_foreign_message = 72; */
+        for (let k of globalThis.Object.keys(message.mapStringForeignMessage)) {
+            writer.tag(72, WireType.LengthDelimited).fork().tag(1, WireType.LengthDelimited).string(k);
+            writer.tag(2, WireType.LengthDelimited).fork();
+            ForeignMessage.internalBinaryWrite(message.mapStringForeignMessage[k], writer, options);
+            writer.join().join();
+        }
+        /* map<string, protobuf_test_messages.proto3.TestAllTypesProto3.NestedEnum> map_string_nested_enum = 73; */
+        for (let k of globalThis.Object.keys(message.mapStringNestedEnum))
+            writer.tag(73, WireType.LengthDelimited).fork().tag(1, WireType.LengthDelimited).string(k).tag(2, WireType.Varint).int32(message.mapStringNestedEnum[k]).join();
+        /* map<string, protobuf_test_messages.proto3.ForeignEnum> map_string_foreign_enum = 74; */
+        for (let k of globalThis.Object.keys(message.mapStringForeignEnum))
+            writer.tag(74, WireType.LengthDelimited).fork().tag(1, WireType.LengthDelimited).string(k).tag(2, WireType.Varint).int32(message.mapStringForeignEnum[k]).join();
         /* repeated int32 packed_int32 = 75 [packed = true]; */
         if (message.packedInt32.length) {
             writer.tag(75, WireType.LengthDelimited).fork();
@@ -2447,71 +2512,6 @@ class TestAllTypesProto3$Type extends MessageType<TestAllTypesProto3> {
         /* repeated protobuf_test_messages.proto3.TestAllTypesProto3.NestedEnum unpacked_nested_enum = 102 [packed = false]; */
         for (let i = 0; i < message.unpackedNestedEnum.length; i++)
             writer.tag(102, WireType.Varint).int32(message.unpackedNestedEnum[i]);
-        /* map<int32, int32> map_int32_int32 = 56; */
-        for (let k of globalThis.Object.keys(message.mapInt32Int32))
-            writer.tag(56, WireType.LengthDelimited).fork().tag(1, WireType.Varint).int32(parseInt(k)).tag(2, WireType.Varint).int32(message.mapInt32Int32[k as any]).join();
-        /* map<int64, int64> map_int64_int64 = 57; */
-        for (let k of globalThis.Object.keys(message.mapInt64Int64))
-            writer.tag(57, WireType.LengthDelimited).fork().tag(1, WireType.Varint).int64(k).tag(2, WireType.Varint).int64(message.mapInt64Int64[k]).join();
-        /* map<uint32, uint32> map_uint32_uint32 = 58; */
-        for (let k of globalThis.Object.keys(message.mapUint32Uint32))
-            writer.tag(58, WireType.LengthDelimited).fork().tag(1, WireType.Varint).uint32(parseInt(k)).tag(2, WireType.Varint).uint32(message.mapUint32Uint32[k as any]).join();
-        /* map<uint64, uint64> map_uint64_uint64 = 59; */
-        for (let k of globalThis.Object.keys(message.mapUint64Uint64))
-            writer.tag(59, WireType.LengthDelimited).fork().tag(1, WireType.Varint).uint64(k).tag(2, WireType.Varint).uint64(message.mapUint64Uint64[k]).join();
-        /* map<sint32, sint32> map_sint32_sint32 = 60; */
-        for (let k of globalThis.Object.keys(message.mapSint32Sint32))
-            writer.tag(60, WireType.LengthDelimited).fork().tag(1, WireType.Varint).sint32(parseInt(k)).tag(2, WireType.Varint).sint32(message.mapSint32Sint32[k as any]).join();
-        /* map<sint64, sint64> map_sint64_sint64 = 61; */
-        for (let k of globalThis.Object.keys(message.mapSint64Sint64))
-            writer.tag(61, WireType.LengthDelimited).fork().tag(1, WireType.Varint).sint64(k).tag(2, WireType.Varint).sint64(message.mapSint64Sint64[k]).join();
-        /* map<fixed32, fixed32> map_fixed32_fixed32 = 62; */
-        for (let k of globalThis.Object.keys(message.mapFixed32Fixed32))
-            writer.tag(62, WireType.LengthDelimited).fork().tag(1, WireType.Bit32).fixed32(parseInt(k)).tag(2, WireType.Bit32).fixed32(message.mapFixed32Fixed32[k as any]).join();
-        /* map<fixed64, fixed64> map_fixed64_fixed64 = 63; */
-        for (let k of globalThis.Object.keys(message.mapFixed64Fixed64))
-            writer.tag(63, WireType.LengthDelimited).fork().tag(1, WireType.Bit64).fixed64(k).tag(2, WireType.Bit64).fixed64(message.mapFixed64Fixed64[k]).join();
-        /* map<sfixed32, sfixed32> map_sfixed32_sfixed32 = 64; */
-        for (let k of globalThis.Object.keys(message.mapSfixed32Sfixed32))
-            writer.tag(64, WireType.LengthDelimited).fork().tag(1, WireType.Bit32).sfixed32(parseInt(k)).tag(2, WireType.Bit32).sfixed32(message.mapSfixed32Sfixed32[k as any]).join();
-        /* map<sfixed64, sfixed64> map_sfixed64_sfixed64 = 65; */
-        for (let k of globalThis.Object.keys(message.mapSfixed64Sfixed64))
-            writer.tag(65, WireType.LengthDelimited).fork().tag(1, WireType.Bit64).sfixed64(k).tag(2, WireType.Bit64).sfixed64(message.mapSfixed64Sfixed64[k]).join();
-        /* map<int32, float> map_int32_float = 66; */
-        for (let k of globalThis.Object.keys(message.mapInt32Float))
-            writer.tag(66, WireType.LengthDelimited).fork().tag(1, WireType.Varint).int32(parseInt(k)).tag(2, WireType.Bit32).float(message.mapInt32Float[k as any]).join();
-        /* map<int32, double> map_int32_double = 67; */
-        for (let k of globalThis.Object.keys(message.mapInt32Double))
-            writer.tag(67, WireType.LengthDelimited).fork().tag(1, WireType.Varint).int32(parseInt(k)).tag(2, WireType.Bit64).double(message.mapInt32Double[k as any]).join();
-        /* map<bool, bool> map_bool_bool = 68; */
-        for (let k of globalThis.Object.keys(message.mapBoolBool))
-            writer.tag(68, WireType.LengthDelimited).fork().tag(1, WireType.Varint).bool(k === "true").tag(2, WireType.Varint).bool(message.mapBoolBool[k]).join();
-        /* map<string, string> map_string_string = 69; */
-        for (let k of globalThis.Object.keys(message.mapStringString))
-            writer.tag(69, WireType.LengthDelimited).fork().tag(1, WireType.LengthDelimited).string(k).tag(2, WireType.LengthDelimited).string(message.mapStringString[k]).join();
-        /* map<string, bytes> map_string_bytes = 70; */
-        for (let k of globalThis.Object.keys(message.mapStringBytes))
-            writer.tag(70, WireType.LengthDelimited).fork().tag(1, WireType.LengthDelimited).string(k).tag(2, WireType.LengthDelimited).bytes(message.mapStringBytes[k]).join();
-        /* map<string, protobuf_test_messages.proto3.TestAllTypesProto3.NestedMessage> map_string_nested_message = 71; */
-        for (let k of globalThis.Object.keys(message.mapStringNestedMessage)) {
-            writer.tag(71, WireType.LengthDelimited).fork().tag(1, WireType.LengthDelimited).string(k);
-            writer.tag(2, WireType.LengthDelimited).fork();
-            TestAllTypesProto3_NestedMessage.internalBinaryWrite(message.mapStringNestedMessage[k], writer, options);
-            writer.join().join();
-        }
-        /* map<string, protobuf_test_messages.proto3.ForeignMessage> map_string_foreign_message = 72; */
-        for (let k of globalThis.Object.keys(message.mapStringForeignMessage)) {
-            writer.tag(72, WireType.LengthDelimited).fork().tag(1, WireType.LengthDelimited).string(k);
-            writer.tag(2, WireType.LengthDelimited).fork();
-            ForeignMessage.internalBinaryWrite(message.mapStringForeignMessage[k], writer, options);
-            writer.join().join();
-        }
-        /* map<string, protobuf_test_messages.proto3.TestAllTypesProto3.NestedEnum> map_string_nested_enum = 73; */
-        for (let k of globalThis.Object.keys(message.mapStringNestedEnum))
-            writer.tag(73, WireType.LengthDelimited).fork().tag(1, WireType.LengthDelimited).string(k).tag(2, WireType.Varint).int32(message.mapStringNestedEnum[k]).join();
-        /* map<string, protobuf_test_messages.proto3.ForeignEnum> map_string_foreign_enum = 74; */
-        for (let k of globalThis.Object.keys(message.mapStringForeignEnum))
-            writer.tag(74, WireType.LengthDelimited).fork().tag(1, WireType.LengthDelimited).string(k).tag(2, WireType.Varint).int32(message.mapStringForeignEnum[k]).join();
         /* uint32 oneof_uint32 = 111; */
         if (message.oneofField.oneofKind === "oneofUint32")
             writer.tag(111, WireType.Varint).uint32(message.oneofField.oneofUint32);
@@ -2626,9 +2626,6 @@ class TestAllTypesProto3$Type extends MessageType<TestAllTypesProto3> {
         /* repeated google.protobuf.FieldMask repeated_fieldmask = 313; */
         for (let i = 0; i < message.repeatedFieldmask.length; i++)
             FieldMask.internalBinaryWrite(message.repeatedFieldmask[i], writer.tag(313, WireType.LengthDelimited).fork(), options).join();
-        /* repeated google.protobuf.Struct repeated_struct = 324; */
-        for (let i = 0; i < message.repeatedStruct.length; i++)
-            Struct.internalBinaryWrite(message.repeatedStruct[i], writer.tag(324, WireType.LengthDelimited).fork(), options).join();
         /* repeated google.protobuf.Any repeated_any = 315; */
         for (let i = 0; i < message.repeatedAny.length; i++)
             Any.internalBinaryWrite(message.repeatedAny[i], writer.tag(315, WireType.LengthDelimited).fork(), options).join();
@@ -2638,6 +2635,9 @@ class TestAllTypesProto3$Type extends MessageType<TestAllTypesProto3> {
         /* repeated google.protobuf.ListValue repeated_list_value = 317; */
         for (let i = 0; i < message.repeatedListValue.length; i++)
             ListValue.internalBinaryWrite(message.repeatedListValue[i], writer.tag(317, WireType.LengthDelimited).fork(), options).join();
+        /* repeated google.protobuf.Struct repeated_struct = 324; */
+        for (let i = 0; i < message.repeatedStruct.length; i++)
+            Struct.internalBinaryWrite(message.repeatedStruct[i], writer.tag(324, WireType.LengthDelimited).fork(), options).join();
         /* int32 fieldname1 = 401; */
         if (message.fieldname1 !== 0)
             writer.tag(401, WireType.Varint).int32(message.fieldname1);

--- a/packages/test-long_type_string/gen/google/protobuf/unittest_mset.ts
+++ b/packages/test-long_type_string/gen/google/protobuf/unittest_mset.ts
@@ -290,12 +290,12 @@ class NestedTestInt$Type extends MessageType<NestedTestInt> {
         /* optional fixed32 a = 1; */
         if (message.a !== undefined)
             writer.tag(1, WireType.Bit32).fixed32(message.a);
-        /* optional int32 b = 3; */
-        if (message.b !== undefined)
-            writer.tag(3, WireType.Varint).int32(message.b);
         /* optional protobuf_unittest.NestedTestInt child = 2; */
         if (message.child)
             NestedTestInt.internalBinaryWrite(message.child, writer.tag(2, WireType.LengthDelimited).fork(), options).join();
+        /* optional int32 b = 3; */
+        if (message.b !== undefined)
+            writer.tag(3, WireType.Varint).int32(message.b);
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);

--- a/packages/test-long_type_string/gen/google/protobuf/unittest_proto3.ts
+++ b/packages/test-long_type_string/gen/google/protobuf/unittest_proto3.ts
@@ -1282,9 +1282,6 @@ class TestAllTypes$Type extends MessageType<TestAllTypes> {
         /* proto3_unittest.TestAllTypes.NestedMessage optional_unverified_lazy_message = 28; */
         if (message.optionalUnverifiedLazyMessage)
             TestAllTypes_NestedMessage.internalBinaryWrite(message.optionalUnverifiedLazyMessage, writer.tag(28, WireType.LengthDelimited).fork(), options).join();
-        /* protobuf_unittest_import.ImportMessage optional_lazy_import_message = 115; */
-        if (message.optionalLazyImportMessage)
-            ImportMessage.internalBinaryWrite(message.optionalLazyImportMessage, writer.tag(115, WireType.LengthDelimited).fork(), options).join();
         /* repeated int32 repeated_int32 = 31; */
         if (message.repeatedInt32.length) {
             writer.tag(31, WireType.LengthDelimited).fork();
@@ -1426,6 +1423,9 @@ class TestAllTypes$Type extends MessageType<TestAllTypes> {
         /* bytes oneof_bytes = 114; */
         if (message.oneofField.oneofKind === "oneofBytes")
             writer.tag(114, WireType.LengthDelimited).bytes(message.oneofField.oneofBytes);
+        /* protobuf_unittest_import.ImportMessage optional_lazy_import_message = 115; */
+        if (message.optionalLazyImportMessage)
+            ImportMessage.internalBinaryWrite(message.optionalLazyImportMessage, writer.tag(115, WireType.LengthDelimited).fork(), options).join();
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);

--- a/packages/test-long_type_string/gen/google/protobuf/unittest_proto3_arena.ts
+++ b/packages/test-long_type_string/gen/google/protobuf/unittest_proto3_arena.ts
@@ -973,9 +973,6 @@ class TestAllTypes$Type extends MessageType<TestAllTypes> {
         /* proto3_arena_unittest.TestAllTypes.NestedMessage optional_lazy_message = 27; */
         if (message.optionalLazyMessage)
             TestAllTypes_NestedMessage.internalBinaryWrite(message.optionalLazyMessage, writer.tag(27, WireType.LengthDelimited).fork(), options).join();
-        /* protobuf_unittest_import.ImportMessage optional_lazy_import_message = 115; */
-        if (message.optionalLazyImportMessage)
-            ImportMessage.internalBinaryWrite(message.optionalLazyImportMessage, writer.tag(115, WireType.LengthDelimited).fork(), options).join();
         /* repeated int32 repeated_int32 = 31; */
         if (message.repeatedInt32.length) {
             writer.tag(31, WireType.LengthDelimited).fork();
@@ -1117,6 +1114,9 @@ class TestAllTypes$Type extends MessageType<TestAllTypes> {
         /* bytes oneof_bytes = 114; */
         if (message.oneofField.oneofKind === "oneofBytes")
             writer.tag(114, WireType.LengthDelimited).bytes(message.oneofField.oneofBytes);
+        /* protobuf_unittest_import.ImportMessage optional_lazy_import_message = 115; */
+        if (message.optionalLazyImportMessage)
+            ImportMessage.internalBinaryWrite(message.optionalLazyImportMessage, writer.tag(115, WireType.LengthDelimited).fork(), options).join();
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);

--- a/packages/test-long_type_string/gen/google/rpc/context/attribute_context.ts
+++ b/packages/test-long_type_string/gen/google/rpc/context/attribute_context.ts
@@ -504,9 +504,6 @@ class AttributeContext$Type extends MessageType<AttributeContext> {
         return message;
     }
     internalBinaryWrite(message: AttributeContext, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
-        /* google.rpc.context.AttributeContext.Peer origin = 7; */
-        if (message.origin)
-            AttributeContext_Peer.internalBinaryWrite(message.origin, writer.tag(7, WireType.LengthDelimited).fork(), options).join();
         /* google.rpc.context.AttributeContext.Peer source = 1; */
         if (message.source)
             AttributeContext_Peer.internalBinaryWrite(message.source, writer.tag(1, WireType.LengthDelimited).fork(), options).join();
@@ -525,6 +522,9 @@ class AttributeContext$Type extends MessageType<AttributeContext> {
         /* google.rpc.context.AttributeContext.Api api = 6; */
         if (message.api)
             AttributeContext_Api.internalBinaryWrite(message.api, writer.tag(6, WireType.LengthDelimited).fork(), options).join();
+        /* google.rpc.context.AttributeContext.Peer origin = 7; */
+        if (message.origin)
+            AttributeContext_Peer.internalBinaryWrite(message.origin, writer.tag(7, WireType.LengthDelimited).fork(), options).join();
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);

--- a/packages/test-long_type_string/spec/generated-binary-read-compat.spec.ts
+++ b/packages/test-long_type_string/spec/generated-binary-read-compat.spec.ts
@@ -1,4 +1,4 @@
-import {IMessageType, MessageType} from "@protobuf-ts/runtime";
+import {IMessageType, MessageType, base64encode} from "@protobuf-ts/runtime";
 import {EnumFieldMessage} from "../gen/msg-enum";
 import {JsonNamesMessage} from "../gen/msg-json-names";
 import {MessageFieldMessage} from "../gen/msg-message";
@@ -6,6 +6,7 @@ import {OneofMessageMemberMessage, OneofScalarMemberMessage} from "../gen/msg-on
 import {Proto2OptionalsMessage} from "../gen/msg-proto2-optionals";
 import {Proto3OptionalsMessage} from "../gen/msg-proto3-optionals";
 import {RepeatedScalarValuesMessage, ScalarValuesMessage} from "../gen/msg-scalar";
+import {TestAllTypesProto3} from "../gen/google/protobuf/test_messages_proto3";
 
 // Copied from test-default/generated-binary-read-compat.spec.ts. Do not edit.
 let generatedRegistry: IMessageType<any>[] = [
@@ -39,6 +40,20 @@ describe('generated code compatibility', () => {
             });
         }
     });
+
+    it('should have same serialization order regardless of optimization options', function () {
+        const reflectionType = new MessageType<TestAllTypesProto3>(TestAllTypesProto3.typeName, [...TestAllTypesProto3.fields].reverse());
+        const message = TestAllTypesProto3.fromJson({
+            optionalInt32: 123,
+            optionalInt64: "1",
+            optionalString: "1",
+            optionalNestedMessage: {
+                a: 2,
+            }
+        });
+        expect(base64encode(TestAllTypesProto3.toBinary(message)))
+            .toBe(base64encode(reflectionType.toBinary(message)));
+    })
 
 });
 


### PR DESCRIPTION
This follows up on https://github.com/timostamm/protobuf-ts/pull/577.

Changes to make field writing order between CODE_SIZE and SPEED are kept. But changes to field order in generated types and reflection info are undone, so that order is the same as in proto.