### PR TITLE
Split out plugin option parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   },
   "scripts": {
     "clean": "git clean -Xdf",
-    "all": "turbo run --ui tui build generate test conformance",
-    "affected": "turbo run --affected --ui tui build generate test conformance",
+    "all": "turbo run --ui tui build generate test conformance bootstrap",
+    "affected": "turbo run --affected --ui tui build generate test conformance bootstrap",
     "setversion": "node scripts/set-version.mjs",
     "postsetversion": "npx turbo run generate bootstrap"
   },

--- a/packages/plugin-framework/turbo.json
+++ b/packages/plugin-framework/turbo.json
@@ -3,7 +3,7 @@
   "extends": ["//"],
   "tasks": {
     "bootstrap": {
-      "dependsOn": ["^build"],
+      "dependsOn": ["^build", "@protobuf-ts/plugin#build"],
       "inputs": [
         "package.json"
       ],

--- a/packages/plugin/spec/create-option-parser.spec.ts
+++ b/packages/plugin/spec/create-option-parser.spec.ts
@@ -1,0 +1,117 @@
+import {createOptionParser} from "../src/framework/create-option-parser";
+
+describe('createOptionParser()', function () {
+    it('should accept empty spec', () => {
+        const parse = createOptionParser({});
+        expect(parse).toBeDefined();
+    });
+    describe('with invalid spec', () => {
+        it('should raise error for bad "requires"', () => {
+            const spec = {
+                a: {
+                    kind: "flag",
+                    description: "a",
+                    requires: ["b"],
+                },
+            } as const;
+            expect(() => createOptionParser(spec)).toThrowError(/Invalid parameter spec for parameter "a"/);
+        });
+        it('should raise error for bad "excludes"', () => {
+            const spec = {
+                a: {
+                    kind: "flag",
+                    description: "a",
+                    excludes: ["b"],
+                },
+            } as const;
+            expect(() => createOptionParser(spec)).toThrowError(/Invalid parameter spec for parameter "a"/);
+        });
+    });
+    describe("returned parser", () => {
+        it('should parse raw options', () => {
+            const parse = createOptionParser({
+                a: {
+                    kind: "flag",
+                    description: "a",
+                },
+                b: {
+                    kind: "flag",
+                    description: "b",
+                },
+            });
+            const opt = parse([{key: "a", value: ""}]);
+            expect(opt.a).toBe(true);
+            expect(opt.b).toBe(false);
+        });
+        it('should parse parameter string', () => {
+            const parse = createOptionParser({
+                a: {
+                    kind: "flag",
+                    description: "a",
+                },
+                b: {
+                    kind: "flag",
+                    description: "b",
+                },
+            });
+            const opt = parse("a");
+            expect(opt.a).toBe(true);
+            expect(opt.b).toBe(false);
+        });
+        it('should error for unknown option', () => {
+            const parse = createOptionParser({});
+            const raw = [{key: "a", value: ""}];
+            expect(() => parse(raw)).toThrowError(/Option "a" not recognized/);
+        });
+        it('should error for flag given twice', () => {
+            const parse = createOptionParser({
+                a: {
+                    kind: "flag",
+                    description: "a",
+                },
+            });
+            const raw = [{key: "a", value: ""}, {key: "a", value: ""}];
+            expect(() => parse(raw)).toThrowError(/Option "a" cannot be given more than once/);
+        });
+        it('should error for flag with value', () => {
+            const parse = createOptionParser({
+                a: {
+                    kind: "flag",
+                    description: "a",
+                },
+            });
+            const raw = [{key: "a", value: "b"}];
+            expect(() => parse(raw)).toThrowError(/Option "a" does not take a value/);
+        });
+        it('should error for violated "requires"', () => {
+            const parse = createOptionParser({
+                a: {
+                    kind: "flag",
+                    description: "a",
+                    requires: ["b"],
+                },
+                b: {
+                    kind: "flag",
+                    description: "b",
+                },
+            });
+            const raw = [{key: "a", value: ""}];
+            expect(() => parse(raw)).toThrowError(/Option "a" requires option "b"/);
+        });
+        it('should error for violated "excludes"', () => {
+            const parse = createOptionParser({
+                a: {
+                    kind: "flag",
+                    description: "a",
+                    excludes: ["b"],
+                },
+                b: {
+                    kind: "flag",
+                    description: "b",
+                },
+            });
+            const raw = [{key: "a", value: ""}, {key: "b", value: ""}];
+            expect(() => parse(raw)).toThrowError(/If option "a" is set, option "b" cannot be set/);
+        });
+    });
+});

--- a/packages/plugin/src/framework/create-option-parser.ts
+++ b/packages/plugin/src/framework/create-option-parser.ts
@@ -1,0 +1,150 @@
+
+/**
+ * Plugin options derived from an options spec.
+ */
+export type Options<S extends OptionSpecs> = {
+    [K in keyof S]: boolean;
+};
+
+type OptionSpecs = Record<string, OptionSpec>;
+
+type OptionSpec = {
+    kind: "flag";
+    /**
+     * A description for this option.
+     */
+    description: string;
+    /**
+     * If this option is set, setting any of the following other options is an error.
+     */
+    excludes?: readonly string[];
+    /**
+     * If this option is set, the following other options must be set as well.
+     */
+    requires?: readonly string[];
+};
+
+/**
+ * Function to parse raw options into typed options.
+ * May throw an error.
+ */
+export type OptionsParseFn<S extends OptionSpecs> = (input: string | {key: string, value: string}[]) => Options<S>;
+
+
+/**
+ * Create a function for parsing options from an options spec.
+ */
+export function createOptionParser<S extends OptionSpecs>(optionSpecs: S): OptionsParseFn<S> {
+    validateSpecs(optionSpecs);
+    return function parseOptions(input: string | {key: string, value: string}[]): Options<S> {
+        const options = defaultOptions(optionSpecs);
+        const rawOptions = typeof input == "string" ? splitParameter(input) : input;
+        const seen = new Set<keyof S>();
+        for (const rawOption of rawOptions ) {
+            if (!Object.prototype.hasOwnProperty.call(optionSpecs, rawOption.key)) {
+                throwOptionError(optionSpecs, `Option "${rawOption.key}" not recognized.`);
+            }
+            const key = rawOption.key as keyof S;
+            const spec = optionSpecs[key];
+            switch (spec.kind) {
+                case "flag":
+                    if (seen.has(key)) {
+                        throwOptionError(optionSpecs, `Option "${rawOption.key}" cannot be given more than once.`);
+                    }
+                    seen.add(key);
+                    if (rawOption.value.length > 0) {
+                        throwOptionError(optionSpecs, `Option "${key}" does not take a value.`);
+                    }
+                    options[key] = true;
+                    break;
+            }
+        }
+        validateOptions(options, optionSpecs);
+        return options;
+    }
+}
+
+/**
+ * Split a raw parameter string (e.g. "foo,bar=baz,qux=123") into an
+ * array of key/values.
+ */
+function splitParameter(
+    parameter: string,
+): { key: string; value: string }[] {
+    if (parameter.length == 0) {
+        return [];
+    }
+    return parameter.split(",").map((raw) => {
+        const i = raw.indexOf("=");
+        return {
+            key: i === -1 ? raw : raw.substring(0, i),
+            value: i === -1 ? "" : raw.substring(i + 1),
+        };
+    });
+}
+
+function defaultOptions<S extends OptionSpecs>(optionSpecs: S): Options<S> {
+    const o: Record<string, boolean> = {};
+    for (const [key, spec] of Object.entries(optionSpecs)) {
+        switch (spec.kind) {
+            case "flag":
+                o[key] = false;
+                break;
+        }
+    }
+    return o as Options<S>;
+}
+
+function validateOptions<S extends OptionSpecs>(options: Options<S>, optionSpecs: S) {
+    for (const [key, spec] of Object.entries(optionSpecs) as Iterable<[keyof S, OptionSpec]>) {
+        switch (spec.kind) {
+            case "flag":
+                const value: boolean = options[key];
+                if (value) {
+                    const requiredKeys = (spec.requires ?? []) as (keyof S)[];
+                    const excludedKeys = (spec.excludes ?? []) as (keyof S)[];
+                    const missingKeys = requiredKeys.filter(key => !options[key]);
+                    if (missingKeys.length > 0) {
+                        throwOptionError(optionSpecs, `Option "${key}" requires option "${missingKeys.join('", "')}" to be set.`);
+                    }
+                    const deniedKeys = excludedKeys.filter(key => options[key]);
+                    if (deniedKeys.length > 0) {
+                        throwOptionError(optionSpecs, `If option "${key}" is set, option "${deniedKeys.join('", "')}" cannot be set.`);
+                    }
+                }
+                break;
+        }
+    }
+}
+
+function validateSpecs(spec: OptionSpecs) {
+    const known = Object.keys(spec);
+    for (const [key, {excludes, requires}] of Object.entries(spec)) {
+        let r = requires?.filter(i => !known.includes(i)) ?? [];
+        if (r.length > 0) {
+            throw new Error(`Invalid parameter spec for parameter "${key}". "requires" points to unknown parameters: ${r.join(', ')}`);
+        }
+        let e = excludes?.filter(i => !known.includes(i)) ?? [];
+        if (e.length > 0) {
+            throw new Error(`Invalid parameter spec for parameter "${key}". "excludes" points to unknown parameters: ${e.join(', ')}`);
+        }
+    }
+}
+
+function throwOptionError(optionSpecs: OptionSpecs, error: string) {
+    let text = '';
+    text += error + '\n';
+    text += `\n`;
+    text += `Available options:\n`;
+    text += `\n`;
+    for (let [key, val] of Object.entries(optionSpecs)) {
+        text += `- "${key}"\n`;
+        for (let l of val.description.split('\n')) {
+            text += `  ${l}\n`;
+        }
+        text += `\n`;
+    }
+    let err = new Error(text);
+    err.name = `ParameterError`;
+    throw err;
+}

--- a/packages/plugin/src/our-options.ts
+++ b/packages/plugin/src/our-options.ts
@@ -6,6 +6,232 @@ import * as ts from "typescript";
 import {DescFile, DescService} from "@bufbuild/protobuf";
 import {Interpreter} from "./interpreter";
 import {FileOptions_OptimizeMode} from "@bufbuild/protobuf/wkt";
+import {createOptionParser} from "./framework/create-option-parser";
+
+/**
+ * Parsed Protobuf-TS plugin options.
+ */
+export type ProtobufTsPluginOptions = ReturnType<typeof parseOptions>;
+
+/**
+ * Parse Protobuf-TS plugin options from raw options.
+ */
+export const parseOptions = createOptionParser({
+    // long type
+    long_type_string: {
+        kind: "flag",
+        description: "Sets jstype = JS_STRING for message fields with 64 bit integral values. \n" +
+            "The default behaviour is to use native `bigint`. \n" +
+            "Only applies to fields that do *not* use the option `jstype`.",
+        excludes: ["long_type_number", "long_type_bigint"],
+    },
+    long_type_number: {
+        kind: "flag",
+        description: "Sets jstype = JS_NUMBER for message fields with 64 bit integral values. \n" +
+            "The default behaviour is to use native `bigint`. \n" +
+            "Only applies to fields that do *not* use the option `jstype`.",
+        excludes: ["long_type_string", "long_type_bigint"],
+    },
+    long_type_bigint: {
+        kind: "flag",
+        description: "Sets jstype = JS_NORMAL for message fields with 64 bit integral values. \n" +
+            "This is the default behavior. \n" +
+            "Only applies to fields that do *not* use the option `jstype`.",
+        excludes: ["long_type_string", "long_type_number"],
+    },
+
+    // misc
+    generate_dependencies: {
+        kind: "flag",
+        description: "By default, only the PROTO_FILES passed as input to protoc are generated, \n" +
+            "not the files they import (with the exception of well-known types, which are \n" +
+            "always generated when imported). \n"+
+            "Set this option to generate code for dependencies too.",
+    },
+    force_exclude_all_options: {
+        kind: "flag",
+        description: "By default, custom options are included in the metadata and can be blacklisted \n" +
+            "with our option (ts.exclude_options). Set this option if you are certain you \n" +
+            "do not want to include any options at all.",
+    },
+    keep_enum_prefix: {
+        kind: "flag",
+        description: "By default, if all enum values share a prefix that corresponds with the enum's \n" +
+            "name, the prefix is dropped from the value names. Set this option to disable \n" +
+            "this behavior.",
+    },
+    use_proto_field_name: {
+        kind: "flag",
+        description: "By default interface fields use lowerCamelCase names by transforming proto field\n" +
+            "names to follow common style convention for TypeScript. Set this option to preserve\n" +
+            "original proto field names in generated interfaces.",
+    },
+    ts_nocheck: {
+        kind: "flag",
+        description: "Generate a @ts-nocheck annotation at the top of each file. This will become the \n" +
+            "default behaviour in the next major release.",
+        excludes: ['disable_ts_nocheck'],
+    },
+    disable_ts_nocheck: {
+        kind: "flag",
+        description: "Do not generate a @ts-nocheck annotation at the top of each file. Since this is \n" +
+            "the default behaviour, this option has no effect.",
+        excludes: ['ts_nocheck'],
+    },
+    eslint_disable: {
+        kind: "flag",
+        description: "Generate a eslint-disable comment at the top of each file. This will become the \n" +
+            "default behaviour in the next major release.",
+        excludes: ['no_eslint_disable'],
+    },
+    no_eslint_disable: {
+        kind: "flag",
+        description: "Do not generate a eslint-disable comment at the top of each file. Since this is \n" +
+            "the default behaviour, this option has no effect.",
+        excludes: ['eslint_disable'],
+    },
+    add_pb_suffix: {
+        kind: "flag",
+        description: "Adds the suffix `_pb` to the names of all generated files. This will become the \n" +
+            "default behaviour in the next major release.",
+    },
+
+    // output types
+    output_typescript: {
+        kind: "flag",
+        description: "Output TypeScript files. This is the default behavior.",
+        excludes: ["output_javascript", "output_javascript_es2015", "output_javascript_es2016", "output_javascript_es2017", "output_javascript_es2018", "output_javascript_es2019", "output_javascript_es2020"]
+    },
+    output_javascript: {
+        kind: "flag",
+        description: "Output JavaScript for the currently recommended target ES2020. The target may \n" +
+            "change with a major release of protobuf-ts. \n" +
+            "Along with JavaScript files, this always outputs TypeScript declaration files.",
+        excludes: ["output_typescript", "output_javascript_es2015", "output_javascript_es2016", "output_javascript_es2017", "output_javascript_es2018", "output_javascript_es2019", "output_javascript_es2020"]
+    },
+    output_javascript_es2015: {
+        kind: "flag",
+        description: "Output JavaScript for the ES2015 target.",
+        excludes: ["output_typescript", "output_javascript_es2016", "output_javascript_es2017", "output_javascript_es2018", "output_javascript_es2019", "output_javascript_es2020"]
+    },
+    output_javascript_es2016: {
+        kind: "flag",
+        description: "Output JavaScript for the ES2016 target.",
+        excludes: ["output_typescript", "output_javascript_es2015", "output_javascript_es2017", "output_javascript_es2018", "output_javascript_es2019", "output_javascript_es2020"]
+    },
+    output_javascript_es2017: {
+        kind: "flag",
+        description: "Output JavaScript for the ES2017 target.",
+        excludes: ["output_typescript", "output_javascript_es2015", "output_javascript_es2016", "output_javascript_es2018", "output_javascript_es2019", "output_javascript_es2020"]
+    },
+    output_javascript_es2018: {
+        kind: "flag",
+        description: "Output JavaScript for the ES2018 target.",
+        excludes: ["output_typescript", "output_javascript_es2015", "output_javascript_es2016", "output_javascript_es2017", "output_javascript_es2019", "output_javascript_es2020"]
+    },
+    output_javascript_es2019: {
+        kind: "flag",
+        description: "Output JavaScript for the ES2019 target.",
+        excludes: ["output_typescript", "output_javascript_es2015", "output_javascript_es2016", "output_javascript_es2017", "output_javascript_es2018", "output_javascript_es2020"]
+    },
+    output_javascript_es2020: {
+        kind: "flag",
+        description: "Output JavaScript for the ES2020 target.",
+        excludes: ["output_typescript", "output_javascript_es2015", "output_javascript_es2016", "output_javascript_es2017", "output_javascript_es2018", "output_javascript_es2019"]
+    },
+    output_legacy_commonjs: {
+        kind: "flag",
+        description: "Use CommonJS instead of the default ECMAScript module system.",
+        excludes: ["output_typescript"]
+    },
+
+    // client
+    client_none: {
+        kind: "flag",
+        description: "Do not generate rpc clients. \n" +
+            "Only applies to services that do *not* use the option `ts.client`. \n" +
+            "If you do not want rpc clients at all, use `force_client_none`.",
+        excludes: ['client_generic', 'client_grpc1'],
+    },
+    client_generic: {
+        kind: "flag",
+        description: "Only applies to services that do *not* use the option `ts.client`. \n" +
+            "Since GENERIC_CLIENT is the default, this option has no effect.",
+        excludes: ['client_none', 'client_grpc1', 'force_client_none', 'force_disable_services'],
+    },
+    client_grpc1: {
+        kind: "flag",
+        description: "Generate a client using @grpc/grpc-js (major version 1). \n" +
+            "Only applies to services that do *not* use the option `ts.client`." ,
+        excludes: ['client_none', 'client_generic', 'force_client_none', 'force_disable_services'],
+    },
+    force_client_none: {
+        kind: "flag",
+        description: "Do not generate rpc clients, ignore options in proto files.",
+        excludes: ['client_none', 'client_generic', 'client_grpc1'],
+    },
+
+    // server
+    server_none: {
+        kind: "flag",
+        description: "Do not generate rpc servers. \n" +
+            "This is the default behaviour, but only applies to services that do \n" +
+            "*not* use the option `ts.server`. \n" +
+            "If you do not want servers at all, use `force_server_none`.",
+        excludes: ['server_grpc1'],
+    },
+    server_generic: {
+        kind: "flag",
+        description: "Generate a generic server interface. Adapters are used to serve the service, \n" +
+            "for example @protobuf-ts/grpc-backend for gRPC. \n" +
+            "Note that this is an experimental feature and may change with a minor release. \n" +
+            "Only applies to services that do *not* use the option `ts.server`.",
+        excludes: ['server_none', 'force_server_none', 'force_disable_services'],
+    },
+    server_grpc1: {
+        kind: "flag",
+        description: "Generate a server interface and definition for use with @grpc/grpc-js \n" +
+            "(major version 1). \n" +
+            "Only applies to services that do *not* use the option `ts.server`.",
+        excludes: ['server_none', 'force_server_none', 'force_disable_services'],
+    },
+    force_server_none: {
+        kind: "flag",
+        description: "Do not generate rpc servers, ignore options in proto files.",
+    },
+
+    force_disable_services: {
+        kind: "flag",
+        description: "Do not generate anything for service definitions, and ignore options in proto \n" +
+            "files. This is the same as setting both options `force_server_none` and \n" +
+            "`force_client_none`, but also stops generating service metadata.",
+        excludes: ['client_generic', 'client_grpc1', 'server_generic', 'server_grpc1']
+    },
+
+    // optimization
+    optimize_speed: {
+        kind: "flag",
+        description: "Sets optimize_for = SPEED for proto files that have no file option \n" +
+            "'option optimize_for'. Since SPEED is the default, this option has no effect.",
+        excludes: ['force_optimize_speed'],
+    },
+    optimize_code_size: {
+        kind: "flag",
+        description: "Sets optimize_for = CODE_SIZE for proto files that have no file option \n" +
+            "'option optimize_for'.",
+        excludes: ['force_optimize_speed'],
+    },
+    force_optimize_code_size: {
+        kind: "flag",
+        description: "Forces optimize_for = CODE_SIZE for all proto files, ignore file options.",
+        excludes: ['optimize_code_size', 'force_optimize_speed']
+    },
+    force_optimize_speed: {
+        kind: "flag",
+        description: "Forces optimize_for = SPEED for all proto files, ignore file options.",
+        excludes: ['optimize_code_size', 'force_optimize_code_size']
+    },
+});
 
 
 /**
@@ -129,38 +355,7 @@ export interface InternalOptions {
 }
 
 export function makeInternalOptions(
-    params?: {
-        generate_dependencies: boolean,
-        long_type_string: boolean,
-        long_type_number: boolean,
-        force_exclude_all_options: boolean,
-        keep_enum_prefix: boolean,
-        use_proto_field_name: boolean,
-        ts_nocheck: boolean,
-        eslint_disable: boolean,
-        force_optimize_code_size: boolean,
-        force_optimize_speed: boolean,
-        optimize_code_size: boolean,
-        force_server_none: boolean,
-        server_none: boolean,
-        server_generic: boolean
-        server_grpc1: boolean
-        force_client_none: boolean,
-        client_generic: boolean,
-        client_none: boolean,
-        client_grpc1: boolean,
-        add_pb_suffix: boolean,
-        force_disable_services: boolean;
-        output_typescript: boolean,
-        output_javascript: boolean,
-        output_javascript_es2015: boolean,
-        output_javascript_es2016: boolean,
-        output_javascript_es2017: boolean,
-        output_javascript_es2018: boolean,
-        output_javascript_es2019: boolean,
-        output_javascript_es2020: boolean,
-        output_legacy_commonjs: boolean,
-    },
+    params: ProtobufTsPluginOptions,
     pluginCredit?: string,
 ): InternalOptions {
     type Writeable<T> = { -readonly [P in keyof T]: T[P] };
@@ -193,85 +388,85 @@ export function makeInternalOptions(
     if (pluginCredit) {
         o.pluginCredit = pluginCredit;
     }
-    if (params?.generate_dependencies) {
+    if (params.generate_dependencies) {
         o.generateDependencies = true;
     }
-    if (params?.force_exclude_all_options) {
+    if (params.force_exclude_all_options) {
         o.forceExcludeAllOptions = true;
     }
-    if (params?.keep_enum_prefix) {
+    if (params.keep_enum_prefix) {
         o.keepEnumPrefix = true;
     }
-    if (params?.use_proto_field_name) {
+    if (params.use_proto_field_name) {
         o.useProtoFieldName = true;
     }
-    if (params?.ts_nocheck) {
+    if (params.ts_nocheck) {
         o.tsNoCheck = true;
     }
-    if (params?.eslint_disable) {
+    if (params.eslint_disable) {
         o.esLintDisable = true;
     }
-    if (params?.long_type_string) {
+    if (params.long_type_string) {
         o.normalLongType = rt.LongType.STRING;
     }
-    if (params?.long_type_number) {
+    if (params.long_type_number) {
         o.normalLongType = rt.LongType.NUMBER;
     }
-    if (params?.optimize_code_size) {
+    if (params.optimize_code_size) {
         o.normalOptimizeMode = FileOptions_OptimizeMode.CODE_SIZE;
     }
-    if (params?.force_optimize_speed) {
+    if (params.force_optimize_speed) {
         o.forcedOptimizeMode = FileOptions_OptimizeMode.SPEED;
     }
-    if (params?.force_optimize_code_size) {
+    if (params.force_optimize_code_size) {
         o.forcedOptimizeMode = FileOptions_OptimizeMode.CODE_SIZE;
     }
-    if (params?.client_none) {
+    if (params.client_none) {
         o.normalClientStyle = ClientStyle.NO_CLIENT;
     }
-    if (params?.client_grpc1) {
+    if (params.client_grpc1) {
         o.normalClientStyle = ClientStyle.GRPC1_CLIENT;
     }
-    if (params?.force_client_none) {
+    if (params.force_client_none) {
         o.forcedClientStyle = ClientStyle.NO_CLIENT;
     }
-    if (params?.server_generic) {
+    if (params.server_generic) {
         o.normalServerStyle = ServerStyle.GENERIC_SERVER;
     }
-    if (params?.server_grpc1) {
+    if (params.server_grpc1) {
         o.normalServerStyle = ServerStyle.GRPC1_SERVER;
     }
-    if (params?.force_server_none) {
+    if (params.force_server_none) {
         o.forcedServerStyle = ServerStyle.NO_SERVER;
     }
-    if (params?.add_pb_suffix) {
+    if (params.add_pb_suffix) {
         o.addPbSuffix = true;
     }
-    if (params?.force_disable_services) {
+    if (params.force_disable_services) {
       o.forceDisableServices = true;
     }
-    if (params?.output_javascript) {
+    if (params.output_javascript) {
         o.transpileTarget = ts.ScriptTarget.ES2020;
     }
-    if (params?.output_javascript_es2015) {
+    if (params.output_javascript_es2015) {
         o.transpileTarget = ts.ScriptTarget.ES2015;
     }
-    if (params?.output_javascript_es2016) {
+    if (params.output_javascript_es2016) {
         o.transpileTarget = ts.ScriptTarget.ES2016;
     }
-    if (params?.output_javascript_es2017) {
+    if (params.output_javascript_es2017) {
         o.transpileTarget = ts.ScriptTarget.ES2017;
     }
-    if (params?.output_javascript_es2018) {
+    if (params.output_javascript_es2018) {
         o.transpileTarget = ts.ScriptTarget.ES2018;
     }
-    if (params?.output_javascript_es2019) {
+    if (params.output_javascript_es2019) {
         o.transpileTarget = ts.ScriptTarget.ES2019;
     }
-    if (params?.output_javascript_es2020) {
+    if (params.output_javascript_es2020) {
         o.transpileTarget = ts.ScriptTarget.ES2020;
     }
-    if (params?.output_legacy_commonjs) {
+    if (params.output_legacy_commonjs) {
         o.transpileModule = ts.ModuleKind.CommonJS;
     }
     return o;


### PR DESCRIPTION
This moves the logic for parsing plugin options received through CodeGeneratorRequest.parameter from plugin-base.ts to a separate file.

The new function createOptionParser returns a function that parses options from either a parameter string, or "raw options", a type that is compatible with parseOptions in @bufbuild/protoplugin (`{key: string, value: string}[]`).