### PR TITLE
Simplify internal handling of protobuf-ts.proto options

### DIFF
--- a/packages/plugin/src/file-table.ts
+++ b/packages/plugin/src/file-table.ts
@@ -1,5 +1,5 @@
 import {DescFile} from "@bufbuild/protobuf";
-import {InternalOptions} from "./our-options";
+import {Options} from "./options";
 import {OutFile} from "./out-file";
 
 
@@ -13,7 +13,7 @@ export class FileTable {
 
 
     constructor(
-        private readonly options: InternalOptions,
+        private readonly options: Options,
         clashResolver?: ClashResolver,
     ) {
         this.clashResolver = clashResolver ?? FileTable.defaultClashResolver;

--- a/packages/plugin/src/options.ts
+++ b/packages/plugin/src/options.ts
@@ -233,7 +233,7 @@ const parseParameter = createOptionParser({
 /**
  * Internal settings for the file generation.
  */
-export interface InternalOptions {
+export interface Options {
     readonly generateDependencies: boolean;
     readonly pluginCredit?: string;
     readonly normalLongType: rt.LongType,
@@ -264,10 +264,10 @@ export interface InternalOptions {
 export function parseOptions(
     parameter: string,
     pluginCredit?: string,
-): InternalOptions {
+): Options {
     const params = parseParameter(parameter);
     type Writeable<T> = { -readonly [P in keyof T]: T[P] };
-    const o: Writeable<InternalOptions> = {
+    const o: Writeable<Options> = {
         generateDependencies: false,
         normalLongType: rt.LongType.BIGINT,
         normalOptimizeMode: FileOptions_OptimizeMode.SPEED,

--- a/packages/plugin/src/our-options.ts
+++ b/packages/plugin/src/our-options.ts
@@ -12,7 +12,7 @@ import {client, server, ServerStyle, ClientStyle} from "./gen/protobuf-ts_pb";
 /**
  * Parse Protobuf-TS plugin options from raw options.
  */
-const parsePluginOptions = createOptionParser({
+const parseParameter = createOptionParser({
     // long type
     long_type_string: {
         kind: "flag",
@@ -265,7 +265,7 @@ export function parseOptions(
     parameter: string,
     pluginCredit?: string,
 ): InternalOptions {
-    const i = parsePluginOptions(parameter);
+    const params = parseParameter(parameter);
     type Writeable<T> = { -readonly [P in keyof T]: T[P] };
     const o: Writeable<InternalOptions> = {
         generateDependencies: false,
@@ -354,85 +354,85 @@ export function parseOptions(
     if (pluginCredit) {
         o.pluginCredit = pluginCredit;
     }
-    if (i.generate_dependencies) {
+    if (params.generate_dependencies) {
         o.generateDependencies = true;
     }
-    if (i.force_exclude_all_options) {
+    if (params.force_exclude_all_options) {
         o.forceExcludeAllOptions = true;
     }
-    if (i.keep_enum_prefix) {
+    if (params.keep_enum_prefix) {
         o.keepEnumPrefix = true;
     }
-    if (i.use_proto_field_name) {
+    if (params.use_proto_field_name) {
         o.useProtoFieldName = true;
     }
-    if (i.ts_nocheck) {
+    if (params.ts_nocheck) {
         o.tsNoCheck = true;
     }
-    if (i.eslint_disable) {
+    if (params.eslint_disable) {
         o.esLintDisable = true;
     }
-    if (i.long_type_string) {
+    if (params.long_type_string) {
         o.normalLongType = rt.LongType.STRING;
     }
-    if (i.long_type_number) {
+    if (params.long_type_number) {
         o.normalLongType = rt.LongType.NUMBER;
     }
-    if (i.optimize_code_size) {
+    if (params.optimize_code_size) {
         o.normalOptimizeMode = FileOptions_OptimizeMode.CODE_SIZE;
     }
-    if (i.force_optimize_speed) {
+    if (params.force_optimize_speed) {
         o.forcedOptimizeMode = FileOptions_OptimizeMode.SPEED;
     }
-    if (i.force_optimize_code_size) {
+    if (params.force_optimize_code_size) {
         o.forcedOptimizeMode = FileOptions_OptimizeMode.CODE_SIZE;
     }
-    if (i.client_none) {
+    if (params.client_none) {
         o.normalClientStyle = ClientStyle.NO_CLIENT;
     }
-    if (i.client_grpc1) {
+    if (params.client_grpc1) {
         o.normalClientStyle = ClientStyle.GRPC1_CLIENT;
     }
-    if (i.force_client_none) {
+    if (params.force_client_none) {
         o.forcedClientStyle = ClientStyle.NO_CLIENT;
     }
-    if (i.server_generic) {
+    if (params.server_generic) {
         o.normalServerStyle = ServerStyle.GENERIC_SERVER;
     }
-    if (i.server_grpc1) {
+    if (params.server_grpc1) {
         o.normalServerStyle = ServerStyle.GRPC1_SERVER;
     }
-    if (i.force_server_none) {
+    if (params.force_server_none) {
         o.forcedServerStyle = ServerStyle.NO_SERVER;
     }
-    if (i.add_pb_suffix) {
+    if (params.add_pb_suffix) {
         o.addPbSuffix = true;
     }
-    if (i.force_disable_services) {
+    if (params.force_disable_services) {
       o.forceDisableServices = true;
     }
-    if (i.output_javascript) {
+    if (params.output_javascript) {
         o.transpileTarget = ts.ScriptTarget.ES2020;
     }
-    if (i.output_javascript_es2015) {
+    if (params.output_javascript_es2015) {
         o.transpileTarget = ts.ScriptTarget.ES2015;
     }
-    if (i.output_javascript_es2016) {
+    if (params.output_javascript_es2016) {
         o.transpileTarget = ts.ScriptTarget.ES2016;
     }
-    if (i.output_javascript_es2017) {
+    if (params.output_javascript_es2017) {
         o.transpileTarget = ts.ScriptTarget.ES2017;
     }
-    if (i.output_javascript_es2018) {
+    if (params.output_javascript_es2018) {
         o.transpileTarget = ts.ScriptTarget.ES2018;
     }
-    if (i.output_javascript_es2019) {
+    if (params.output_javascript_es2019) {
         o.transpileTarget = ts.ScriptTarget.ES2019;
     }
-    if (i.output_javascript_es2020) {
+    if (params.output_javascript_es2020) {
         o.transpileTarget = ts.ScriptTarget.ES2020;
     }
-    if (i.output_legacy_commonjs) {
+    if (params.output_legacy_commonjs) {
         o.transpileModule = ts.ModuleKind.CommonJS;
     }
     return o;

--- a/packages/plugin/src/our-options.ts
+++ b/packages/plugin/src/our-options.ts
@@ -3,20 +3,16 @@
  */
 import * as rt from "@protobuf-ts/runtime";
 import * as ts from "typescript";
-import {DescFile, DescService} from "@bufbuild/protobuf";
-import {Interpreter} from "./interpreter";
+import {DescFile, DescService, getOption} from "@bufbuild/protobuf";
 import {FileOptions_OptimizeMode} from "@bufbuild/protobuf/wkt";
 import {createOptionParser} from "./framework/create-option-parser";
+import {client, server, ServerStyle, ClientStyle} from "./gen/protobuf-ts_pb";
 
-/**
- * Parsed Protobuf-TS plugin options.
- */
-export type ProtobufTsPluginOptions = ReturnType<typeof parseOptions>;
 
 /**
  * Parse Protobuf-TS plugin options from raw options.
  */
-export const parseOptions = createOptionParser({
+const parsePluginOptions = createOptionParser({
     // long type
     long_type_string: {
         kind: "flag",
@@ -235,98 +231,6 @@ export const parseOptions = createOptionParser({
 
 
 /**
- * Custom file options interpreted by @protobuf-ts/plugin
- * The extensions are declared in protobuf-ts.proto
- */
-export interface OurFileOptions {
-
-    /**
-     * Exclude field or method options from being emitted in reflection data.
-     *
-     * For example, to stop the data of the "google.api.http" method option
-     * from being exported in the reflection information, set the following
-     * file option:
-     *
-     * ```proto
-     * option (ts.exclude_options) = "google.api.http";
-     * ```
-     *
-     * The option can be set multiple times.
-     * `*` serves as a wildcard and will greedily match anything.
-     */
-    readonly ["ts.exclude_options"]: readonly string[];
-}
-
-
-/**
- * Custom service options interpreted by @protobuf-ts/plugin
- */
-export interface OurServiceOptions {
-
-    /**
-     * Generate a client for this service with this style.
-     * Can be set multiple times to generate several styles.
-     */
-    readonly ["ts.client"]: ClientStyle[];
-
-    /**
-     * Generate a server for this service with this style.
-     * Can be set multiple times to generate several styles.
-     */
-    readonly ["ts.server"]: ServerStyle[];
-}
-
-/**
- * The available client styles from @protobuf-ts/plugin
- * The extensions are declared in protobuf-ts.proto
- */
-export enum ClientStyle {
-
-    /**
-     * Do not emit a client for this service.
-     */
-    NO_CLIENT = 0,
-
-    /**
-     * Use the call implementations of @protobuf-ts/runtime-rpc.
-     * This is the default behaviour.
-     */
-    GENERIC_CLIENT = 1,
-
-    /**
-     * Generate a client using @grpc/grpc-js (major version 1).
-     */
-    GRPC1_CLIENT = 4
-}
-
-
-/**
- * The available server styles from @protobuf-ts/plugin
- * The extensions are declared in protobuf-ts.proto
- */
-export enum ServerStyle {
-
-    /**
-     * Do not emit a server for this service.
-     * This is the default behaviour.
-     */
-    NO_SERVER = 0,
-
-    /**
-     * Generate a generic server interface.
-     * Adapters be used to serve the service, for example @protobuf-ts/grpc-backend
-     * for gRPC.
-     */
-    GENERIC_SERVER = 1,
-
-    /**
-     * Generate a server for @grpc/grpc-js (major version 1).
-     */
-    GRPC1_SERVER = 2,
-}
-
-
-/**
  * Internal settings for the file generation.
  */
 export interface InternalOptions {
@@ -352,200 +256,185 @@ export interface InternalOptions {
     readonly transpileModule: ts.ModuleKind,
     readonly forceDisableServices: boolean;
     readonly addPbSuffix: boolean;
+    getOptimizeMode(file: DescFile): FileOptions_OptimizeMode;
+    getClientStyles(descriptor: DescService): ClientStyle[];
+    getServerStyles(descriptor: DescService): ServerStyle[];
 }
 
-export function makeInternalOptions(
-    params: ProtobufTsPluginOptions,
+export function parseOptions(
+    parameter: string,
     pluginCredit?: string,
 ): InternalOptions {
+    const i = parsePluginOptions(parameter);
     type Writeable<T> = { -readonly [P in keyof T]: T[P] };
-    const o = Object.assign<Partial<InternalOptions>, InternalOptions>(
-        {},
-        {
-            generateDependencies: false,
-            normalLongType: rt.LongType.BIGINT,
-            normalOptimizeMode: FileOptions_OptimizeMode.SPEED,
-            forcedOptimizeMode: undefined,
-            normalClientStyle: ClientStyle.GENERIC_CLIENT,
-            forcedClientStyle: undefined,
-            normalServerStyle: ServerStyle.NO_SERVER,
-            forcedServerStyle: undefined,
-            synthesizeEnumZeroValue: 'UNSPECIFIED$',
-            oneofKindDiscriminator: 'oneofKind',
-            runtimeRpcImportPath: '@protobuf-ts/runtime-rpc',
-            runtimeImportPath: '@protobuf-ts/runtime',
-            forceExcludeAllOptions: false,
-            keepEnumPrefix: false,
-            useProtoFieldName: false,
-            tsNoCheck: false,
-            esLintDisable: false,
-            transpileTarget: undefined,
-            transpileModule: ts.ModuleKind.ES2015,
-            forceDisableServices: false,
-            addPbSuffix: false,
+    const o: Writeable<InternalOptions> = {
+        generateDependencies: false,
+        normalLongType: rt.LongType.BIGINT,
+        normalOptimizeMode: FileOptions_OptimizeMode.SPEED,
+        forcedOptimizeMode: undefined,
+        normalClientStyle: ClientStyle.GENERIC_CLIENT,
+        forcedClientStyle: undefined,
+        normalServerStyle: ServerStyle.NO_SERVER,
+        forcedServerStyle: undefined,
+        synthesizeEnumZeroValue: 'UNSPECIFIED$',
+        oneofKindDiscriminator: 'oneofKind',
+        runtimeRpcImportPath: '@protobuf-ts/runtime-rpc',
+        runtimeImportPath: '@protobuf-ts/runtime',
+        forceExcludeAllOptions: false,
+        keepEnumPrefix: false,
+        useProtoFieldName: false,
+        tsNoCheck: false,
+        esLintDisable: false,
+        transpileTarget: undefined,
+        transpileModule: ts.ModuleKind.ES2015,
+        forceDisableServices: false,
+        addPbSuffix: false,
+        getOptimizeMode(file: DescFile): FileOptions_OptimizeMode {
+            if (this.forcedOptimizeMode !== undefined) {
+                return this.forcedOptimizeMode;
+            }
+            if (file.proto.options?.optimizeFor !== undefined) {
+                return file.proto.options.optimizeFor;
+            }
+            return this.normalOptimizeMode;
         },
-    ) as Writeable<InternalOptions>;
+        getClientStyles(descriptor: DescService): ClientStyle[] {
+            const opt = getOption(descriptor, client);
+
+            // always check service options valid
+            if (opt.includes(ClientStyle.NO_CLIENT) && opt.some(s => s !== ClientStyle.NO_CLIENT)) {
+                // TODO
+                //let err = new Error(`You provided invalid options for ${this.stringFormat.formatQualifiedName(descriptor, true)}. If you set (ts.client) = NO_CLIENT, you cannot set additional client styles.`);
+                let err = new Error(`You provided invalid options for ${descriptor.typeName}. If you set (ts.client) = NO_CLIENT, you cannot set additional client styles.`);
+                err.name = `PluginMessageError`;
+                throw err;
+            }
+
+            if (this.forcedClientStyle !== undefined) {
+                return [this.forcedClientStyle];
+            }
+
+            // look for service options
+            if (opt.length) {
+                return opt
+                    .filter(s => s !== ClientStyle.NO_CLIENT)
+                    .filter((value, index, array) => array.indexOf(value) === index);
+            }
+
+            // fall back to normal style set by option
+            return [this.normalClientStyle];
+        },
+        getServerStyles(descriptor: DescService): ServerStyle[] {
+            const opt = getOption(descriptor, server);
+
+            // always check service options valid
+            if (opt.includes(ServerStyle.NO_SERVER) && opt.some(s => s !== ServerStyle.NO_SERVER)) {
+                // TODO
+                //let err = new Error(`You provided invalid options for ${this.stringFormat.formatQualifiedName(descriptor, true)}. If you set (ts.server) = NO_SERVER, you cannot set additional server styles.`);
+                let err = new Error(`You provided invalid options for ${descriptor.typeName}. If you set (ts.server) = NO_SERVER, you cannot set additional server styles.`);
+                err.name = `PluginMessageError`;
+                throw err;
+            }
+
+            if (this.forcedServerStyle !== undefined) {
+                return [this.forcedServerStyle];
+            }
+
+            // look for service options
+            if (opt.length) {
+                return opt
+                    .filter(s => s !== ServerStyle.NO_SERVER)
+                    .filter((value, index, array) => array.indexOf(value) === index);
+            }
+
+            // fall back to normal style set by option
+            return [this.normalServerStyle];
+        }
+    };
     if (pluginCredit) {
         o.pluginCredit = pluginCredit;
     }
-    if (params.generate_dependencies) {
+    if (i.generate_dependencies) {
         o.generateDependencies = true;
     }
-    if (params.force_exclude_all_options) {
+    if (i.force_exclude_all_options) {
         o.forceExcludeAllOptions = true;
     }
-    if (params.keep_enum_prefix) {
+    if (i.keep_enum_prefix) {
         o.keepEnumPrefix = true;
     }
-    if (params.use_proto_field_name) {
+    if (i.use_proto_field_name) {
         o.useProtoFieldName = true;
     }
-    if (params.ts_nocheck) {
+    if (i.ts_nocheck) {
         o.tsNoCheck = true;
     }
-    if (params.eslint_disable) {
+    if (i.eslint_disable) {
         o.esLintDisable = true;
     }
-    if (params.long_type_string) {
+    if (i.long_type_string) {
         o.normalLongType = rt.LongType.STRING;
     }
-    if (params.long_type_number) {
+    if (i.long_type_number) {
         o.normalLongType = rt.LongType.NUMBER;
     }
-    if (params.optimize_code_size) {
+    if (i.optimize_code_size) {
         o.normalOptimizeMode = FileOptions_OptimizeMode.CODE_SIZE;
     }
-    if (params.force_optimize_speed) {
+    if (i.force_optimize_speed) {
         o.forcedOptimizeMode = FileOptions_OptimizeMode.SPEED;
     }
-    if (params.force_optimize_code_size) {
+    if (i.force_optimize_code_size) {
         o.forcedOptimizeMode = FileOptions_OptimizeMode.CODE_SIZE;
     }
-    if (params.client_none) {
+    if (i.client_none) {
         o.normalClientStyle = ClientStyle.NO_CLIENT;
     }
-    if (params.client_grpc1) {
+    if (i.client_grpc1) {
         o.normalClientStyle = ClientStyle.GRPC1_CLIENT;
     }
-    if (params.force_client_none) {
+    if (i.force_client_none) {
         o.forcedClientStyle = ClientStyle.NO_CLIENT;
     }
-    if (params.server_generic) {
+    if (i.server_generic) {
         o.normalServerStyle = ServerStyle.GENERIC_SERVER;
     }
-    if (params.server_grpc1) {
+    if (i.server_grpc1) {
         o.normalServerStyle = ServerStyle.GRPC1_SERVER;
     }
-    if (params.force_server_none) {
+    if (i.force_server_none) {
         o.forcedServerStyle = ServerStyle.NO_SERVER;
     }
-    if (params.add_pb_suffix) {
+    if (i.add_pb_suffix) {
         o.addPbSuffix = true;
     }
-    if (params.force_disable_services) {
+    if (i.force_disable_services) {
       o.forceDisableServices = true;
     }
-    if (params.output_javascript) {
+    if (i.output_javascript) {
         o.transpileTarget = ts.ScriptTarget.ES2020;
     }
-    if (params.output_javascript_es2015) {
+    if (i.output_javascript_es2015) {
         o.transpileTarget = ts.ScriptTarget.ES2015;
     }
-    if (params.output_javascript_es2016) {
+    if (i.output_javascript_es2016) {
         o.transpileTarget = ts.ScriptTarget.ES2016;
     }
-    if (params.output_javascript_es2017) {
+    if (i.output_javascript_es2017) {
         o.transpileTarget = ts.ScriptTarget.ES2017;
     }
-    if (params.output_javascript_es2018) {
+    if (i.output_javascript_es2018) {
         o.transpileTarget = ts.ScriptTarget.ES2018;
     }
-    if (params.output_javascript_es2019) {
+    if (i.output_javascript_es2019) {
         o.transpileTarget = ts.ScriptTarget.ES2019;
     }
-    if (params.output_javascript_es2020) {
+    if (i.output_javascript_es2020) {
         o.transpileTarget = ts.ScriptTarget.ES2020;
     }
-    if (params.output_legacy_commonjs) {
+    if (i.output_legacy_commonjs) {
         o.transpileModule = ts.ModuleKind.CommonJS;
     }
     return o;
-}
-
-
-export class OptionResolver {
-
-
-    constructor(
-        private readonly interpreter: Interpreter,
-        private readonly options: InternalOptions,
-    ) {
-    }
-
-    getOptimizeMode(file: DescFile): FileOptions_OptimizeMode {
-        if (this.options.forcedOptimizeMode !== undefined) {
-            return this.options.forcedOptimizeMode;
-        }
-        if (file.proto.options?.optimizeFor !== undefined) {
-            return file.proto.options.optimizeFor;
-        }
-        return this.options.normalOptimizeMode;
-    }
-
-    getClientStyles(descriptor: DescService): ClientStyle[] {
-        const opt = this.interpreter.readOurServiceOptions(descriptor)["ts.client"];
-
-        // always check service options valid
-        if (opt.includes(ClientStyle.NO_CLIENT) && opt.some(s => s !== ClientStyle.NO_CLIENT)) {
-            descriptor.typeName
-            // TODO
-            //let err = new Error(`You provided invalid options for ${this.stringFormat.formatQualifiedName(descriptor, true)}. If you set (ts.client) = NO_CLIENT, you cannot set additional client styles.`);
-            let err = new Error(`You provided invalid options for ${descriptor.typeName}. If you set (ts.client) = NO_CLIENT, you cannot set additional client styles.`);
-            err.name = `PluginMessageError`;
-            throw err;
-        }
-
-        if (this.options.forcedClientStyle !== undefined) {
-            return [this.options.forcedClientStyle];
-        }
-
-        // look for service options
-        if (opt.length) {
-            return opt
-                .filter(s => s !== ClientStyle.NO_CLIENT)
-                .filter((value, index, array) => array.indexOf(value) === index);
-        }
-
-        // fall back to normal style set by option
-        return [this.options.normalClientStyle];
-    }
-
-    getServerStyles(descriptor: DescService): ServerStyle[] {
-        const opt = this.interpreter.readOurServiceOptions(descriptor)["ts.server"];
-
-        // always check service options valid
-        if (opt.includes(ServerStyle.NO_SERVER) && opt.some(s => s !== ServerStyle.NO_SERVER)) {
-            // TODO
-            //let err = new Error(`You provided invalid options for ${this.stringFormat.formatQualifiedName(descriptor, true)}. If you set (ts.server) = NO_SERVER, you cannot set additional server styles.`);
-            let err = new Error(`You provided invalid options for ${descriptor.typeName}. If you set (ts.server) = NO_SERVER, you cannot set additional server styles.`);
-            err.name = `PluginMessageError`;
-            throw err;
-        }
-
-        if (this.options.forcedServerStyle !== undefined) {
-            return [this.options.forcedServerStyle];
-        }
-
-        // look for service options
-        if (opt.length) {
-            return opt
-                .filter(s => s !== ServerStyle.NO_SERVER)
-                .filter((value, index, array) => array.indexOf(value) === index);
-        }
-
-        // fall back to normal style set by option
-        return [this.options.normalServerStyle];
-    }
-
 }
 

--- a/packages/plugin/src/out-file.ts
+++ b/packages/plugin/src/out-file.ts
@@ -1,6 +1,6 @@
 import {TypescriptFile} from "./framework/typescript-file";
 import {GeneratedFile} from "./framework/generated-file";
-import {InternalOptions} from "./our-options";
+import {Options} from "./options";
 import {DescFile} from "@bufbuild/protobuf";
 import {getPackageComments, getSyntaxComments} from "@bufbuild/protoplugin";
 
@@ -17,7 +17,7 @@ export class OutFile extends TypescriptFile implements GeneratedFile {
     constructor(
         name: string,
         public readonly descFile: DescFile,
-        private readonly options: InternalOptions,
+        private readonly options: Options,
     ) {
         super(name);
     }

--- a/packages/plugin/src/protobufts-plugin.ts
+++ b/packages/plugin/src/protobufts-plugin.ts
@@ -1,14 +1,13 @@
+import {DescEnum, DescExtension, DescFile, DescMessage, DescService} from "@bufbuild/protobuf";
+import {create, createFileRegistry, FileRegistry} from "@bufbuild/protobuf";
+import type {FileDescriptorSet} from "@bufbuild/protobuf/wkt";
+import {CodeGeneratorResponse_Feature, FileDescriptorSetSchema} from "@bufbuild/protobuf/wkt";
+import {nestedTypes} from "@bufbuild/protobuf/reflect";
+import type {CodeGeneratorRequest} from "@bufbuild/protobuf/wkt";
 import {setupCompiler} from "./framework/typescript-compile";
 import {GeneratedFile} from "./framework/generated-file";
 import {OutFile} from "./out-file";
-import {
-    ClientStyle,
-    InternalOptions,
-    makeInternalOptions,
-    OptionResolver,
-    parseOptions,
-    ServerStyle
-} from "./our-options";
+import {InternalOptions, parseOptions} from "./our-options";
 import {ServiceServerGeneratorGrpc} from "./code-gen/service-server-generator-grpc";
 import {CommentGenerator} from "./code-gen/comment-generator";
 import {MessageInterfaceGenerator} from "./code-gen/message-interface-generator";
@@ -21,16 +20,11 @@ import {ServiceServerGeneratorGeneric} from "./code-gen/service-server-generator
 import {ServiceClientGeneratorGrpc} from "./code-gen/service-client-generator-grpc";
 import * as ts from "typescript";
 import {WellKnownTypes} from "./message-type-extensions/well-known-types";
-import {nestedTypes} from "@bufbuild/protobuf/reflect";
-import type {CodeGeneratorRequest} from "@bufbuild/protobuf/wkt";
 import {Interpreter} from "./interpreter";
 import {SymbolTable} from "./framework/symbol-table";
 import {TypeScriptImports} from "./framework/typescript-imports";
-import {DescEnum, DescExtension, DescFile, DescMessage, DescService} from "@bufbuild/protobuf";
 import {PluginBaseProtobufES} from "./framework/plugin-base";
-import {create, createFileRegistry, FileRegistry} from "@bufbuild/protobuf";
-import type {FileDescriptorSet} from "@bufbuild/protobuf/wkt";
-import {CodeGeneratorResponse_Feature, FileDescriptorSetSchema} from "@bufbuild/protobuf/wkt";
+import {ServerStyle, ClientStyle} from "./gen/protobuf-ts_pb";
 
 
 export class ProtobuftsPlugin extends PluginBaseProtobufES {
@@ -44,8 +38,8 @@ export class ProtobuftsPlugin extends PluginBaseProtobufES {
 
     generate(request: CodeGeneratorRequest): GeneratedFile[] {
         const
-            options = makeInternalOptions(
-                parseOptions(request.parameter),
+            options = parseOptions(
+                request.parameter,
                 `by protobuf-ts ${this.version}` + (request.parameter ? ` with parameter ${request.parameter}` : '')
             ),
             registryEs = createFileRegistryFromRequest(request),
@@ -54,7 +48,6 @@ export class ProtobuftsPlugin extends PluginBaseProtobufES {
             imports = new TypeScriptImports(symbols, registryEs),
             comments = new CommentGenerator(),
             interpreter = new Interpreter(registryEs, options),
-            optionResolver = new OptionResolver(interpreter, options),
             genMessageInterface = new MessageInterfaceGenerator(symbols, imports, comments, interpreter, options),
             genEnum = new EnumGenerator(symbols, imports, comments, interpreter),
             genMessageType = new MessageTypeGenerator(registryEs, imports, comments, interpreter, options),
@@ -129,7 +122,7 @@ export class ProtobuftsPlugin extends PluginBaseProtobufES {
             for (const desc of nestedTypes(descFile)) {
                 switch (desc.kind) {
                     case "message":
-                        genMessageType.generateMessageType(outMain, desc, optionResolver.getOptimizeMode(descFile));
+                        genMessageType.generateMessageType(outMain, desc, options.getOptimizeMode(descFile));
                         break;
                     case "service":
                         if (options.forceDisableServices) {
@@ -138,7 +131,7 @@ export class ProtobuftsPlugin extends PluginBaseProtobufES {
                         // service type
                         genServiceType.generateServiceType(outMain, desc);
                         // clients
-                        const clientStyles = optionResolver.getClientStyles(desc);
+                        const clientStyles = options.getClientStyles(desc);
                         if (clientStyles.includes(ClientStyle.GENERIC_CLIENT)) {
                             genClientGeneric.generateInterface(outClientCall, desc);
                             genClientGeneric.generateImplementationClass(outClientCall, desc);
@@ -148,7 +141,7 @@ export class ProtobuftsPlugin extends PluginBaseProtobufES {
                             genClientGrpc.generateImplementationClass(outClientGrpc, desc);
                         }
                         // servers
-                        const serverStyles = optionResolver.getServerStyles(desc);
+                        const serverStyles = options.getServerStyles(desc);
                         if (serverStyles.includes(ServerStyle.GENERIC_SERVER)) {
                             genServerGeneric.generateInterface(outServerGeneric, desc);
                         }

--- a/packages/plugin/src/protobufts-plugin.ts
+++ b/packages/plugin/src/protobufts-plugin.ts
@@ -7,7 +7,7 @@ import type {CodeGeneratorRequest} from "@bufbuild/protobuf/wkt";
 import {setupCompiler} from "./framework/typescript-compile";
 import {GeneratedFile} from "./framework/generated-file";
 import {OutFile} from "./out-file";
-import {InternalOptions, parseOptions} from "./our-options";
+import {Options, parseOptions} from "./options";
 import {ServiceServerGeneratorGrpc} from "./code-gen/service-server-generator-grpc";
 import {CommentGenerator} from "./code-gen/comment-generator";
 import {MessageInterfaceGenerator} from "./code-gen/message-interface-generator";
@@ -187,7 +187,7 @@ export class ProtobuftsPlugin extends PluginBaseProtobufES {
     }
 
 
-    protected transpile(tsFiles: OutFile[], options: InternalOptions): GeneratedFile[] {
+    protected transpile(tsFiles: OutFile[], options: Options): GeneratedFile[] {
         if (options.transpileTarget === undefined) {
             return tsFiles;
         }


### PR DESCRIPTION
We define a few custom options in protobuf-ts.proto that affect code generation.

They are read from descriptors given to the plugin in interpreter.ts. Two interfaces and two enums are defined to match the types in protobuf-ts.proto.

This removes the 4 definitions with types generated from protobuf-ts.proto,

This also removes the OptionResolver class, moving the methods into InternalOptions.