### PR TITLE
Deprecate @protobuf-ts/plugin-framework

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,9 +62,9 @@ we generate a `FileDescriptorSet` ahead of time. The `FileDescriptorSet` contain
 information necessary to create the `CodeGeneratorRequest`s we need for testing 
 the plugin. 
 
-`packages/plugin` and `packages/plugin-framework` are both tested using the 
-`FileDescriptorSet`. In `spec/helpers.ts`, the function `getCodeGeneratorRequest` 
-can be used to create a `CodeGeneratorRequest` from the file descriptors.  
+`packages/plugin` is tested using the `FileDescriptorSet`. In `spec/helpers.ts`, 
+the function `getCodeGeneratorRequest` can be used to create a `CodeGeneratorRequest` 
+from the file descriptors.  
 
 The plugin itself has only very basic test coverage. We generate TypeScript 
 (in memory) for all .proto files in `packages/proto` and compile the 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,6 @@ Read the [MANUAL](MANUAL.md) to learn more.
 
 - The [code to decode UTF8](./packages/runtime/src/protobufjs-utf8.ts) is Copyright 2016 by Daniel Wirtz, licensed under BSD-3-Clause.
 - The [code to encode and decode varint](./packages/runtime/src/goog-varint.ts) is Copyright 2008 Google Inc., licensed under BSD-3-Clause.
-- The files [plugin.ts](./packages/plugin-framework/src/google/protobuf/compiler/plugin.ts) and [descriptor.ts](./packages/plugin-framework/src/google/protobuf/descriptor.ts) are Copyright 2008 Google Inc., licensed under BSD-3-Clause
 - The [gRPC status codes](./packages/grpcweb-transport/src/goog-grpc-status-code.ts) are Copyright 2016 gRPC authors, licensed under Apache-2.0.
 - The [Twirp error codes](./packages/twirp-transport/src/twitch-twirp-error-code.ts) are Copyright 2018 Twitch Interactive, Inc., licensed under Apache-2.0.
 - The proto files in [proto/google](./packages/proto/google) and [test-conformance/proto](./packages/test-conformance/proto) are Copyright Google Inc. / Google LLC, licensed under Apache-2.0 / BSD-3-Clause.

--- a/packages/README.md
+++ b/packages/README.md
@@ -18,6 +18,4 @@
   [![npm](https://img.shields.io/npm/v/@protobuf-ts/grpc-backend?style=flat-square)](https://www.npmjs.com/package/@protobuf-ts/grpc-backend)
 - [@protobuf-ts/runtime-rpc](./runtime-rpc) - shared contracts for RPC  
   [![npm](https://img.shields.io/npm/v/@protobuf-ts/runtime-rpc?style=flat-square)](https://www.npmjs.com/package/@protobuf-ts/runtime-rpc)
-- [@protobuf-ts/plugin-framework](./plugin-framework) - a framework for writing `protoc` plugins in TypeScript  
-  [![npm](https://img.shields.io/npm/v/@protobuf-ts/plugin-framework?style=flat-square)](https://www.npmjs.com/package/@protobuf-ts/plugin-framework)
 

--- a/packages/plugin-framework/README.md
+++ b/packages/plugin-framework/README.md
@@ -1,6 +1,11 @@
 @protobuf-ts/plugin-framework
 =============================
 
+> [!IMPORTANT]
+> 
+> This plugin framework is deprecated.  
+> For a good alternative, see [@bufbuild/protoplugin](https://www.npmjs.com/package/@bufbuild/protoplugin)
+
 A framework to create protoc plugins in typescript.
 
 The google protocol buffer compiler (protoc) has a plugin system. With a 
@@ -51,7 +56,6 @@ code, but can be used to generate code in other languages.
 - Take a look at `descriptor-registry.ts` to see the if it can help you work with the 
   descriptor protos that the compiler sends you.
 - Take a look at `plugin-base.ts` for a base class that can help with some plumbing.
-- Take a look at the source code of [protobuf-ts](https://github.com/timostamm/protobuf-ts/), which uses this framework.    
 
 
 ### Copyright


### PR DESCRIPTION
> [!IMPORTANT]
> 
> This plugin framework is deprecated.  
> For a good alternative, see [@bufbuild/protoplugin](https://www.npmjs.com/package/@bufbuild/protoplugin)

(The package isn't deprecated on npmjs.com yet, and is not removed from this repo or the release process yet.)