### PR TITLE
Work around global `Object.prototype` pollution

### DIFF
--- a/packages/runtime/src/message-type.ts
+++ b/packages/runtime/src/message-type.ts
@@ -19,8 +19,8 @@ import type {UnknownMessage} from "./unknown-types";
 import {binaryWriteOptions} from "./binary-writer";
 import {binaryReadOptions} from "./binary-reader";
 
-const baseDescriptors = Object.getOwnPropertyDescriptors(Object.getPrototypeOf({}));
-const messageTypeDescriptor = baseDescriptors[MESSAGE_TYPE] = {};
+const baseDescriptors = Object.getOwnPropertyDescriptors(Object.getPrototypeOf({})) as Record<typeof MESSAGE_TYPE, unknown>;
+const messageTypeDescriptor = baseDescriptors[MESSAGE_TYPE] = {} as {value?: unknown};
 
 /**
  * This standard message type provides reflection-based

--- a/packages/runtime/src/message-type.ts
+++ b/packages/runtime/src/message-type.ts
@@ -20,6 +20,7 @@ import {binaryWriteOptions} from "./binary-writer";
 import {binaryReadOptions} from "./binary-reader";
 
 const baseDescriptors = Object.getOwnPropertyDescriptors(Object.getPrototypeOf({}));
+const messageTypeDescriptor = baseDescriptors[MESSAGE_TYPE] = {};
 
 /**
  * This standard message type provides reflection-based
@@ -69,7 +70,8 @@ export class MessageType<T extends object> implements IMessageType<T> {
         this.typeName = name;
         this.fields = fields.map(normalizeFieldInfo);
         this.options = options ?? {};
-        this.messagePrototype = Object.create(null, { ...baseDescriptors, [MESSAGE_TYPE]: { value: this } });
+        messageTypeDescriptor.value = this;
+        this.messagePrototype = Object.create(null, baseDescriptors);
         this.refTypeCheck = new ReflectionTypeCheck(this);
         this.refJsonReader = new ReflectionJsonReader(this);
         this.refJsonWriter = new ReflectionJsonWriter(this);


### PR DESCRIPTION
Fixes https://github.com/timostamm/protobuf-ts/issues/724

There shouldn’t be any issue in mutating the `baseDescriptors` object directly since:

1. `Object.getOwnPropertyDescriptors()` always returns a referentially unique object every time it’s called.
2. `Object.create()` doesn’t retain any references to the second argument (the descriptors) in the resulting object.

```js
var a = Object.getPrototypeOf({});
var b = Object.getPrototypeOf({});
a === b; // true

var descriptor  = Object.getOwnPropertyDescriptors(a);
var descriptor2 = Object.getOwnPropertyDescriptors(a);
descriptor === descriptor2; // false

descriptor.field = {};

descriptor.field.value = 1;
var one = Object.create(null, descriptor);
one.field === 1; // true

descriptor.field.value = 2;
var two = Object.create(null, descriptor);
two.field === 2; // true
one.field === 1; // still true
```