### PR TITLE
Support MESSAGE_TYPE in MessageType.is and isAssignable

### DIFF
--- a/packages/runtime/spec/message-type.spec.ts
+++ b/packages/runtime/spec/message-type.spec.ts
@@ -99,5 +99,60 @@ describe('MessageType', () => {
         expect(msg).toEqual(exp);
     })
 
+    it('create() sets MESSAGE_TYPE', () => {
+        const msg = MyMessage.create({
+            stringField: "hello world",
+        });
+        expect(MESSAGE_TYPE in msg);
+        expect((msg as unknown as {[MESSAGE_TYPE]: MessageType<any>})[MESSAGE_TYPE]).toBe(MyMessage);
+    })
+
+
+    describe('is()', () => {
+        it('returns false for null', () => {
+            expect(MyMessage.is(null)).toBe(false);
+        });
+
+        it('decodes on MESSAGE_TYPE', () => {
+            const A: MessageType<any> = new MessageType<any>('.test.A', [
+                {no: 1, name: 'string_field', kind: "scalar", T: ScalarType.STRING},
+            ]);
+            const B: MessageType<any> = new MessageType<any>('.test.B', [
+                {no: 99, name: 'bool_field', kind: "scalar", T: ScalarType.BOOL},
+            ]);
+            const a = A.create();
+            const b = B.create();
+            expect(A.is(a)).toBe(true);
+            expect(A.is(b)).toBe(false);
+            expect(B.is(a)).toBe(false);
+            expect(B.is(b)).toBe(true);
+        });
+    });
+
+    describe('isAssignable()', () => {
+        it('returns false for null', () => {
+            expect(MyMessage.isAssignable(null)).toBe(false);
+        });
+
+        it('prefers MESSAGE_TYPE', () => {
+            const A: MessageType<any> = new MessageType<any>('.test.A', [
+                {no: 1, name: 'string_field', kind: "scalar", T: ScalarType.STRING},
+            ]);
+            const B: MessageType<any> = new MessageType<any>('.test.B', [
+                {no: 99, name: 'bool_field', kind: "scalar", T: ScalarType.BOOL},
+            ]);
+            const C: MessageType<any> = new MessageType<any>('.test.C', [
+                {no: 1, name: 'string_field', kind: "scalar", T: ScalarType.STRING},
+            ]);
+            const a = A.create();
+            const b = B.create();
+            const c = C.create();
+            expect(A.isAssignable(a)).toBe(true);
+            expect(A.isAssignable(b)).toBe(false);
+            expect(A.isAssignable(c)).toBe(true);
+        });
+
+    });
+
 });
 

--- a/packages/runtime/src/message-type.ts
+++ b/packages/runtime/src/message-type.ts
@@ -18,6 +18,7 @@ import {reflectionEquals} from "./reflection-equals";
 import type {UnknownMessage} from "./unknown-types";
 import {binaryWriteOptions} from "./binary-writer";
 import {binaryReadOptions} from "./binary-reader";
+import {containsMessageType} from "./reflection-contains-message-type";
 
 const baseDescriptors = Object.getOwnPropertyDescriptors(Object.getPrototypeOf({})) as Record<typeof MESSAGE_TYPE, unknown>;
 const messageTypeDescriptor = baseDescriptors[MESSAGE_TYPE] = {} as {value?: unknown};
@@ -134,10 +135,22 @@ export class MessageType<T extends object> implements IMessageType<T> {
 
 
     /**
-     * Is the given value assignable to our message type
-     * and contains no [excess properties](https://www.typescriptlang.org/docs/handbook/interfaces.html#excess-property-checks)?
+     * Is the given value a message of our type?
+     *
+     * This method checks the MESSAGE_TYPE symbol property added by create()
+     * since v2.0.3: It returns true if the value matches our message type,
+     * false otherwise.
+     *
+     * If the value does not have the MESSAGE_TYPE symbol, this method checks all
+     * field types recursively, and returns false if it contains [excess properties](https://www.typescriptlang.org/docs/handbook/interfaces.html#excess-property-checks).
      */
     is(arg: any, depth = this.defaultCheckDepth): arg is T {
+        if (typeof arg != 'object' || arg == null) {
+            return false;
+        }
+        if (containsMessageType(arg as object)) {
+            return arg[MESSAGE_TYPE].typeName === this.typeName;
+        }
         return this.refTypeCheck.is(arg, depth, false);
     }
 
@@ -145,8 +158,20 @@ export class MessageType<T extends object> implements IMessageType<T> {
     /**
      * Is the given value assignable to our message type,
      * regardless of [excess properties](https://www.typescriptlang.org/docs/handbook/interfaces.html#excess-property-checks)?
+     *
+     * This method checks the MESSAGE_TYPE symbol property added by create()
+     * since v2.0.3: It returns true if the value matches our message type.
+     *
+     * If the value does not have the MESSAGE_TYPE symbol, this method checks all
+     * field types recursively, and returns false if it's missing a mandatory property.
      */
     isAssignable(arg: any, depth = this.defaultCheckDepth): arg is T {
+        if (typeof arg != 'object' || arg == null) {
+            return false;
+        }
+        if (containsMessageType(arg as object) && arg[MESSAGE_TYPE].typeName === this.typeName) {
+            return true;
+        }
         return this.refTypeCheck.is(arg, depth, true);
     }
 

--- a/packages/test-default/spec/message-type.spec.ts
+++ b/packages/test-default/spec/message-type.spec.ts
@@ -1,0 +1,22 @@
+import {Duration} from "../gen/google/protobuf/duration";
+import {Timestamp} from "../gen/google/protobuf/timestamp";
+
+
+describe('MessageType', function () {
+    it('is()', () => {
+        const dur = Duration.create();
+        const tim = Timestamp.create();
+        expect( Duration.is(dur)).toBe(true);
+        expect( Timestamp.is(tim)).toBe(true);
+        expect( Duration.is(tim)).toBe(false);
+        expect( Timestamp.is(dur)).toBe(false);
+    });
+    it('isAssignable()', () => {
+        const dur = Duration.create();
+        const tim = Timestamp.create();
+        expect( Duration.isAssignable(dur)).toBe(true);
+        expect( Timestamp.isAssignable(tim)).toBe(true);
+        expect( Duration.isAssignable(tim)).toBe(true);
+        expect( Timestamp.isAssignable(dur)).toBe(true);
+    });
+});

--- a/packages/test-force_optimize_code_size/spec/message-type.spec.ts
+++ b/packages/test-force_optimize_code_size/spec/message-type.spec.ts
@@ -1,0 +1,23 @@
+import {Duration} from "../gen/google/protobuf/duration";
+import {Timestamp} from "../gen/google/protobuf/timestamp";
+
+// Copied from test-default/message-type.spec.ts. Do not edit.
+
+describe('MessageType', function () {
+    it('is()', () => {
+        const dur = Duration.create();
+        const tim = Timestamp.create();
+        expect( Duration.is(dur)).toBe(true);
+        expect( Timestamp.is(tim)).toBe(true);
+        expect( Duration.is(tim)).toBe(false);
+        expect( Timestamp.is(dur)).toBe(false);
+    });
+    it('isAssignable()', () => {
+        const dur = Duration.create();
+        const tim = Timestamp.create();
+        expect( Duration.isAssignable(dur)).toBe(true);
+        expect( Timestamp.isAssignable(tim)).toBe(true);
+        expect( Duration.isAssignable(tim)).toBe(true);
+        expect( Timestamp.isAssignable(dur)).toBe(true);
+    });
+});

--- a/packages/test-force_optimize_speed-long_type_string/spec/message-type.spec.ts
+++ b/packages/test-force_optimize_speed-long_type_string/spec/message-type.spec.ts
@@ -1,0 +1,23 @@
+import {Duration} from "../gen/google/protobuf/duration";
+import {Timestamp} from "../gen/google/protobuf/timestamp";
+
+// Copied from test-default/message-type.spec.ts. Do not edit.
+
+describe('MessageType', function () {
+    it('is()', () => {
+        const dur = Duration.create();
+        const tim = Timestamp.create();
+        expect( Duration.is(dur)).toBe(true);
+        expect( Timestamp.is(tim)).toBe(true);
+        expect( Duration.is(tim)).toBe(false);
+        expect( Timestamp.is(dur)).toBe(false);
+    });
+    it('isAssignable()', () => {
+        const dur = Duration.create();
+        const tim = Timestamp.create();
+        expect( Duration.isAssignable(dur)).toBe(true);
+        expect( Timestamp.isAssignable(tim)).toBe(true);
+        expect( Duration.isAssignable(tim)).toBe(true);
+        expect( Timestamp.isAssignable(dur)).toBe(true);
+    });
+});

--- a/packages/test-force_optimize_speed/spec/message-type.spec.ts
+++ b/packages/test-force_optimize_speed/spec/message-type.spec.ts
@@ -1,0 +1,23 @@
+import {Duration} from "../gen/google/protobuf/duration";
+import {Timestamp} from "../gen/google/protobuf/timestamp";
+
+// Copied from test-default/message-type.spec.ts. Do not edit.
+
+describe('MessageType', function () {
+    it('is()', () => {
+        const dur = Duration.create();
+        const tim = Timestamp.create();
+        expect( Duration.is(dur)).toBe(true);
+        expect( Timestamp.is(tim)).toBe(true);
+        expect( Duration.is(tim)).toBe(false);
+        expect( Timestamp.is(dur)).toBe(false);
+    });
+    it('isAssignable()', () => {
+        const dur = Duration.create();
+        const tim = Timestamp.create();
+        expect( Duration.isAssignable(dur)).toBe(true);
+        expect( Timestamp.isAssignable(tim)).toBe(true);
+        expect( Duration.isAssignable(tim)).toBe(true);
+        expect( Timestamp.isAssignable(dur)).toBe(true);
+    });
+});

--- a/packages/test-long_type_string/spec/message-type.spec.ts
+++ b/packages/test-long_type_string/spec/message-type.spec.ts
@@ -1,0 +1,23 @@
+import {Duration} from "../gen/google/protobuf/duration";
+import {Timestamp} from "../gen/google/protobuf/timestamp";
+
+// Copied from test-default/message-type.spec.ts. Do not edit.
+
+describe('MessageType', function () {
+    it('is()', () => {
+        const dur = Duration.create();
+        const tim = Timestamp.create();
+        expect( Duration.is(dur)).toBe(true);
+        expect( Timestamp.is(tim)).toBe(true);
+        expect( Duration.is(tim)).toBe(false);
+        expect( Timestamp.is(dur)).toBe(false);
+    });
+    it('isAssignable()', () => {
+        const dur = Duration.create();
+        const tim = Timestamp.create();
+        expect( Duration.isAssignable(dur)).toBe(true);
+        expect( Timestamp.isAssignable(tim)).toBe(true);
+        expect( Duration.isAssignable(tim)).toBe(true);
+        expect( Timestamp.isAssignable(dur)).toBe(true);
+    });
+});


### PR DESCRIPTION
Since v2.0.3, `create()` adds the MESSAGE_TYPE symbol property. See https://github.com/timostamm/protobuf-ts/pull/147 for context.

With this PR, `MessageType.is` and `MessageType.isAssignable` respect the MESSAGE_TYPE property:

- `ExampleMsg.is` will return whether the given value's `MESSAGE_TYPE.typeName` matches `ExampleMsg.typeName`. If MESSAGE_TYPE is not defined, `is` checks for matching properties recursively.
- `ExampleMsg.isAssignable` will return true if the given value's `MESSAGE_TYPE.typeName` matches `ExampleMsg.typeName`. Otherwise (also if MESSAGE_TYPE is not defined), it checks for matching properties recursively, ignoring excess properties.

This makes both methods more accurate, and allows `Timestamp.is` to distinguish a `Timestamp` from a `Duration`. 

With the added strictness also comes what could be argued to be a breaking change: Where `Timstamp.is(Duration.create())` previously returned `true`, it now returns false. On the other hand, the intent of `is` has always been to be a reliable type guard, and the existing behavior is a limitation of the design, rather than a design choice. Hopefully this won't break any practical use cases. In case it does, there's the escape hatch to use `ReflectionTypeCheck`.

Closes https://github.com/timostamm/protobuf-ts/issues/727.