### PR TITLE
Support MESSAGE_TYPE in MessageType.equals

### DIFF
--- a/packages/runtime/spec/message-type.spec.ts
+++ b/packages/runtime/spec/message-type.spec.ts
@@ -99,5 +99,19 @@ describe('MessageType', () => {
         expect(msg).toEqual(exp);
     })
 
+    describe('equals()', () => {
+        it('decides on wrong MESSAGE_TYPE', () => {
+            const A: MessageType<any> = new MessageType<any>('.test.A', [
+                {no: 1, name: 'string_field', kind: "scalar", T: ScalarType.STRING},
+            ]);
+            const B: MessageType<any> = new MessageType<any>('.test.B', [
+                {no: 1, name: 'string_field', kind: "scalar", T: ScalarType.STRING},
+            ]);
+            const a = A.create();
+            const b = B.create();
+            expect(A.equals(a, b)).toBe(false);
+        });
+    });
+
 });
 

--- a/packages/test-default/spec/message-type.spec.ts
+++ b/packages/test-default/spec/message-type.spec.ts
@@ -1,0 +1,11 @@
+import {Duration} from "../gen/google/protobuf/duration";
+import {Timestamp} from "../gen/google/protobuf/timestamp";
+
+
+describe('MessageType', function () {
+    it('equals()', () => {
+        const dur = Duration.create();
+        const tim = Timestamp.create();
+        expect( Duration.equals(dur, tim)).toBe(false);
+    });
+});

--- a/packages/test-force_optimize_code_size/spec/message-type.spec.ts
+++ b/packages/test-force_optimize_code_size/spec/message-type.spec.ts
@@ -1,0 +1,12 @@
+import {Duration} from "../gen/google/protobuf/duration";
+import {Timestamp} from "../gen/google/protobuf/timestamp";
+
+// Copied from test-default/message-type.spec.ts. Do not edit.
+
+describe('MessageType', function () {
+    it('equals()', () => {
+        const dur = Duration.create();
+        const tim = Timestamp.create();
+        expect( Duration.equals(dur, tim)).toBe(false);
+    });
+});

--- a/packages/test-force_optimize_speed-long_type_string/spec/message-type.spec.ts
+++ b/packages/test-force_optimize_speed-long_type_string/spec/message-type.spec.ts
@@ -1,0 +1,12 @@
+import {Duration} from "../gen/google/protobuf/duration";
+import {Timestamp} from "../gen/google/protobuf/timestamp";
+
+// Copied from test-default/message-type.spec.ts. Do not edit.
+
+describe('MessageType', function () {
+    it('equals()', () => {
+        const dur = Duration.create();
+        const tim = Timestamp.create();
+        expect( Duration.equals(dur, tim)).toBe(false);
+    });
+});

--- a/packages/test-force_optimize_speed/spec/message-type.spec.ts
+++ b/packages/test-force_optimize_speed/spec/message-type.spec.ts
@@ -1,0 +1,12 @@
+import {Duration} from "../gen/google/protobuf/duration";
+import {Timestamp} from "../gen/google/protobuf/timestamp";
+
+// Copied from test-default/message-type.spec.ts. Do not edit.
+
+describe('MessageType', function () {
+    it('equals()', () => {
+        const dur = Duration.create();
+        const tim = Timestamp.create();
+        expect( Duration.equals(dur, tim)).toBe(false);
+    });
+});

--- a/packages/test-long_type_string/spec/message-type.spec.ts
+++ b/packages/test-long_type_string/spec/message-type.spec.ts
@@ -1,0 +1,12 @@
+import {Duration} from "../gen/google/protobuf/duration";
+import {Timestamp} from "../gen/google/protobuf/timestamp";
+
+// Copied from test-default/message-type.spec.ts. Do not edit.
+
+describe('MessageType', function () {
+    it('equals()', () => {
+        const dur = Duration.create();
+        const tim = Timestamp.create();
+        expect( Duration.equals(dur, tim)).toBe(false);
+    });
+});


### PR DESCRIPTION
Similar to https://github.com/timostamm/protobuf-ts/pull/728, this adds support for the MESSAGE_TYPE symbol property, added by `create()` since v2.0.3. See https://github.com/timostamm/protobuf-ts/pull/147 for context.

With this PR, `MessageType.equals` respects the MESSAGE_TYPE property: If either of both provided messages do not match the expected type, it returns false. Note that the added strictness can be considered a breaking change, same as with https://github.com/timostamm/protobuf-ts/pull/728.