### PR TITLE
Add noResolve option to TypeScript compiler options

### DIFF
--- a/packages/plugin/src/protobufts-plugin.ts
+++ b/packages/plugin/src/protobufts-plugin.ts
@@ -195,6 +195,7 @@ export class ProtobuftsPlugin extends PluginBaseProtobufES {
             moduleResolution: ts.ModuleResolutionKind.NodeJs,
             skipLibCheck: true,
             declaration: true,
+            noResolve: true,
             module: options.transpileModule,
             target: options.transpileTarget,
         };


### PR DESCRIPTION
src/test.proto
```
syntax = "proto3";

package test.v1;

service View {
    rpc View(ViewReq) returns (ViewReply);
}

message ViewReply {
    // 
    int64 id = 1;
}

message ViewReq {
    // 
    int64 id = 1;
}
```
`protoc --ts_out ./ --ts_opt generate_dependencies,long_type_string,output_javascript --proto_path ./src ./src/test.proto`
Using the above command will generate the following files:
```
test.client.d.ts
test.client.js
test.d.ts
test.js
```
If you change the `id` field to `id2` and then run the command again, the `test.d.ts` file will not be modified.
If the `noResolve` option is enabled, `test.d.ts` will be generated correctly.

This issue only occurs on Windows; there is no such problem on Linux or macOS.